### PR TITLE
Close the licensing Troubleshoot coverage gap

### DIFF
--- a/skills/uipath-platform/SKILL.md
+++ b/skills/uipath-platform/SKILL.md
@@ -181,6 +181,7 @@ Choose the appropriate operation from the Task Navigation table below. For `uip 
 | **Assign user/group license bundles** | [references/licensing/user-licenses-allocations.md](references/licensing/user-licenses-allocations.md) |
 | **Report on license consumption** | [references/licensing/consumables-report.md](references/licensing/consumables-report.md) |
 | **Understand licensing concepts** | [references/licensing/licensing.md](references/licensing/licensing.md) |
+| **Diagnose a licensing symptom** | [references/licensing/diagnose/CAPABILITY.md](references/licensing/diagnose/CAPABILITY.md) |
 | **Full CLI command reference** | [references/uip-commands.md](references/uip-commands.md) |
 | **Build/run/validate coded workflows** | [/uipath:uipath-rpa](/uipath:uipath-rpa) |
 
@@ -313,7 +314,7 @@ Every `uip` command accepts:
 - **[Data Fabric](references/data-fabric/data-fabric.md)** — Entity schemas, records CRUD, query filters and aggregates, choice sets, file attachments, CSV bulk import, folder scoping
 - **[LLM Gateway — BYO Connections](references/llmgateway/byo-connections.md)** — Register tenant-owned LLM keys against UiPath products
 - **[Guardrails — BYOG Configurations](references/guardrails/byo-configurations.md)** — Manage tenant-registered bring-your-own guardrail (BYOG) configurations and diagnose their underlying Integration Service connections
-- **[Licensing](references/licensing/licensing.md)** — Tenant allocations, user/group bundles, consumables reporting
+- **[Licensing](references/licensing/licensing.md)** — Tenant allocations, user/group bundles, consumables reporting, [diagnose](references/licensing/diagnose/CAPABILITY.md)
 - **[Coded Workflows](/uipath:uipath-rpa)** — Building coded automation projects
 
 > **Trouble?** If something didn't work as expected, use `/uipath-feedback` to send a report.

--- a/skills/uipath-platform/references/licensing/diagnose/CAPABILITY.md
+++ b/skills/uipath-platform/references/licensing/diagnose/CAPABILITY.md
@@ -1,0 +1,79 @@
+# Diagnose — Investigate Licensing State Failures
+
+Capability index for diagnosing licensing symptoms via `uip platform`: entitlement gaps, allocation changes that did not take effect, and consumption reports that read wrong.
+
+> **Where you came from / where to go next.** Diagnose is downstream of Operate (a user lost access, an allocation did
+> not apply, a report read wrong). Fixes — `tenants licenses set`, `users licenses set`, `groups rules set` — are Operate
+> actions requiring explicit user consent after root cause analysis.
+>
+> **Scope boundary.** This capability diagnoses **licensing state**: which layer holds (or fails to hold) an entitlement,
+> and why a licensing command's result differs from what the user expected. It does NOT diagnose runtime faults that
+> merely *mention* a license (a job stuck Pending, Studio failing to start, a robot not connecting). For those the
+> licensing layer is one hypothesis among many — establish the entitlement facts here, then hand the runtime causal chain
+> to `uipath-troubleshoot`.
+>
+> **Inherits universal rules from [SKILL.md](../../../SKILL.md).** Use `uip platform ... --output json` for all diagnostic reads.
+
+## When to use this capability
+
+- A user or group lost (or never gained) a license bundle they should hold.
+- `tenants licenses set` reported success but `get` shows unchanged units.
+- A product code is absent from `get` output entirely.
+- Seat or unit totals do not reconcile against the purchased pool.
+- A consumables report reads zero, or lower/higher than the user expects.
+- An allocation cannot be applied because the code will not route to a tenant.
+- Determine whether a reported access failure is a licensing cause at all, before escalating.
+
+## Critical rules
+
+1. **Diagnose reads; Operate mutates.** Never run a `set` command while diagnosing — a `set` is an overlay that destroys the evidence of the prior state. Read first, present findings, let the user authorize the fix.
+2. **Identify the layer before running anything.** Licensing is four independent layers (see [troubleshooting-guide.md](references/troubleshooting-guide.md#step-1-identify-the-layer)). A symptom answered at the wrong layer produces a confident wrong answer.
+3. **Read `get` before reasoning about `set`.** `quantity` is absolute, not a delta, and absent codes keep their current value. Without the starting state you cannot tell an ineffective `set` from a correctly-applied no-op.
+4. **Treat an absent row as a window question first.** `tenants licenses get` returns only products whose active interval contains the current time. Absent ≠ never allocated.
+5. **`consumed` and consumables totals lag.** Accountant-side aggregation is minutes behind job completion. Never conclude "nothing ran" from a fresh zero.
+6. **Do not infer seat-consumption semantics that the workflow guides do not document.** When reconciliation needs a rule that is not written down, say so and fall back to the portal or the REST APIs — do not derive it.
+7. **Do not expose private data.** Redact tenant URLs, account GUIDs, user emails, and tokens in summaries.
+
+## Workflow
+
+| Journey | Read |
+|---------|------|
+| Triage a licensing symptom (sequential ladder) | [references/troubleshooting-guide.md](references/troubleshooting-guide.md) |
+| Recognize a known failure pattern (lookup) | [references/failure-modes.md](references/failure-modes.md) |
+
+## Common tasks
+
+| I need to... | Read |
+|---|---|
+| Work out which licensing layer owns the symptom | [troubleshooting guide → Step 1](references/troubleshooting-guide.md#step-1-identify-the-layer) |
+| Investigate why a user lacks a bundle | [troubleshooting guide → Step 3](references/troubleshooting-guide.md#step-3-walk-the-user-bundle-layer) |
+| Diagnose an allocation that did not take effect | [failure modes → Allocation reported success but units unchanged](references/failure-modes.md#allocation-reported-success-but-units-unchanged) |
+| Explain a product code missing from `get` | [failure modes → Product code absent from get output](references/failure-modes.md#product-code-absent-from-get-output) |
+| Diagnose a zero or unexpected consumables figure | [failure modes → Consumables report reads zero or wrong](references/failure-modes.md#consumables-report-reads-zero-or-wrong) |
+| Explain why a code will not route to a tenant | [failure modes → Product code will not route](references/failure-modes.md#product-code-will-not-route-to-the-tenant) |
+| Reconcile seats against the purchased pool | [failure modes → Unit totals do not reconcile](references/failure-modes.md#unit-totals-do-not-reconcile) |
+| Decide whether licensing is the cause at all | [troubleshooting guide → Step 5](references/troubleshooting-guide.md#step-5-decide-whether-licensing-is-the-cause) |
+
+## Anti-patterns
+
+- **Never run `set` to "test" a hypothesis.** `users licenses set` replaces the user's direct bundles and `groups rules set` replaces the whole rule — a diagnostic `set` silently revokes entitlements.
+- **Never conclude "no license" from the user-bundle layer alone.** Unattended runtime comes from the tenant allocation, not a user bundle; the two are separate license types.
+- **Never read a fresh `consumed: 0` as proof no work ran.** Check the window and the aggregation lag first.
+- **Never compare a scoped consumables figure to an account-wide one.** Under `--tenant`, `consumedFromOrgWithoutTenant` is suppressed to zero by design.
+- **Never claim a group member holds a bundle without checking `orphan`.** Orphaned rows still consume a lease until the rule is re-applied.
+- **Never guess a tenant key or bundle code.** Resolve them first — the resolver requires exactly one match.
+
+## References
+
+### Diagnose-scoped
+
+- [troubleshooting-guide.md](references/troubleshooting-guide.md) — layer-first triage ladder
+- [failure-modes.md](references/failure-modes.md) — recurring failure patterns
+
+### Cross-capability
+
+- [licensing.md](../licensing.md) — license hierarchy, product codes, response envelope
+- [tenant-allocations.md](../tenant-allocations.md) — tenant layer commands, field reference, error table
+- [user-licenses-allocations.md](../user-licenses-allocations.md) — user/group layer commands, code resolution, error table
+- [consumables-report.md](../consumables-report.md) — consumption modes, flag reference, error table
+- [../../orchestrator/setup-environment.md](../../orchestrator/setup-environment.md) — `uip or licenses`, the Orchestrator license-slot layer

--- a/skills/uipath-platform/references/licensing/diagnose/references/failure-modes.md
+++ b/skills/uipath-platform/references/licensing/diagnose/references/failure-modes.md
@@ -1,0 +1,147 @@
+# Failure Modes — Licensing
+
+Named failure patterns with symptom → cause → investigation → fix. Match the user's symptom to a pattern, then follow the investigation steps.
+
+These are keyed by **symptom** — what the user reports. For patterns keyed by **CLI error message** (you already have the error text in hand), use the `Error Conditions` table in the owning workflow guide instead: [tenant-allocations.md](../../tenant-allocations.md#error-conditions), [user-licenses-allocations.md](../../user-licenses-allocations.md#error-conditions), [consumables-report.md](../../consumables-report.md#error-conditions).
+
+All investigation commands are read-only. Never run a `set` while diagnosing.
+
+---
+
+## Allocation Reported Success But Units Unchanged
+
+**Symptom:** User ran `tenants licenses set`, it returned success, but `get` shows the old numbers — or numbers they did not expect.
+
+**Causes:**
+1. `quantity` treated as a delta — it is absolute, so `5` set the tenant to 5 rather than adding 5
+2. Codes omitted from the input file kept their previous quantity — `set` is an overlay, not a replace
+3. Applied to a different tenant than the one being inspected
+4. The value did apply, but a bundle window means `get` no longer returns that row
+5. Only some codes in the input routed; the rest were rejected per-code
+
+**Investigation:**
+1. Read current state: `uip platform tenants licenses get "<TENANT_KEY>" --output json`
+2. Ask for the exact input file used, and diff its codes against the `get` output — separate "code absent from input" (expected to be unchanged) from "code present in input but unchanged" (the real failure)
+3. Confirm the tenant key in the `set` command matches the one being inspected
+4. If a code is missing entirely rather than unchanged, switch to [Product code absent from get output](#product-code-absent-from-get-output)
+
+**Fix:** Cause 1 → re-issue with the intended absolute total. Cause 2 → include the code explicitly, with `quantity: 0` to zero it out. Cause 3 → re-issue against the correct tenant key. Cause 4 → see the window pattern below. Cause 5 → see the routing pattern below. Present the corrected `set` command; do not run it.
+
+---
+
+## Product Code Absent From `get` Output
+
+**Symptom:** A product the user knows is purchased and allocated does not appear in `tenants licenses get` at all.
+
+**Causes:**
+1. Bundle window — `get` returns only products whose active interval contains the current time. An expired bundle is hidden even with `allocated > 0` historically
+2. The code was never provisioned on this tenant's service licenses
+3. The SKU is not on the account at all
+
+**Investigation:**
+1. `uip platform tenants licenses get "<TENANT_KEY>" --output json` — note that every returned row carries `startDate` / `endDate`, so the returned rows tell you what "currently active" means for this account
+2. Check whether the same code appears for a different tenant — present elsewhere means provisioned on the account, absent on this tenant
+3. Attempting to allocate it will surface a routing error naming the cause — see the next pattern rather than guessing
+
+**Fix:** Cause 1 → renewal or window question; the CLI cannot extend a window. Causes 2 and 3 → the SKU must be provisioned through the portal first; `set` cannot introduce a new code. In all three, state that this is a provisioning action outside the CLI.
+
+---
+
+## Product Code Will Not Route To The Tenant
+
+**Symptom:** `tenants licenses set` fails for a specific code, complaining it cannot be routed, or that routing is ambiguous.
+
+**Causes:**
+1. The code is not already present on the tenant's service licenses — `set` adjusts existing codes, it cannot introduce new ones
+2. The same code exists on more than one of the tenant's service licenses, so the target is ambiguous
+
+**Investigation:**
+1. `uip platform tenants licenses get "<TENANT_KEY>" --output json` — a code absent here cannot be routed by `set`
+2. Distinguish the two: "cannot route" means absent; "ambiguous routing" means duplicated across service types, and the error names the service types involved
+
+**Fix:** Cause 1 → provision the SKU on the tenant through the portal, then re-run `set`. Cause 2 → the duplicate allocation must be resolved in the portal or via support; the CLI cannot disambiguate. Neither is fixable from the CLI — say so plainly rather than retrying.
+
+---
+
+## User Lacks A Bundle They Should Hold
+
+**Symptom:** One person cannot use a product others can, or reports losing access they previously had.
+
+**Causes:**
+1. Never assigned — no direct grant and no group rule covers them
+2. A later `users licenses set` replaced their direct bundles; anything absent from that input was revoked
+3. A `groups rules set` replaced the group rule, dropping the bundle for every member
+4. A group rule `quota` is filled, so this member gets no lease
+5. Their group row is `orphan: true` — the lease is consumed but not effective for them
+6. Account seats are exhausted, so no new lease could be granted
+
+**Investigation:**
+1. `uip platform users licenses get "<USER_EMAIL>" --output json` — read `source` on each row (`direct` vs `group`) and `leasedAt` for when it was granted
+2. If the expected code is absent, read the rule rather than the user: `uip platform groups rules details "<GROUP_NAME>" --output json` — check entitled bundles, `quota`, and the member's `orphan` flag. The rule header is on **stderr**
+3. Check seat availability: `uip platform users licenses available --output json`
+4. Compare `leasedAt` on their surviving bundles — a cluster of identical timestamps points to a bulk `set` that replaced their prior grants
+
+**Fix:** Cause 1 → assign directly or add to the group. Cause 2 → re-issue `users licenses set` with the **full** intended bundle list, not just the missing one. Cause 3 → re-issue `groups rules set` with the full rule. Cause 4 → raise the quota or grant directly. Cause 5 → re-apply the rule or fully remove the departed user to release the lease. Cause 6 → free seats or purchase more. Present the command; do not run it.
+
+---
+
+## Consumables Report Reads Zero Or Wrong
+
+**Symptom:** A consumption report shows zero, or a figure the user says is too low or too high.
+
+**Causes:**
+1. Aggregation lag — `consumed` and consumable totals are minutes behind job completion
+2. Window mismatch — with no `--start-date`/`--end-date`, every consumable uses **its own** bundle window, so rows in one summary can span different date ranges
+3. Scope suppression — under `--tenant`, `consumedFromOrgWithoutTenant` is deliberately zero; only tenant-pool and org-pool figures are populated
+4. Non-recursive folders — in `folders` mode, `consumedBySelf` excludes child folders, so a parent looks emptier than the subtree
+5. Comparing point-in-time totals as if they were running totals — `consumedAmount` and `consumedBySelf` are totals over the requested range
+6. Wrong unit — the code is not an active consumable in this organization, or is a runtime code rather than a consumable
+7. Reading a scoped figure against an account-wide expectation
+
+**Investigation:**
+1. Re-run with the window stated explicitly so every row shares one range:
+   ```bash
+   uip platform licenses consumables get --mode summary \
+     --start-date "<YYYY-MM-DD>" --end-date "<YYYY-MM-DD>" --output json
+   ```
+2. Compare scoped against unscoped — run once with `--tenant` and once without, and attribute the difference to suppression rather than to missing consumption
+3. For a per-day view, all four flags are required: `--mode daily --tenant <T> --unit <CODE> --start-date <D> --end-date <D>`
+4. Confirm the unit is a consumable at all — runtime codes (`UNATT`, `RU`, `TEU`) are allocated, not consumed; `PLTU` appears on both axes and is a common source of confusion
+5. For `folders` mode, sum the children yourself before comparing to a tenant total
+
+**Fix:** Cause 1 → re-query after the lag; do not report zero as fact. Causes 2, 3, 5, 7 → the number is correct, the comparison is not; explain the semantics. Cause 4 → reconstruct the tree and roll up. Cause 6 → pick a code from the list the CLI returns.
+
+---
+
+## Unit Totals Do Not Reconcile
+
+**Symptom:** Allocated plus available does not match what the user believes was purchased.
+
+**Causes:**
+1. Units reserved by other tenants are being overlooked — the identity is `totalUnitsInAccount = allocated + availableForAllocation + allocatedAcrossOtherTenants`
+2. Comparing across bundle windows — only currently-active products are returned
+3. Comparing a consumption figure against an allocation figure; `consumed` is a subset of `allocated`, not an addend
+4. Conflating separate license types — tenant runtime units and per-seat user bundles are different pools and never sum together
+5. Leases consumed by `orphan: true` group rows, which are held without being effective
+
+**Investigation:**
+1. `uip platform tenants licenses get "<TENANT_KEY>" --output json` — verify the four-field identity holds per code. If it does, the arithmetic is right and the user's expectation is what needs correcting
+2. Enumerate every tenant to account for `allocatedAcrossOtherTenants` rather than inferring it
+3. For seats, use `uip platform users licenses available --output json`, and count group leases via `groups rules details` including orphaned rows
+
+**Fix:** Causes 1–4 → walk the user through the identity with their own numbers; no change is needed. Cause 5 → re-apply the rule or remove departed users to release leases. If the identity genuinely does not hold, the CLI cannot explain it — escalate to the portal or the License Resource Manager REST API and say so.
+
+---
+
+## Reported As Licensing, Caused Elsewhere
+
+**Symptom:** A runtime failure the user attributes to licensing — job stays Pending, Studio starts unlicensed, robot will not connect.
+
+**Cause:** The licensing layer they checked is not the one that runtime path draws on, or licensing is not involved at all.
+
+**Investigation:**
+1. Map the runtime path to its layer: unattended job → tenant allocation (`UNATT`, `RU`, `PLTU`); Studio/attended → user bundle (`RPADEVPRONU`, `ATTUNU`); folder-scoped robot slot → `uip or licenses`, a different surface
+2. Confirm presence or absence at that layer only, capturing the output as evidence
+3. Note that a current snapshot cannot prove entitlement state during an incident older than 24 hours
+
+**Fix:** Entitlement absent → licensing is the cause; present the layer, evidence, and recommended `set`. Entitlement present → licensing is excluded; hand the causal chain to `uipath-troubleshoot` along with the evidence gathered so it is not re-fetched. Do not keep digging in licensing once the entitlement is confirmed present.

--- a/skills/uipath-platform/references/licensing/diagnose/references/troubleshooting-guide.md
+++ b/skills/uipath-platform/references/licensing/diagnose/references/troubleshooting-guide.md
@@ -1,0 +1,125 @@
+# Licensing Diagnostic Ladder
+
+Layer-first triage for licensing symptoms. Work through in order — stop when you have enough to diagnose. Every command is read-only.
+
+## Step 1: Identify the Layer
+
+Licensing is four independent layers. An entitlement can be present at one and absent at the next, so the first job is deciding which layer the symptom belongs to — not which command to run.
+
+```
+Account (organization)          totalUnitsInAccount — the purchased pool
+  └── Tenant allocation         units reserved per tenant   → uip platform tenants licenses
+  └── User bundle               per-seat entitlement        → uip platform users licenses / groups rules
+        └── Group rule lease     inherited, optional quota
+  └── Orchestrator slot         user/robot license slot     → uip or licenses  (separate surface)
+```
+
+Tenant allocations and user bundles are **separate license types**, not a hierarchy: an unattended job draws on the tenant's runtime allocation (`UNATT`, `RU`, `PLTU`); a developer opening Studio draws on a user bundle (`RPADEVPRONU`). A user with every bundle cannot make an unattended job run, and a fully allocated tenant cannot get a developer into Studio.
+
+| Symptom | Layer | Next step |
+|---------|-------|-----------|
+| "User can't use <product>", bundle missing for one person | User bundle | Step 3 |
+| "Group members don't have their license" | User bundle → group rule | Step 3 |
+| "No seats left", "can't assign any more" | Account pool → user bundle | Step 2, then Step 3 |
+| "Set the allocation but nothing changed" | Tenant allocation | Step 4, then [failure-modes → Allocation reported success](failure-modes.md#allocation-reported-success-but-units-unchanged) |
+| "Code missing from the output" | Tenant allocation → bundle window | [failure-modes → Product code absent](failure-modes.md#product-code-absent-from-get-output) |
+| "Can't allocate that product to the tenant" | Tenant allocation → routing | [failure-modes → Code will not route](failure-modes.md#product-code-will-not-route-to-the-tenant) |
+| "Report shows zero", "numbers look wrong" | Consumption reporting | [failure-modes → Consumables reads zero or wrong](failure-modes.md#consumables-report-reads-zero-or-wrong) |
+| "Totals don't add up to what we bought" | Account pool | [failure-modes → Totals do not reconcile](failure-modes.md#unit-totals-do-not-reconcile) |
+| "License slot not assigned in the folder" | Orchestrator slot | [setup-environment.md](../../../orchestrator/setup-environment.md) — `uip or licenses`, not `uip platform` |
+| Job Pending/faulted, Studio won't start, robot won't connect | **Not established yet** | Step 5 — establish entitlement facts, then hand off |
+
+## Step 2: Establish the Account Pool Baseline
+
+Every unit question resolves against the purchased pool. Read it once, from any tenant:
+
+```bash
+uip platform tenants licenses get "<TENANT_KEY>" --output json
+```
+
+Each row carries the account-level totals alongside the tenant's own:
+
+| Field | Use in diagnosis |
+|-------|------------------|
+| `totalUnitsInAccount` | The purchased pool. Equals `allocated + availableForAllocation + allocatedAcrossOtherTenants` — if it does not, stop and see [failure-modes → Totals do not reconcile](failure-modes.md#unit-totals-do-not-reconcile) |
+| `availableForAllocation` | Units still free anywhere in the account. `0` means the pool is exhausted — no tenant can gain units without another losing them |
+| `allocatedAcrossOtherTenants` | Units held by other tenants — the source of units if this tenant needs more |
+| `allocated` | Reserved for this tenant |
+| `consumed` | Subset of `allocated` actually in use. Lags real-time by minutes |
+
+For seat-based (user bundle) questions, the equivalent baseline is:
+
+```bash
+uip platform users licenses available --output json
+```
+
+## Step 3: Walk the User-Bundle Layer
+
+Resolve the person, then read what they actually hold. The resolver is a **starts-with** match and requires exactly one hit — pass a full email when a name is ambiguous.
+
+```bash
+uip platform users licenses get "<USER_EMAIL_OR_NAME_PREFIX>" --output json
+```
+
+Read `source` on every returned row:
+
+- `"direct"` — granted by `users licenses set` on this user.
+- `"group"` — leased through a group rule. The user's own record is not where the grant lives; the rule is.
+
+Branch on what you find:
+
+| Finding | Meaning | Next |
+|---------|---------|------|
+| Expected code present | The entitlement exists at this layer. The symptom is elsewhere | Step 5 |
+| No rows at all | User holds no bundles — never assigned, or a `set` replaced them | Check whether a group should be granting it (below) |
+| Code absent, others present | A prior `users licenses set` replaced the direct bundles — it replaces, not merges | Confirm intent with the user before re-adding |
+| Code present via `group` but product still unusable | Entitlement is fine at this layer | Step 5 |
+
+When a group is supposed to be the source, read the rule — not the user:
+
+```bash
+uip platform groups rules get --output json
+uip platform groups rules details "<GROUP_NAME>" --output json
+```
+
+On `details`, check in this order:
+
+1. **Is the code in the rule's entitled bundles at all?** If not, the rule was replaced — `groups rules set` replaces the whole rule, dropping any bundle absent from the input.
+2. **Is there a `quota`, and is it filled?** A quota caps how many members can hold the bundle; members beyond it do not get a lease.
+3. **Is the user's row `orphan: true`?** Orphaned rows still consume a lease until the rule is re-applied or the user is fully removed — so a lease can be consumed by someone who no longer benefits from it.
+4. **Is `useExternalLicense` set?** It is informational, set outside these commands — do not treat it as a grant you can change here.
+
+> The rule header (entitled bundles, quotas) is written to **stderr**; the JSON on stdout is the member list. When piping to `jq` you will lose the header — read both streams.
+
+## Step 4: Walk the Tenant-Allocation Layer
+
+```bash
+uip platform tenants licenses get "<TENANT_KEY>" --output json
+```
+
+Compare against what the user believes they set:
+
+| Observation | Interpretation |
+|-------------|----------------|
+| `allocated` differs from the value in their input file | The `set` did not apply, or applied to a different tenant. See [failure-modes → Allocation reported success](failure-modes.md#allocation-reported-success-but-units-unchanged) |
+| `allocated` matches, user expected it to be higher | `quantity` is absolute, not additive — their value replaced the old one rather than adding to it |
+| Code they set is absent from output | Bundle window, or the code never routed. See [failure-modes → Product code absent](failure-modes.md#product-code-absent-from-get-output) |
+| A code they did **not** include still has its old value | Correct behavior — `set` is an overlay. Codes absent from the input keep their current quantity |
+| `consumed` > 0 but `allocated` reduced below it | Over-committed: jobs are using more than the new reservation. Flag this explicitly to the user |
+| `availableForAllocation: 0` | Pool exhausted — the requested increase was impossible, not merely rejected |
+
+## Step 5: Decide Whether Licensing Is the Cause
+
+For a runtime symptom (job Pending or faulted, Studio unlicensed, robot not connecting), licensing is **one hypothesis**. This capability's job is to settle that hypothesis with facts, then stop.
+
+Establish and record:
+
+1. The relevant layer for that runtime path — unattended job → tenant allocation; Studio/attended → user bundle; folder-scoped robot slot → `uip or licenses`.
+2. Whether the entitlement is present at that layer, with the command output as evidence.
+3. Whether `availableForAllocation` or a quota was exhausted at the time — noting that a current snapshot cannot prove state during an incident older than 24 hours.
+
+Then:
+
+- **Entitlement genuinely absent** → licensing is the cause. Present the layer, the evidence, and the exact `set` command as a recommendation. Do not run it.
+- **Entitlement present** → licensing is excluded. Say so, hand the runtime causal chain to `uipath-troubleshoot`, and pass along the evidence you gathered so it is not re-fetched.
+- **Cannot tell from the CLI** → the operation may not be covered. Fall back to the License Resource Manager / License Accountant REST APIs ([licensing.md → REST API Fallback](../../licensing.md#rest-api-fallback)) or the portal. Say which, and why the CLI was insufficient.

--- a/skills/uipath-platform/references/licensing/licensing.md
+++ b/skills/uipath-platform/references/licensing/licensing.md
@@ -31,6 +31,7 @@ All `uip platform` licensing commands share a set of cross-cutting options:
 | Tenant Allocations | [tenant-allocations.md](tenant-allocations.md) | `tenants licenses get/set` — allocate license units to tenant pools |
 | User & Group Licenses | [user-licenses-allocations.md](user-licenses-allocations.md) | `users licenses get/set/available`, `groups rules get/details/set` — assign bundles directly or via group rules |
 | Consumables Report | [consumables-report.md](consumables-report.md) | `licenses consumables get --mode {summary,daily,folders}` — consumption reporting. `get` is mandatory; summary/daily/folders are `--mode` values, not subcommands (there is no `licenses summary` verb) |
+| Diagnose | [diagnose/CAPABILITY.md](diagnose/CAPABILITY.md) | Symptom-first triage — entitlement gaps, allocations that did not take effect, reports that read wrong. Layer-first ladder + failure-mode lookup |
 
 ---
 

--- a/tests/tasks/uipath-platform/licensing/consumables_daily.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_daily.yaml
@@ -5,7 +5,7 @@ description: >
   `uip platform licenses consumables get --mode daily --tenant <name>
   --unit <code> --start-date <iso> --end-date <iso> --output json`.
   CLI auth failure is expected offline.
-tags: [uipath-platform, smoke, licensing, consumables]
+tags: [uipath-platform, smoke, licensing, consumables, mode:operate, lifecycle:discover]
 
 sandbox:
   # uip PATH shim -> .uip-cmdlog (see _shared/uip-shim): command telemetry as a

--- a/tests/tasks/uipath-platform/licensing/consumables_folders.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_folders.yaml
@@ -5,7 +5,7 @@ description: >
   calls `uip platform licenses consumables get --mode folders --tenant <name>
   --unit <code> --start-date <iso> --end-date <iso> --output json`.
   CLI auth failure is expected offline.
-tags: [uipath-platform, smoke, licensing, consumables]
+tags: [uipath-platform, smoke, licensing, consumables, mode:operate, lifecycle:discover]
 
 sandbox:
   # uip PATH shim -> .uip-cmdlog (see _shared/uip-shim): command telemetry as a

--- a/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
@@ -4,7 +4,7 @@ description: >
   summary report (default mode). Verifies the agent calls `uip platform
   licenses consumables get --output json` (summary is the default `--mode`,
   so the flag is optional). CLI auth failure is expected offline.
-tags: [uipath-platform, smoke, licensing, consumables]
+tags: [uipath-platform, smoke, licensing, consumables, mode:operate, lifecycle:discover]
 
 sandbox:
   # uip PATH shim -> .uip-cmdlog (see _shared/uip-shim): command telemetry as a

--- a/tests/tasks/uipath-platform/licensing/diagnose_allocation_no_effect.yaml
+++ b/tests/tasks/uipath-platform/licensing/diagnose_allocation_no_effect.yaml
@@ -42,7 +42,7 @@ success_criteria:
     command: "grep -Eq 'uip platform tenants licenses get' .uip-cmdlog"
     timeout: 10
     expected_exit_code: 0
-    weight: 2.0
+    weight: 3.0
     pass_threshold: 1.0
 
   - type: run_command
@@ -56,7 +56,7 @@ success_criteria:
   - type: file_exists
     description: "Explanation written to analysis.md"
     path: "analysis.md"
-    weight: 1.5
+    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command
@@ -64,7 +64,7 @@ success_criteria:
     command: "grep -Eiq 'absolut|not a delta|not additive|does not add|replaces the' analysis.md"
     timeout: 10
     expected_exit_code: 0
-    weight: 3.0
+    weight: 2.0
     pass_threshold: 1.0
 
   - type: run_command
@@ -72,5 +72,5 @@ success_criteria:
     command: "grep -Eiq 'overlay|omitted|absent from|not included|keeps? (its|their) current' analysis.md"
     timeout: 10
     expected_exit_code: 0
-    weight: 3.0
+    weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/diagnose_allocation_no_effect.yaml
+++ b/tests/tasks/uipath-platform/licensing/diagnose_allocation_no_effect.yaml
@@ -1,0 +1,76 @@
+task_id: skill-platform-licensing-diagnose-allocation-no-effect
+description: >
+  Integration test (mode:diagnose): a tenant allocation "did not take effect".
+  Verifies the agent explains the two documented semantics behind the symptom —
+  `quantity` is absolute rather than additive, and `set` is an overlay so codes
+  absent from the input keep their value — without re-running the mutation.
+tags: [uipath-platform, integration, licensing, tenants, mode:diagnose, lifecycle:discover]
+
+sandbox:
+  # uip PATH shim -> .uip-cmdlog (see _shared/uip-shim): command telemetry as a
+  # filesystem side effect. Some agent backends (Antigravity) run commands via
+  # background tasks that never surface as tool calls, so command_executed
+  # criteria see zero commands even when the agent ran the exact command.
+  template_sources:
+    - type: template_dir
+      path: _shared/uip-shim
+  mock_path_dirs:
+    - .cmdlog-bin
+
+initial_prompt: |
+  Yesterday I allocated licenses to tenant
+  `c0ffee00-0000-0000-0000-000000000001` with an input file containing exactly
+  `[{"code":"UNATT","quantity":5}]`. The tenant already had 5 Unattended
+  Robots and I wanted 5 more. The command reported success, but:
+
+  1. The tenant still shows 5 Unattended Robots, not 10.
+  2. `AIU`, which was not in my input file at all, still shows its old
+     quantity — I expected it to be cleared.
+
+  Explain both observations. Write the explanation to `analysis.md` in the
+  current directory. Do NOT change the allocation.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected. Run
+    each command once and move on. Do NOT retry or attempt to login.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: run_command
+    description: "Agent read the tenant's current allocation (.uip-cmdlog shim log)"
+    command: "grep -Eq 'uip platform tenants licenses get' .uip-cmdlog"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Agent did NOT re-run the allocation while diagnosing"
+    command: "test -f .uip-cmdlog && ! grep -Eq 'uip platform tenants licenses set' .uip-cmdlog"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Explanation written to analysis.md"
+    path: "analysis.md"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Analysis explains observation 1: quantity is absolute, not a delta"
+    command: "grep -Eiq 'absolut|not a delta|not additive|does not add|replaces the' analysis.md"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Analysis explains observation 2: set is an overlay, so omitted codes keep their value"
+    command: "grep -Eiq 'overlay|omitted|absent from|not included|keeps? (its|their) current' analysis.md"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/diagnose_consumables_scope.yaml
+++ b/tests/tasks/uipath-platform/licensing/diagnose_consumables_scope.yaml
@@ -1,0 +1,84 @@
+task_id: skill-platform-licensing-diagnose-consumables-scope
+description: >
+  Integration test (mode:diagnose): two consumables figures that look wrong but
+  are correct by design — `consumedFromOrgWithoutTenant` suppressed under
+  `--tenant`, and non-recursive `folders` totals. Verifies the agent reaches the
+  "reporting is not broken" verdict and names both documented semantics.
+tags: [uipath-platform, integration, licensing, consumables, mode:diagnose, lifecycle:discover]
+
+sandbox:
+  # uip PATH shim -> .uip-cmdlog (see _shared/uip-shim): command telemetry as a
+  # filesystem side effect. Some agent backends (Antigravity) run commands via
+  # background tasks that never surface as tool calls, so command_executed
+  # criteria see zero commands even when the agent ran the exact command.
+  template_sources:
+    - type: template_dir
+      path: _shared/uip-shim
+  mock_path_dirs:
+    - .cmdlog-bin
+
+initial_prompt: |
+  Our AI Units (`AIU`) consumption reporting looks broken. Two problems, both
+  for tenant `default` over 2026-04-01 to 2026-04-30:
+
+  1. When I scope a consumables summary to that tenant,
+     `consumedFromOrgWithoutTenant` comes back as 0 — but account-wide it is
+     definitely not 0.
+  2. The per-folder AIU numbers for that tenant do not add up to the tenant's
+     own total for the same period.
+
+  Is consumption reporting actually broken? Write your verdict and reasoning to
+  `verdict.md` in the current directory.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected. Run
+    each command once and move on. Do NOT retry or attempt to login.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: run_command
+    description: "Agent ran a consumables summary to reproduce observation 1 (.uip-cmdlog shim log)"
+    command: "grep -E 'uip platform licenses consumables get' .uip-cmdlog | grep -Eq -- '--mode[= ]summary'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Agent ran folders mode to reproduce observation 2"
+    command: "grep -E 'uip platform licenses consumables get' .uip-cmdlog | grep -Eq -- '--mode[= ]folders'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Verdict written to verdict.md"
+    path: "verdict.md"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Verdict explains observation 1: cross-tenant pool figures are suppressed under --tenant"
+    command: "grep -Eiq 'suppress|scoped|by design|deliberat|expected behaviou?r' verdict.md"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Verdict explains observation 2: folders mode is non-recursive (consumedBySelf excludes children)"
+    command: "grep -Eiq 'non.?recursive|not recursive|child folder|consumedBySelf|exclude' verdict.md"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Verdict concludes reporting is NOT broken"
+    command: "grep -Eiq 'not broken|no.{0,3}t broken|working as|correct|by design|expected' verdict.md"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/diagnose_consumables_scope.yaml
+++ b/tests/tasks/uipath-platform/licensing/diagnose_consumables_scope.yaml
@@ -38,11 +38,19 @@ initial_prompt: |
 
 success_criteria:
   - type: run_command
-    description: "Agent ran a consumables summary to reproduce observation 1 (.uip-cmdlog shim log)"
-    command: "grep -E 'uip platform licenses consumables get' .uip-cmdlog | grep -Eq -- '--mode[= ]summary'"
+    description: "Agent ran a tenant-scoped consumables summary to reproduce observation 1 (.uip-cmdlog shim log)"
+    command: "grep -E 'uip platform licenses consumables get' .uip-cmdlog | grep -E -- '--mode[= ]summary' | grep -Eq -- '--tenant[= ]default'"
     timeout: 10
     expected_exit_code: 0
-    weight: 1.5
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Agent also ran the summary UNSCOPED, so scoped and account-wide figures could be compared — the diagnostic move, not just an assertion about it"
+    command: "grep -E 'uip platform licenses consumables get' .uip-cmdlog | grep -E -- '--mode[= ]summary' | grep -v -- '--tenant' | grep -q ."
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
     pass_threshold: 1.0
 
   - type: run_command
@@ -50,13 +58,13 @@ success_criteria:
     command: "grep -E 'uip platform licenses consumables get' .uip-cmdlog | grep -Eq -- '--mode[= ]folders'"
     timeout: 10
     expected_exit_code: 0
-    weight: 2.0
+    weight: 3.0
     pass_threshold: 1.0
 
   - type: file_exists
     description: "Verdict written to verdict.md"
     path: "verdict.md"
-    weight: 1.5
+    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command
@@ -64,7 +72,7 @@ success_criteria:
     command: "grep -Eiq 'suppress|scoped|by design|deliberat|expected behaviou?r' verdict.md"
     timeout: 10
     expected_exit_code: 0
-    weight: 2.5
+    weight: 2.0
     pass_threshold: 1.0
 
   - type: run_command
@@ -72,7 +80,7 @@ success_criteria:
     command: "grep -Eiq 'non.?recursive|not recursive|child folder|consumedBySelf|exclude' verdict.md"
     timeout: 10
     expected_exit_code: 0
-    weight: 2.5
+    weight: 2.0
     pass_threshold: 1.0
 
   - type: run_command
@@ -80,5 +88,5 @@ success_criteria:
     command: "grep -Eiq 'not broken|no.{0,3}t broken|working as|correct|by design|expected' verdict.md"
     timeout: 10
     expected_exit_code: 0
-    weight: 2.0
+    weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/diagnose_user_missing_bundle.yaml
+++ b/tests/tasks/uipath-platform/licensing/diagnose_user_missing_bundle.yaml
@@ -1,0 +1,76 @@
+task_id: skill-platform-licensing-diagnose-user-missing-bundle
+description: >
+  Integration test (mode:diagnose): a group-leased bundle disappeared for one
+  user. Verifies the agent walks the user-bundle layer correctly — reads the
+  user's leases, then reads the group RULE rather than stopping at the user
+  record — and that it diagnoses without mutating licensing state.
+tags: [uipath-platform, integration, licensing, users, groups, mode:diagnose, lifecycle:discover]
+
+sandbox:
+  # uip PATH shim -> .uip-cmdlog (see _shared/uip-shim): command telemetry as a
+  # filesystem side effect. Some agent backends (Antigravity) run commands via
+  # background tasks that never surface as tool calls, so command_executed
+  # criteria see zero commands even when the agent ran the exact command.
+  template_sources:
+    - type: template_dir
+      path: _shared/uip-shim
+  mock_path_dirs:
+    - .cmdlog-bin
+
+initial_prompt: |
+  A developer, `priya.raman@example.com`, reports she can no longer use Studio
+  — her Automation Developer license is gone. She is a member of the
+  "RPA Developers" group, and nobody touched her account directly.
+
+  Work out why she lost the entitlement. Write your findings to `findings.md`
+  in the current directory: which licensing layer the entitlement should come
+  from, what you checked, and the most likely cause.
+
+  This is an investigation, not a repair — do NOT change any licensing state.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected. Run
+    each command once and move on. Do NOT retry or attempt to login.
+  - Use `--output json` on every uip command.
+  - If the CLI fails, still record which commands you ran and what each one
+    would have told you.
+
+success_criteria:
+  - type: run_command
+    description: "Agent read the user's current leases (.uip-cmdlog shim log)"
+    command: "grep -Eq 'uip platform users licenses get' .uip-cmdlog"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Agent read the GROUP RULE, not just the user record — the entitlement source for a group lease"
+    command: "grep -Eq 'uip platform groups rules (details|get)' .uip-cmdlog"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Agent did NOT mutate licensing state while diagnosing (no users/groups/tenants set)"
+    command: "test -f .uip-cmdlog && ! grep -Eq 'uip platform .*(licenses|rules) set' .uip-cmdlog"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Findings written to findings.md"
+    path: "findings.md"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Findings name a documented group-rule cause (rule replaced / quota filled / orphaned lease)"
+    command: "grep -Eiq 'group rule|groups rules|quota|orphan' findings.md"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
@@ -6,6 +6,17 @@ description: >
   and captures the response envelope. CLI auth failure is expected offline.
 tags: [uipath-platform, smoke, licensing, groups, mode:operate, lifecycle:discover]
 
+sandbox:
+  # uip PATH shim -> .uip-cmdlog (see _shared/uip-shim): command telemetry as a
+  # filesystem side effect. Some agent backends (Antigravity) run commands via
+  # background tasks that never surface as tool calls, so command_executed
+  # criteria see zero commands even when the agent ran the exact command.
+  template_sources:
+    - type: template_dir
+      path: _shared/uip-shim
+  mock_path_dirs:
+    - .cmdlog-bin
+
 initial_prompt: |
   Who in the "RPA Developers" group currently holds which license bundle?
 
@@ -18,10 +29,18 @@ initial_prompt: |
   - Use `--output json` on every uip command.
 
 success_criteria:
+  - type: run_command
+    description: "Agent invoked `uip platform groups rules details` (.uip-cmdlog shim log) — details.json alone cannot prove the CLI ran"
+    command: "grep -Eq 'uip platform groups rules details' .uip-cmdlog"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
   - type: file_exists
     description: "Agent wrote the CLI response to details.json"
     path: "details.json"
-    weight: 2.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: file_contains

--- a/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
@@ -4,7 +4,7 @@ description: >
   group's license-rule details — who in the group holds which bundle — and
   saves the full CLI response to `details.json`. Verifies the file is written
   and captures the response envelope. CLI auth failure is expected offline.
-tags: [uipath-platform, smoke, licensing, groups]
+tags: [uipath-platform, smoke, licensing, groups, mode:operate, lifecycle:discover]
 
 initial_prompt: |
   Who in the "RPA Developers" group currently holds which license bundle?

--- a/tests/tasks/uipath-platform/licensing/groups_rules_list.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_list.yaml
@@ -6,6 +6,17 @@ description: >
   and captures the response envelope. CLI auth failure is expected offline.
 tags: [uipath-platform, smoke, licensing, groups, mode:operate, lifecycle:discover]
 
+sandbox:
+  # uip PATH shim -> .uip-cmdlog (see _shared/uip-shim): command telemetry as a
+  # filesystem side effect. Some agent backends (Antigravity) run commands via
+  # background tasks that never surface as tool calls, so command_executed
+  # criteria see zero commands even when the agent ran the exact command.
+  template_sources:
+    - type: template_dir
+      path: _shared/uip-shim
+  mock_path_dirs:
+    - .cmdlog-bin
+
 initial_prompt: |
   List the group license-allocation rules in this account. Sort them by name
   in descending order and limit to the first 20 results.
@@ -19,10 +30,26 @@ initial_prompt: |
   - Use `--output json` on every uip command.
 
 success_criteria:
+  - type: run_command
+    description: "Agent invoked `uip platform groups rules get` (.uip-cmdlog shim log) — rules.json alone cannot prove the CLI ran"
+    command: "grep -Eq 'uip platform groups rules get' .uip-cmdlog"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Agent passed the requested pagination and sort flags (limit 20, name descending)"
+    command: "grep -E 'uip platform groups rules get' .uip-cmdlog | grep -E -- '--limit[= ]20' | grep -Eq -- '--sort-order[= ]Desc'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: file_exists
     description: "Agent wrote the CLI response to rules.json"
     path: "rules.json"
-    weight: 2.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: file_contains

--- a/tests/tasks/uipath-platform/licensing/groups_rules_list.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_list.yaml
@@ -4,7 +4,7 @@ description: >
   license-allocation rules across the account, with pagination flags, and
   saves the full CLI response to `rules.json`. Verifies the file is written
   and captures the response envelope. CLI auth failure is expected offline.
-tags: [uipath-platform, smoke, licensing, groups]
+tags: [uipath-platform, smoke, licensing, groups, mode:operate, lifecycle:discover]
 
 initial_prompt: |
   List the group license-allocation rules in this account. Sort them by name

--- a/tests/tasks/uipath-platform/licensing/groups_rules_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_set.yaml
@@ -7,7 +7,7 @@ description: >
   and (3) calls `uip platform groups rules set <group> --input <path>
   --output json`. CLI auth failure is expected; this validates command shape
   only.
-tags: [uipath-platform, smoke, licensing, groups]
+tags: [uipath-platform, smoke, licensing, groups, mode:operate, lifecycle:setup]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
+++ b/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
@@ -11,6 +11,17 @@ tags: [uipath-platform, e2e, licensing, mode:operate, lifecycle:discover]
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "WebFetch"]
 
+sandbox:
+  # uip PATH shim -> .uip-cmdlog (see _shared/uip-shim): command telemetry as a
+  # filesystem side effect. Some agent backends (Antigravity) run commands via
+  # background tasks that never surface as tool calls, so command_executed
+  # criteria see zero commands even when the agent ran the exact command.
+  template_sources:
+    - type: template_dir
+      path: _shared/uip-shim
+  mock_path_dirs:
+    - .cmdlog-bin
+
 initial_prompt: |
   Produce a read-only licensing snapshot of this account. This is read-only:
   do NOT run anything that mutates licensing state.
@@ -83,6 +94,22 @@ success_criteria:
     timeout: 30
     expected_exit_code: 0
     weight: 5.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "All four read verbs actually ran (.uip-cmdlog shim log) — the envelope validator checks shape, which hand-written JSON also satisfies"
+    command: "grep -Eq 'uip platform users licenses available' .uip-cmdlog && grep -Eq 'uip platform groups rules get' .uip-cmdlog && grep -Eq 'uip platform licenses consumables get' .uip-cmdlog"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Agent honoured the read-only instruction — no licensing state was mutated"
+    command: "test -f .uip-cmdlog && ! grep -Eq 'uip platform .*(licenses|rules) set' .uip-cmdlog"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
     pass_threshold: 1.0
 
   - type: llm_judge

--- a/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
+++ b/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
@@ -6,7 +6,7 @@ description: >
   CLI call succeeds (`Result: "Success"`), each JSON artifact is written,
   and the agent's final summary reports at least one bundle using the
   `<Friendly Name> (<CODE>)` format from the docs page.
-tags: [uipath-platform, e2e, licensing]
+tags: [uipath-platform, e2e, licensing, mode:operate, lifecycle:discover]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "WebFetch"]

--- a/tests/tasks/uipath-platform/licensing/tenant_allocation_get.yaml
+++ b/tests/tasks/uipath-platform/licensing/tenant_allocation_get.yaml
@@ -4,7 +4,7 @@ description: >
   current license unit allocation. Verifies the agent calls
   `uip platform tenants licenses get <tenant-key> --output json`. CLI auth
   failure is expected in this offline environment.
-tags: [uipath-platform, smoke, licensing, tenants]
+tags: [uipath-platform, smoke, licensing, tenants, mode:operate, lifecycle:discover]
 
 run_limits:
   expected_turns: 5

--- a/tests/tasks/uipath-platform/licensing/tenant_allocation_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/tenant_allocation_set.yaml
@@ -5,7 +5,7 @@ description: >
   file containing the runtime codes with quantities, and (2) the agent calls
   `uip platform tenants licenses set <key> --input <path> --output json`.
   CLI auth failure is expected; this validates command shape only.
-tags: [uipath-platform, smoke, licensing, tenants]
+tags: [uipath-platform, smoke, licensing, tenants, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 6

--- a/tests/tasks/uipath-platform/licensing/users_licenses_available.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_available.yaml
@@ -7,7 +7,7 @@ description: >
   (2) it fetches the UiPath docs license-codes page to resolve the code, and
   (3) the final reply uses the required friendly-name format. CLI auth failure
   is expected in this offline environment; the friendly-name rule still applies.
-tags: [uipath-platform, smoke, licensing, users]
+tags: [uipath-platform, smoke, licensing, users, mode:operate, lifecycle:discover]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-platform/licensing/users_licenses_get.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_get.yaml
@@ -6,7 +6,7 @@ description: >
   --output json` shape, (2) docs page fetch for code resolution, and
   (3) final reply uses `<Friendly Name> (<CODE>)` format. CLI auth failure
   is expected in this offline environment.
