### PR TITLE
fix(maestro-bpmn): resolve semantic variables to runtime ids

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/nodes/check_script_jint_guidance.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/check_script_jint_guidance.py
@@ -34,19 +34,18 @@ FORBIDDEN = [
 ]
 
 
-def root_variables_by_name(root: ET.Element) -> dict[str, str]:
-    variables: dict[str, str] = {}
+def root_variable_ids(root: ET.Element) -> set[str]:
+    variables: set[str] = set()
     process = root.find("bpmn:process", NS)
     if process is None:
-        return variables
+        return set()
     for variable in process.findall(
         "bpmn:extensionElements/uipath:variables/*",
         NS,
     ):
-        name = variable.attrib.get("name")
         variable_id = variable.attrib.get("id")
-        if name and variable_id:
-            variables[name] = variable_id
+        if variable_id:
+            variables.add(variable_id)
     return variables
 
 
@@ -125,25 +124,24 @@ def main() -> None:
         if identifier not in body:
             fail(f"script body should reference mapped input identifier {identifier!r}")
 
-    variables = root_variables_by_name(root)
+    variables = root_variable_ids(root)
     for required in ("amount", "daysOverdue", "riskScore"):
         if required not in variables:
-            fail(f"missing root variable named {required!r}")
+            fail(f"missing root variable id {required!r}")
 
     args_input = first_uipath_input(task, "args")
     if args_input is None:
         fail('script mapping must include uipath:input name="args"')
     args_body = text_content(args_input)
     for variable_name in ("amount", "daysOverdue"):
-        expected = f"=vars.{variables[variable_name]}"
+        expected = f"=vars.{variable_name}"
         if expected not in args_body:
             fail(f"script args should map {variable_name!r} through {expected!r}")
         if f"={variable_name}" in args_body:
             fail(f"script args should not use bare variable expression ={variable_name}")
 
-    output_var = variables["riskScore"]
     outputs = uipath_outputs(task)
-    if not any(out.attrib.get("var") == output_var for out in outputs):
+    if not any(out.attrib.get("var") == "riskScore" for out in outputs):
         fail("script output must map to the declared riskScore variable id")
     if not any((out.attrib.get("source") or "").startswith("=result.") for out in outputs):
         fail("script output should map from a result expression such as =result.response")

--- a/tests/tasks/uipath-maestro-bpmn/nodes/check_script_jint_guidance.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/check_script_jint_guidance.py
@@ -34,18 +34,29 @@ FORBIDDEN = [
 ]
 
 
-def root_variable_ids(root: ET.Element) -> set[str]:
-    variables: set[str] = set()
+def normalized_variable_key(value: str) -> str:
+    return "".join(character for character in value.casefold() if character.isalnum())
+
+
+def root_variables_by_key(root: ET.Element) -> dict[str, str]:
+    variables: dict[str, str] = {}
     process = root.find("bpmn:process", NS)
     if process is None:
-        return set()
+        return variables
     for variable in process.findall(
         "bpmn:extensionElements/uipath:variables/*",
         NS,
     ):
         variable_id = variable.attrib.get("id")
-        if variable_id:
-            variables.add(variable_id)
+        if not variable_id:
+            continue
+        name = variable.attrib.get("name")
+        for candidate in (name, variable_id):
+            if candidate:
+                variables.setdefault(normalized_variable_key(candidate), variable_id)
+        id_key = normalized_variable_key(variable_id)
+        if id_key.startswith("var"):
+            variables.setdefault(id_key[3:], variable_id)
     return variables
 
 
@@ -124,24 +135,27 @@ def main() -> None:
         if identifier not in body:
             fail(f"script body should reference mapped input identifier {identifier!r}")
 
-    variables = root_variable_ids(root)
+    variables = root_variables_by_key(root)
     for required in ("amount", "daysOverdue", "riskScore"):
-        if required not in variables:
-            fail(f"missing root variable id {required!r}")
+        key = normalized_variable_key(required)
+        if key not in variables:
+            fail(f"missing root variable for {required!r}")
 
     args_input = first_uipath_input(task, "args")
     if args_input is None:
         fail('script mapping must include uipath:input name="args"')
     args_body = text_content(args_input)
     for variable_name in ("amount", "daysOverdue"):
-        expected = f"=vars.{variable_name}"
+        variable_id = variables[normalized_variable_key(variable_name)]
+        expected = f"=vars.{variable_id}"
         if expected not in args_body:
             fail(f"script args should map {variable_name!r} through {expected!r}")
         if f"={variable_name}" in args_body:
             fail(f"script args should not use bare variable expression ={variable_name}")
 
     outputs = uipath_outputs(task)
-    if not any(out.attrib.get("var") == "riskScore" for out in outputs):
+    output_var = variables[normalized_variable_key("riskScore")]
+    if not any(out.attrib.get("var") == output_var for out in outputs):
         fail("script output must map to the declared riskScore variable id")
     if not any((out.attrib.get("source") or "").startswith("=result.") for out in outputs):
         fail("script output should map from a result expression such as =result.response")


### PR DESCRIPTION
## Summary

- resolve requested logical variables from normalized display names with an ID fallback
- validate script input expressions and output targets against each declaration's exact runtime `id`
- accept valid authored BPMN whether it uses `id="amount"` or `id="Var_Amount" name="Amount"`

## Root cause

The grader treated the optional human-facing `name` attribute as both semantic identity and runtime identity. That rejected valid id-only declarations. Switching to literal IDs alone would create the inverse false negative for the skill's recommended `Var_*` identifiers. UiPath expressions and mapping targets resolve the stable variable `id`, while the task's requested business fields may be represented by a display name.

The checker now separates those concerns: it locates `amount`, `daysOverdue`, and `riskScore` semantically, then verifies `vars.<actual-id>` and `var="<actual-id>"` exactly.

## Validation

- Replayed the checker against both successful SDK sweep artifacts that use literal IDs; both pass.
- Replayed it against the exact CI artifact using `Var_Amount`, `Var_DaysOverdue`, and `Var_RiskScore`; it passes.
- Syntax compilation and `git diff --check` pass.

Supports UiPath/flow-builder-sdk#284.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)