### PR TITLE
fix(tasks): make smoke_completion eval robust to batched complete calls

### DIFF
--- a/tests/tasks/uipath-tasks/smoke_completion.yaml
+++ b/tests/tasks/uipath-tasks/smoke_completion.yaml
@@ -37,44 +37,34 @@ initial_prompt: |
     Run each command once and move on. Do NOT retry or login.
   - Do NOT skip --type on any complete call. Do NOT skip --folder-id.
 
+# Each per-type criterion asserts every required flag for that completion
+# (--type, --folder-id, and --action/--data where required) via order-independent
+# lookaheads scoped to a single line ([^\n]*). This grades behaviour regardless of
+# flag order and whether the agent runs the three completions as separate commands
+# or batches them into one newline-separated Bash call (Codex does the latter),
+# which a min_count:3 "every call" criterion would under-count.
 success_criteria:
   - type: command_executed
-    description: "Agent completed an ExternalTask with --type and --folder-id (minimal form)"
+    description: "Completed an ExternalTask with --type and --folder-id (minimal form)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tasks\s+complete\s+\d+\s+.*--type\s+ExternalTask.*--folder-id\s+\d+'
+    command_pattern: 'uip\s+tasks\s+complete\s+\d+(?=[^\n]*--type\s+ExternalTask)(?=[^\n]*--folder-id\s+\d+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent completed a FormTask with --action and --data"
+    description: "Completed a FormTask with --type, --folder-id, --action and --data"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tasks\s+complete\s+\d+\s+.*--type\s+FormTask.*--action\s+.*--data\s+'
-    min_count: 1
-    weight: 2.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent completed an AppTask with --action and --data"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+tasks\s+complete\s+\d+\s+.*--type\s+AppTask.*--action\s+.*--data\s+'
+    command_pattern: 'uip\s+tasks\s+complete\s+\d+(?=[^\n]*--type\s+FormTask)(?=[^\n]*--folder-id\s+\d+)(?=[^\n]*--action\s+)(?=[^\n]*--data\s+)'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Every complete call includes --folder-id"
+    description: "Completed an AppTask with --type, --folder-id, --action and --data"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tasks\s+complete\s+\d+\s+.*--folder-id\s+\d+'
-    min_count: 3
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Every complete call includes --type"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+tasks\s+complete\s+\d+\s+.*--type\s+\w+'
-    min_count: 3
-    weight: 2.0
+    command_pattern: 'uip\s+tasks\s+complete\s+\d+(?=[^\n]*--type\s+AppTask)(?=[^\n]*--folder-id\s+\d+)(?=[^\n]*--action\s+)(?=[^\n]*--data\s+)'
+    min_count: 1
+    weight: 2.5
     pass_threshold: 1.0
 


### PR DESCRIPTION
`skill-tasks-smoke-completion` fails on the Codex run (uipath-tasks 8/9) but passes on Claude Code. Root cause: Codex batches the three completions into a single newline-separated Bash call, so the two `min_count: 3` "every complete call includes --folder-id / --type" criteria count one command and score 0.33. The completions themselves are correct on both agents.

**Fix:** fold `--type`, `--folder-id` (and `--action`/`--data` for Form/App) into each per-type criterion using order-independent, line-scoped lookaheads (`min_count: 1`), and drop the two batch-fragile `min_count: 3` criteria. Grades behaviour regardless of flag order or command batching.

**Verified** against the real command lists from the 2026-08-24 runs: all three per-type criteria pass (score 1.0) for both Codex (batched) and Claude (separate).

Context: https://uipath-product.slack.com/archives/C0A2T23NJ59/p1787657402634249 · Jira: https://uipath.atlassian.net/browse/ACTN-11600

🤖 Generated with [Claude Code](https://claude.com/claude-code)