### PR TITLE
fix(tests): resolve shared-grader imports under coder-eval 0.11 isolation (15 graders)

### DIFF
--- a/tests/tasks/uipath-admin/identity/check_smtp_settings.py
+++ b/tests/tasks/uipath-admin/identity/check_smtp_settings.py
@@ -5,7 +5,11 @@ import logging
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '_shared'))
+_shared = (os.path.join(os.environ['SKILLS_REPO_PATH'],
+                        'tests', 'tasks', 'uipath-admin', '_shared')
+           if os.environ.get('SKILLS_REPO_PATH')
+           else os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '_shared'))
+sys.path.insert(0, _shared)
 from admin_helpers import run_cli, poll, fail, ok
 
 logging.basicConfig(level=logging.INFO, format="check_smtp: %(message)s")

--- a/tests/tasks/uipath-insights/envelope-contract/check_all_commands_envelope.py
+++ b/tests/tasks/uipath-insights/envelope-contract/check_all_commands_envelope.py
@@ -16,10 +16,14 @@ invokes run_command criteria with cwd set to the sandbox root).
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
+_shared = (Path(os.environ["SKILLS_REPO_PATH"]) / "tests" / "tasks" / "uipath-insights" / "_shared"
+           if os.environ.get("SKILLS_REPO_PATH")
+           else Path(__file__).resolve().parent.parent / "_shared")
+sys.path.insert(0, str(_shared))
 from envelope_check import CODES, check_envelope, load_envelope, probe_live_cli
 
 