-tags: [uipath-platform, smoke, licensing, users]
+tags: [uipath-platform, smoke, licensing, users, mode:operate, lifecycle:discover]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-platform/licensing/users_licenses_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_set.yaml
@@ -7,7 +7,7 @@ description: >
   (3) calls `uip platform users licenses set <user> --input <path>
   --output json`. CLI auth failure is expected; this validates command shape
   only — no live write.
-tags: [uipath-platform, smoke, licensing, users]
+tags: [uipath-platform, smoke, licensing, users, mode:operate, lifecycle:setup]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]


### PR DESCRIPTION
## Why

The Coding Agents Scorecard reports **Licensing (uip platform)** at **50% Troubleshoot Product Coverage vs. Skill**. This PR closes that gap. Scope is deliberately confined to licensing.

I checked whether the 50% was simply untagged tests. It wasn't — licensing diagnosis existed nowhere:

- `uipath-platform` had no diagnose reference for licensing. The workflow guides carry `Error Conditions` tables, but those are keyed by **CLI error string** — a reverse lookup for an error you already hold. Nothing routed from a reported *symptom* to a layer, a command, and an interpretation.
- `uipath-troubleshoot` has no licensing domain under `references/products/`; licensing appears there only incidentally, as a cause inside orchestrator and UIA playbooks.
- All 12 licensing tasks are read/set operations. **Zero** were diagnose-shaped.

