### PR TITLE
fix(maestro-case): recognize V30 stage references

### DIFF
--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -216,6 +216,15 @@ def find_node_by_label(plan: dict, label: str) -> dict:
     _fail(f"no node with data.label={label!r}; available labels: {labels}")
 
 
+def selected_stage_ids(rule: dict) -> list[str]:
+    """Return canonical V30 stage references with legacy-schema compatibility."""
+    selected = rule.get("selectedStageIds")
+    if isinstance(selected, list):
+        return [value for value in selected if isinstance(value, str) and value]
+    legacy_selected = rule.get("selectedStageId")
+    return [legacy_selected] if isinstance(legacy_selected, str) and legacy_selected else []
+
+
 def stage_transitions(plan: dict) -> list[dict]:
     """Stage→stage transitions derived from entry/exit conditions.
 
@@ -224,7 +233,7 @@ def stage_transitions(plan: dict) -> list[dict]:
     exists when EITHER:
 
     - ``Y``'s ``entryConditions`` carries a ``selected-stage-completed`` /
-      ``selected-stage-exited`` rule with ``selectedStageId == X``, OR
+      ``selected-stage-exited`` rule with ``X`` in ``selectedStageIds``, OR
     - ``X``'s ``exitConditions`` carries ``exitToStageId == Y``.
 
     ``case-entered`` entries are NOT transitions — their source is the case
@@ -244,8 +253,7 @@ def stage_transitions(plan: dict) -> list[dict]:
         for cond in iter_stage_entry_conditions(node):
             for group in cond.get("rules") or []:
                 for rule in group or []:
-                    src = (rule or {}).get("selectedStageId")
-                    if src:
+                    for src in selected_stage_ids(rule or {}):
                         pairs.add((src, nid))
         for cond in iter_stage_exit_conditions(node):
             dst = cond.get("exitToStageId")

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/check_expense_runnable_structure.py
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/check_expense_runnable_structure.py
@@ -35,6 +35,7 @@ from _shared.case_check import (  # noqa: E402
     get_case_exit_conditions,
     iter_tasks,
     read_caseplan,
+    selected_stage_ids,
 )
 
 EXPECTED_CASEPLAN = os.path.join(
@@ -218,8 +219,8 @@ def main():
         rname = rule.get("rule")
         if rname == "required-stages-completed" and ce.get("marksCaseComplete") is True:
             happy = True
-        if rname in ("selected-stage-completed", "selected-stage-exited") and rule.get("selectedStageId") in terminal_ids:
-            terminal_seen.add(rule.get("selectedStageId"))
+        if rname in ("selected-stage-completed", "selected-stage-exited"):
+            terminal_seen.update(terminal_ids & set(selected_stage_ids(rule)))
     if not happy:
         _fail("missing happy-path case-exit 'required-stages-completed' with marksCaseComplete=true")
     missing_term = [name for name, node in terminal.items() if node["id"] not in terminal_seen]

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/test_check_expense_runnable_structure.py
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/test_check_expense_runnable_structure.py
@@ -13,6 +13,7 @@ from check_expense_runnable_structure import (  # noqa: E402
     _assert_bindings_v2_metadata,
     _assert_required_external_bindings,
 )
+from _shared.case_check import selected_stage_ids, stage_transitions  # noqa: E402
 
 
 class BindingsV2MetadataTests(unittest.TestCase):
@@ -76,6 +77,52 @@ class RunLimitTests(unittest.TestCase):
             if separator and name in {"task_timeout", "turn_timeout"}:
                 limits[name] = int(value.strip())
         self.assertEqual(limits["turn_timeout"], limits["task_timeout"])
+
+
+class StageTransitionTests(unittest.TestCase):
+    def test_selected_stage_ids_prefers_v30_plural_and_accepts_legacy_singular(self) -> None:
+        self.assertEqual(
+            selected_stage_ids({"selectedStageIds": ["first", "second"]}),
+            ["first", "second"],
+        )
+        self.assertEqual(selected_stage_ids({"selectedStageId": "legacy"}), ["legacy"])
+
+    def test_reads_v30_plural_and_legacy_singular_stage_ids(self) -> None:
+        plan = {
+            "nodes": [
+                {
+                    "id": "target",
+                    "type": "case-management:Stage",
+                    "data": {
+                        "entryConditions": [
+                            {
+                                "rules": [
+                                    [
+                                        {
+                                            "rule": "selected-stage-completed",
+                                            "selectedStageIds": ["first", "second"],
+                                        },
+                                        {
+                                            "rule": "selected-stage-exited",
+                                            "selectedStageId": "legacy",
+                                        },
+                                    ]
+                                ]
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+
+        self.assertEqual(
+            stage_transitions(plan),
+            [
+                {"source": "first", "target": "target"},
+                {"source": "legacy", "target": "target"},
+                {"source": "second", "target": "target"},
+            ],
+        )
 
 
 def _valid_resources() -> list[dict]:


### PR DESCRIPTION
## Root cause

The shared Case graph helpers still read the pre-V30 singular `selectedStageId` field. Product schema normalization now emits canonical `selectedStageIds[]`, so valid migrated plans appeared disconnected and terminal case-exit rules were invisible to the expense checker.

## Fix

- centralize canonical and legacy reads in `selected_stage_ids`
- derive stage transitions through that shared accessor
- use the same accessor for terminal case-exit grading
- cover multi-stage V30 references and legacy compatibility

## Validation

- `python3 -m compileall -q ...`
- `python3 -m unittest tests/tasks/uipath-maestro-case/e2e_expense_runnable/test_check_expense_runnable_structure.py` (8 passed)
- frozen expense structural checker passes against a real SDK-generated plan normalized to V30

Supports UiPath/flow-builder-sdk#562.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)