### PR TITLE
fix(uipath-automationhub): workspace-file rule + single-invocation discovery/verify (RPANAV-18978)

### DIFF
--- a/skills/uipath-automationhub/references/cli-commands.md
+++ b/skills/uipath-automationhub/references/cli-commands.md
@@ -22,6 +22,8 @@ Always pass `--output json`. Success:
 
 Failure: `Result` is `Failure`/`ValidationError` with a `Message` and usually an `Instructions` hint — surface both to the user. Exit codes: `0` success, `1` failure, `3` validation.
 
+> ⚠️ **`--output-filter` requires an explicit `--limit`.** List commands default to `--limit 20`, and the CLI rejects an output filter on an implicit page (validation error, exit `3`) because it would silently filter only the first 20 records. Whenever you pass `--output-filter`, also pass a `--limit` sized to cover the full result set (the option's `--help` text states the command's maximum).
+
 ## Commands used by the flows
 
 | Command | Purpose | Data shape notes |

--- a/skills/uipath-automationhub/references/get-process-cli-guide.md
+++ b/skills/uipath-automationhub/references/get-process-cli-guide.md
@@ -37,6 +37,8 @@ Only file-backed documents download, and the command takes the **`FileId`** — 
 uip ah documents download $FILE_ID --destination "<path>" --output json
 ```
 
+> 📁 **Download to the current working directory — never `/tmp`.** Hosted runtimes (e.g. the Delegate) sandbox their file tools to the session workspace: the CLI can write to `/tmp`, but every file-tool access to the download then fails with an access-denied error.
+
 - `Data` reports `Destination` and `Bytes` — confirm the file exists and is non-empty before reporting success.
 - Link-backed documents: present the `EmbedLink` instead. Never invent a download path.
 

--- a/skills/uipath-automationhub/references/publish-process-cli-guide.md
+++ b/skills/uipath-automationhub/references/publish-process-cli-guide.md
@@ -24,7 +24,7 @@ Default to the entry whose `Name` contains "Business Process" (case-insensitive)
 uip ah automations schema get --idea-flow-id $IDEA_FLOW_ID --destination ./ah-schema.json --output json
 ```
 
-> 📁 **Working files (`ah-schema.json`, `ah-answers.json`) go in the current working directory — never `/tmp`.** Hosted runtimes (e.g. the Delegate) sandbox their file tools to the session workspace: a file written to `/tmp` is readable by the CLI but every file-tool access to it fails with an access-denied error.
+> 📁 **Working files (`ah-schema.json`, `ah-answers.json`, and any document files you generate for upload) go in the current working directory — never `/tmp`.** Hosted runtimes (e.g. the Delegate) sandbox their file tools to the session workspace: a file written to `/tmp` is readable by the CLI but every file-tool access to it fails with an access-denied error.
 
 Read `./ah-schema.json`: the field catalog is under `properties.schema.properties` (Assessment Type > Section > Question; enums carry `answer_option` codes) and `user_inputs` is the payload template.
 

--- a/skills/uipath-automationhub/references/publish-process-cli-guide.md
+++ b/skills/uipath-automationhub/references/publish-process-cli-guide.md
@@ -24,6 +24,8 @@ Default to the entry whose `Name` contains "Business Process" (case-insensitive)
 uip ah automations schema get --idea-flow-id $IDEA_FLOW_ID --destination ./ah-schema.json --output json
 ```
 
+> 📁 **Working files (`ah-schema.json`, `ah-answers.json`) go in the current working directory — never `/tmp`.** Hosted runtimes (e.g. the Delegate) sandbox their file tools to the session workspace: a file written to `/tmp` is readable by the CLI but every file-tool access to it fails with an access-denied error.
+
 Read `./ah-schema.json`: the field catalog is under `properties.schema.properties` (Assessment Type > Section > Question; enums carry `answer_option` codes) and `user_inputs` is the payload template.
 
 > ⚠️ **Do NOT submit `user_inputs` verbatim** — its example values are placeholders the API rejects (category `1`, placeholder answer codes, example emails). Shape only.
@@ -43,6 +45,8 @@ First **enumerate the tenant's actual required set from the schema file**: every
 | **Owner email** | `uip ah users list` → must be a listed `Email` (prefer `IsActive: 1`). Default to the signed-in user; confirm. |
 | **Submitter email** | Same as owner; usually the same person. |
 | **Application questions** (when tenant-required) | `uip ah applications list` → valid entries; if the material leaves systems unconfirmed, ask — never record an app the material does not support. Follow the question's own schema shape. |
+
+The discovery commands are independent — run the ones you need (`categories get`, `users list`, `applications list`) **in a single shell invocation** rather than one per turn; each is fast, the round-trips between them are not.
 
 Write the answers to `./ah-answers.json` as the filled `user_inputs` structure (the CLI accepts the whole schema-get document or just the answers map). Wrapping rules unchanged: most fields `{ "value": <v> }`; owner/submitter are **direct strings**; enum codes from that field's own `enum`; integers as numbers. Show the user a concise preview and get a confirm before writing.
 
@@ -78,17 +82,16 @@ When the caller wants the process linked to a Studio Web solution (or supplies o
 
 ## Step 7: Verify, then report
 
+Both verification reads are independent — run them in **one shell invocation**:
+
 ```bash
 uip ah documents list $PROCESS_ID --output json
-```
-
-Every attached document id must appear (file-backed ones with a `FileId`). Missing → report it failed; never claim an attach you didn't see in this list.
-
-The report **MUST end with both View deep links**. The URL segment is `process_slug` — fetch it:
-
-```bash
 uip ah automations get $PROCESS_ID --all-fields --output json   # read process_slug from Data
 ```
+
+Every attached document id must appear in the documents list (file-backed ones with a `FileId`). Missing → report it failed; never claim an attach you didn't see in this list.
+
+The report **MUST end with both View deep links** — the URL segment is `process_slug` from the `--all-fields` record.
 
 ```
 Published to Automation Hub:


### PR DESCRIPTION
Two hardening fixes to the publish flow, driven by Delegate e2e findings from two successful live runs (processes 19 & 20 + byte-uploaded PDDs on alpha). Tracked in [RPANAV-18978](https://uipath.atlassian.net/browse/RPANAV-18978).

**1. Working files go in the CWD — never `/tmp`.** In both runs the agent wrote `ah-schema.json`/`ah-answers.json` to `/tmp`; the CLI reads them fine (bash is unsandboxed), but the Delegate's file tools are sandboxed to the session workspace and denied every access — 12 failed tool actions in the Aug 25 run alone (`Access denied: /tmp/ah-answers.json (ro) is outside the allowed filesystem ruleset`). Step 3 now carries an explicit rule — covering the answers/schema JSON and any document files the agent generates for upload — and the get-flow's download step (`documents download --destination`) carries the mirrored rule, since a download to `/tmp` is unreadable to the file tools for the same reason.

**2. Batch independent CLI reads into one shell invocation.** Discovery (`categories get` / `users list` / `applications list`) and the Step-7 verify pair (`documents list` + `automations get --all-fields`) each ran as separate agent turns; the commands are 1–4s each — the model round-trips between them are the cost (~4 avoidable turns, ~30–60s of a ~7m40s run).

Doc-only; no command or criteria changes. `check-cli-verbs` / `check-skill-verbs` clean against the 1.202.0-dev catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RPANAV-18978]: https://uipath.atlassian.net/browse/RPANAV-18978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