## What changed

### 1. Licensing diagnose capability (`6c0506a`)

New `skills/uipath-platform/references/licensing/diagnose/`, following the `references/diagnose/` pattern already used by `uipath-admin` and `uipath-governance`:

| File | Contents |
|---|---|
| `CAPABILITY.md` | Capability index, 7 critical rules, anti-patterns |
| `references/troubleshooting-guide.md` | Five-step layer-first ladder |
| `references/failure-modes.md` | Seven symptom-keyed patterns |

The organising idea: licensing is **four independent layers** (account pool → tenant allocation → user bundle → Orchestrator slot), and tenant allocations vs. user bundles are *separate license types*, not a hierarchy. A user holding every bundle still cannot make an unattended job run. Answering at the wrong layer produces a confident wrong answer, so Step 1 routes to the layer before any command is issued.

Every claim is grounded in behaviour already documented in the workflow guides. Where reconciliation would need an undocumented rule, the guide says to escalate rather than derive it. The failure-mode patterns deliberately do **not** restate the existing error tables — they link to them.

**Scope boundary:** this diagnoses licensing *state*. `uipath-platform`'s description routes root-cause to `uipath-troubleshoot`, so Step 5 settles the entitlement question and hands the runtime causal chain onward with its evidence.

Plus 3 `mode:diagnose` tasks — the first integration-tier licensing tasks. They grade diagnostic behaviour: that the agent reads the group **rule** rather than stopping at the user record, and that it never issues a `set` while diagnosing (a `set` is an overlay that destroys the evidence of the prior state).