--- a/tests/tasks/uipath-insights/job-health/check_job_health_investigation.py
+++ b/tests/tasks/uipath-insights/job-health/check_job_health_investigation.py
@@ -22,10 +22,14 @@ invokes run_command criteria with cwd set to the sandbox root).
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
+_shared = (Path(os.environ["SKILLS_REPO_PATH"]) / "tests" / "tasks" / "uipath-insights" / "_shared"
+           if os.environ.get("SKILLS_REPO_PATH")
+           else Path(__file__).resolve().parent.parent / "_shared")
+sys.path.insert(0, str(_shared))
 from envelope_check import (
     CODES,
     check_envelope,

--- a/tests/tasks/uipath-maestro-bpmn/smoke/check_author_validate.py
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/check_author_validate.py
@@ -15,7 +15,11 @@ import os
 import sys
 
 # Import shared helpers from the task suite's _shared module.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-maestro-bpmn", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(__file__), "..", "_shared"))
+sys.path.insert(0, _shared)
 
 from bpmn_check import (  # noqa: E402
     attr,

--- a/tests/tasks/uipath-review/rpa/coded-structural/check_coded_structural.py
+++ b/tests/tasks/uipath-review/rpa/coded-structural/check_coded_structural.py
@@ -13,7 +13,11 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "CodedProc"

--- a/tests/tasks/uipath-review/rpa/credential-security/check_credential_security.py
+++ b/tests/tasks/uipath-review/rpa/credential-security/check_credential_security.py
@@ -14,7 +14,11 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts_any, fixture_contains  # noqa: E402
 
 # SecureString / Get Credential are the FIX. Count them only when the report

--- a/tests/tasks/uipath-review/rpa/e2e-multi-project-solution/check_e2e_multi_project_solution.py
+++ b/tests/tasks/uipath-review/rpa/e2e-multi-project-solution/check_e2e_multi_project_solution.py
@@ -15,7 +15,11 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "RetailSolution"

--- a/tests/tasks/uipath-review/rpa/e2e-reframework-process/check_e2e_reframework_process.py
+++ b/tests/tasks/uipath-review/rpa/e2e-reframework-process/check_e2e_reframework_process.py
@@ -22,7 +22,11 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "RefxFull"

--- a/tests/tasks/uipath-review/rpa/exception-classification/check_exception_classification.py
+++ b/tests/tasks/uipath-review/rpa/exception-classification/check_exception_classification.py
@@ -14,7 +14,11 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "ExceptionBot"

--- a/tests/tasks/uipath-review/rpa/hardcoded-config/check_hardcoded_config.py
+++ b/tests/tasks/uipath-review/rpa/hardcoded-config/check_hardcoded_config.py
@@ -12,7 +12,11 @@ URL must still exist in the fixture.
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "HardcodedBot"

--- a/tests/tasks/uipath-review/rpa/logging-pii/check_logging_pii.py
+++ b/tests/tasks/uipath-review/rpa/logging-pii/check_logging_pii.py
@@ -14,7 +14,11 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "LoggingBot"

--- a/tests/tasks/uipath-review/rpa/performance-datatable/check_performance_datatable.py
+++ b/tests/tasks/uipath-review/rpa/performance-datatable/check_performance_datatable.py
@@ -12,7 +12,11 @@ must still exist in the fixture.
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "PerfBot"

--- a/tests/tasks/uipath-review/rpa/reframework-integrity/check_reframework_integrity.py
+++ b/tests/tasks/uipath-review/rpa/reframework-integrity/check_reframework_integrity.py
@@ -13,7 +13,11 @@ correctly" does not count. The planted swallow must still exist in the fixture.
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "REFrameworkBot"

--- a/tests/tasks/uipath-review/rpa/selector-brittle/check_selector_brittle.py
+++ b/tests/tasks/uipath-review/rpa/selector-brittle/check_selector_brittle.py
@@ -11,7 +11,11 @@ planted idx selector must still exist in the fixture.
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "BrittleBot"

--- a/tests/tasks/uipath-review/rpa/transaction-shape/check_transaction_shape.py
+++ b/tests/tasks/uipath-review/rpa/transaction-shape/check_transaction_shape.py
@@ -13,7 +13,11 @@ planted loop must also still exist in the sandbox fixture (guards shell edits).
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "TxnShapeBot"


### PR DESCRIPTION
## Problem

coder-eval 0.11 isolates each grader to a copy at `$TASK_DIR` (`/work/task_dir/`) and no longer exposes the task dir's parent. Graders that reach a shared helper by walking UP out of the task dir break with `ModuleNotFoundError` — their `run_command` criterion scores **0.0** and the task FAILS even though the agent ran fine.

`tests/scripts/stage_shared.sh` already rescues most such graders: it detects `from _shared` / `import _shared` and co-locates the group-top `tests/tasks/<group>/_shared` package into each task dir. But **15 graders slip through that net** and are still broken on main:

- **11 `uipath-review/rpa/*`** import `from grader_common` (bare module name — not matched by the `_shared` detector) **and** their helper lives in the **nested** `tests/tasks/uipath-review/rpa/_shared/` (stage_shared copies the group-top `uipath-review/_shared` — the wrong directory).
- **`uipath-maestro-bpmn/smoke/check_author_validate.py`** imports `from bpmn_check` (bare; detector misses it).
- **`uipath-insights/{envelope-contract,job-health}`** import `from envelope_check` (bare; detector misses it).
- **`uipath-admin/identity/check_smtp_settings.py`** imports `from admin_helpers` via a `dirname(dirname(__file__))/_shared` up-walk and is invoked from the isolated copy (`runpy.run_path($TASK_DIR/check_smtp_settings.py)`). *(Added after a reviewer flagged the admin/governance bare-import pattern — see Scope note.)*

## Fix

Root each shared-import at `$SKILLS_REPO_PATH` with the proven relative up-walk kept as fallback:

```python
_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
                        "tests", "tasks", "<skill>", ..., "_shared")
           if os.environ.get("SKILLS_REPO_PATH")
           else <original relative up-walk>)
sys.path.insert(0, _shared)   # str(_shared) for the pathlib graders
```

- The env-var branch resolves under CI/docker isolation (the plugin repo is bind-mounted at the same host path in-container, and `SKILLS_REPO_PATH` is passed through `smoke.yaml` `env_passthrough_extra`).
- The fallback is byte-identical to today's behavior, so it cannot regress stray local runs.
- Each file points at its **own** `tests/tasks/<skill>/_shared`; the two insights graders keep their pathlib idiom; the admin grader keeps its `dirname(dirname())` fallback.
- **No change** to the shared helper packages or `stage_shared.sh`. `legacy-precision` is untouched (already uses `SKILLS_REPO_PATH`).

## Scope — why exactly these 15

The fix targets **only** graders invoked from the isolated `$TASK_DIR`. Two families with the same bare-import up-walk are intentionally **left untouched** because they are already operational:

- The **21 `from _shared.<module>` graders** — `stage_shared.sh` detects and co-locates their group-top `_shared`.
- The **62 admin/governance `setup_`/`verify_`/`cleanup_` scripts** (`admin_helpers`/`audit_helpers`/`gov_helpers`) — invoked via **absolute `$SKILLS_REPO_PATH` paths** (`runpy.run_path(os.path.join(os.environ['SKILLS_REPO_PATH'], 'tests','tasks',...))`), so `__file__` is the bind-mounted repo path and their up-walk resolves. Modifying them would touch working tasks. `check_smtp_settings.py` is the **sole** admin/governance script invoked via `$TASK_DIR`, hence the only broken one.

Fixed files (15): `uipath-review/rpa/` (coded-structural, credential-security, e2e-multi-project-solution, e2e-reframework-process, exception-classification, hardcoded-config, logging-pii, performance-datatable, reframework-integrity, selector-brittle, transaction-shape) · `uipath-maestro-bpmn/smoke/check_author_validate` · `uipath-insights/{envelope-contract,job-health}` · `uipath-admin/identity/check_smtp_settings`.

## Verification

**End-to-end in docker (coder-eval 0.11, gpt-5.6-luna)** — `selector-brittle`, same skill content, only the grader differs:

| | `run_command` criterion | Task |
|---|---|---|
| **main** (unfixed) | **0.0** — `ModuleNotFoundError: No module named 'grader_common'` at `/work/task_dir/check_selector_brittle.py:15`, exit 1 | **FAILURE** (0.375) |
| **PR** (fixed) | **1.0** — exit 0, "PASS", stderr empty | **SUCCESS** (1.0) |

**Per-task isolation A/B (all 15)** — each grader run alone in a `/work/task_dir`-style dir with no `../_shared` (the exact condition the docker run reproduced): every one **fails on main** (`ModuleNotFoundError`) and **imports cleanly on the PR** with `SKILLS_REPO_PATH` set. No already-operational task is modified.

> Opened as its own focused PR (not folded into uipath-review skill PR #2740) — it fixes a latent bug on `main` affecting all consumers and unblocks #2740's smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)