### 2. Tag the licensing tasks (`f88d546`)

`tests/README.md` and `.claude/rules/test-writing.md` require `skill` + `tier` + `mode:*` + `lifecycle:*` on every task. None of the 12 licensing tasks carried `mode:*` or `lifecycle:*`.

Not cosmetic: the scorecard splits coverage by mode, so a task with no `mode:*` tag is invisible to its product's Build / Operate / Troubleshoot columns — it passes in the weekly run and still contributes 0% to the number it should be moving.

All 12 are read/set operations against live tenant state, so they are `mode:operate`; lifecycle is `discover` for reads and `setup` for the three `set` tasks.

### 3. Ground the criteria in observed CLI behaviour (`c6ab3a0`) — addresses the lint advisory

**Three tasks could pass without the CLI ever running.** `groups_rules_details` and `groups_rules_list` graded only `file_exists` plus `file_contains: ['"Result"']` — writing `{"Result":"x"}` to the expected path scored full marks having invoked nothing. `licensing_read_e2e` was better off (`licensing_check.py` validates envelope shape and `Result == "Success"`) but a hand-authored envelope satisfies a shape check too. All three now carry the `_shared/uip-shim` sandbox config and grep `.uip-cmdlog` for the verbs they claim to exercise, matching the 12 siblings that already did. `licensing_read_e2e` also gains the read-only guard its prompt always implied but nothing checked.

> The lint suggested grepping for `uip platform groups rules list`. **That verb does not exist** — `assets/uip-catalog-snapshot.json` has `groups rules get`, `details`, `set`. Used `get`.

**Two diagnose tasks were self-report-heavy**, which the repo's own rule against grading self-reports warns about:

| Task | Before | After |
|---|---|---|
| `diagnose_allocation_no_effect` | 5.0 behavioural vs 7.5 self-written | **6.0 vs 5.0** |
| `diagnose_consumables_scope` | 3.5 vs 8.5 | **7.0 vs 6.0** |
| `diagnose_user_missing_bundle` | 8.0 vs 3.5 | unchanged |

Rebalanced onto the documented weight scale: reads and the no-mutation guard are primary validation (3.0), the written analysis is artifact content (2.0), its existence is supporting (1.0). `diagnose_consumables_scope` also gains a genuinely behavioural criterion — the agent must run the summary **both** scoped and unscoped, which is the comparison the failure-modes guide prescribes for telling suppression apart from missing consumption. That grades the diagnostic move rather than an assertion about it.

Every new guard was verified in both directions, including that an absent `.uip-cmdlog` fails rather than passing vacuously. The unscoped check is written `... | grep -v -- '--tenant' | grep -q .` rather than `grep -vq`, because `-vq` is not consistent across grep implementations.

## What this does and does not move

Tagging the 12 existing tasks **does not raise the Troubleshoot number** — they are correctly `mode:operate`. It makes the number *truthful*, not higher. Licensing's genuine `mode:diagnose` count goes 0 → 3, all from commit 1.

## Reviewer notes

- **The `uipath-troubleshoot` handoff has no receiver.** Step 5 hands runtime causality to a licensing domain that doesn't exist yet. Natural follow-up.
- The scorecard reports Licensing at **7/7** tests; the repo had **12** before this PR (15 after). Worth reconciling before treating the 64% Test Coverage figure as precise.
- **Domain accuracy** of the seven failure-mode patterns (absolute vs. delta quantity, overlay behaviour, bundle windows, scope suppression) is drawn from the existing workflow guides rather than verified against a live tenant. A domain expert should confirm.

## Two findings for the scorecard owners, deliberately not fixed here

Both are out of scope for a licensing PR, but they affect how the whole Troubleshoot column reads:

1. **144 tasks repo-wide carry no `mode:*` tag** (479 have some tag problem), and nothing enforces the rule. Every one contributes 0% to its product's mode coverage while still passing. I had a validator + changed-files CI gate in this PR and removed it to keep the scope clean — happy to raise it separately.

2. **`uipath-troubleshoot` holds 264 diagnose tasks**, all tagged `uipath-troubleshoot`, so the per-product Troubleshoot columns cannot see any of them. The repo centralises diagnosis in one skill while the scorecard measures it per product row. Products with their own diagnose tasks score well (admin 30, governance 17); products relying on the central skill score badly. Licensing at 50% is one instance of a column-wide measurement mismatch.

Also worth a separate fix: 3 llmgateway tasks are tagged `mode:troubleshoot`, which is not a valid value (the column is fed by `mode:diagnose`), so they silently drop out of every mode slice. Reverted here to keep this PR licensing-only.

## On the lint's Theme 1

The advisory flags all three diagnose tasks for the self-report axis and suggests *"consider whether a carve-out for diagnose-mode tasks is warranted."* That is a rubric question for whoever owns `.claude/commands/lint-task.md`, not something to settle in this PR. The rebalance above narrows the exposure; the residual tension is real — for a diagnose task the written analysis genuinely **is** the deliverable, not a meta-report about a separate action.

## Verification

- All relative links and anchors in the new references resolve
- All 15 licensing tasks carry valid `mode:*` + `lifecycle:*`; every task now has at least one behavioural criterion
- `check-skill-status.py` and `check-task-driver.py` pass
- SKILL.md frontmatter valid, description 981 chars (cap 1024)

🤖 Generated with [Claude Code](https://claude.com/claude-code)