### PR TITLE
ci: default coder-eval runs to codex + gpt-5.6-luna

### DIFF
--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -75,17 +75,23 @@ on:
       # Windows runs it in-process on the host (tempdir driver) with its own
       # delegate-stdio install, ROPC user token, and shared interop — ports of
       # coder_eval_uipath's daily.sh / daily-windows.ps1 wiring.
+      #
+      # codex is the DEFAULT: it is the harness the nightly runs daily (claude runs
+      # twice a week), and codex on the cheap tier measures at pass-rate parity with
+      # claude-sonnet-5 for a fraction of the cost. An ad-hoc run should reproduce the
+      # daily driver by default, not the twice-weekly one.
       agent:
         description: 'Agent to run.'
         type: choice
         options:
-          - claude
           - codex
+          - claude
           - antigravity
           - delegate-sdk
-        default: claude
+        default: codex
       # Overrides the model for ANY agent. Blank keeps that harness's own repo
-      # variable (CLAUDE_CODE_MODEL / CODEX_MODEL / ANTIGRAVITY_MODEL).
+      # variable (CLAUDE_CODE_MODEL / CODEX_MODEL / ANTIGRAVITY_MODEL) — which is
+      # where the default model lives, so it stays correct whichever agent is picked.
       agent_model:
         description: 'Model override (blank = default).'
         type: string

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -352,9 +352,11 @@ jobs:
 
       # Host coder-eval CLI = pinned wheel from the Azure Artifacts `coder_eval`
       # feed; its UiPath deps resolve from the ml-packages feed (both as extra
-      # indexes). No source checkout.
+      # indexes). No source checkout. The [codex] extra is required even though the
+      # agent itself runs inside the container: the docker driver imports the selected
+      # agent class on the HOST before dispatching work.
       - name: Install coder-eval
-        run: uv pip install --system "coder-eval==${{ steps.ceref.outputs.version }}"
+        run: uv pip install --system --prerelease=allow "coder-eval[codex]==${{ steps.ceref.outputs.version }}"
 
       # Pull the pinned agent image from GHCR (never built from source); the
       # skills smoke image extends it below. Needs read:packages only —
@@ -431,8 +433,8 @@ jobs:
       # evaluated nothing. Fail here instead, before any task runs.
       - name: Require an agent model
         env:
-          AGENT_MODEL: ${{ vars.CLAUDE_CODE_MODEL }}
-        run: ': "${AGENT_MODEL:?unset — set the CLAUDE_CODE_MODEL repo variable}"'
+          AGENT_MODEL: ${{ vars.CODEX_MODEL }}
+        run: ': "${AGENT_MODEL:?unset — set the CODEX_MODEL repo variable}"'
 
       # coder-eval 0.11 isolates $TASK_DIR to the leaf task folder, so graders
       # can no longer import the group-level _shared/ helper by walking up the
@@ -459,22 +461,27 @@ jobs:
           BEDROCK_MODEL: ${{ secrets.BEDROCK_MODEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           TASK_PARALLELISM: ${{ vars.TASK_PARALLELISM || '1' }}
+          # Codex auth: the key + the endpoint the codex binary talks to. Same secrets
+          # the nightly and run-coder-eval.yml use.
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+          CODEX_BASE_URL: ${{ secrets.CODEX_BASE_URL }}
           # The gate's agent model, passed explicitly on the command line rather than
           # pinned in experiments/smoke.yaml — one repo variable moves every gate here,
           # and the experiment file stays harness-agnostic (the nightly runs the same
-          # file under codex/antigravity with their own models). No literal fallback:
+          # file under claude/antigravity with their own models). No literal fallback:
           # gating on a model nobody configured reports a verdict about the wrong thing,
           # so an unset variable fails the guard step above. NOT $BEDROCK_MODEL: that
-          # is the evaluation-side model (llm_judge + the simulated user), and reusing
-          # it here would move the grader with the agent.
-          AGENT_MODEL: ${{ vars.CLAUDE_CODE_MODEL }}
+          # is the evaluation-side model (llm_judge + the simulated user), which stays
+          # on Claude on purpose — the grader must not move with the agent.
+          AGENT_MODEL: ${{ vars.CODEX_MODEL }}
         working-directory: tests
         id: smoke
         run: |
           shopt -s globstar nullglob
-          echo "Running: coder-eval run ${{ needs.detect.outputs.task_globs }} --model $AGENT_MODEL --tags smoke -j $TASK_PARALLELISM"
+          echo "Running: coder-eval run ${{ needs.detect.outputs.task_globs }} --type codex --model $AGENT_MODEL --tags smoke -j $TASK_PARALLELISM"
           coder-eval run ${{ needs.detect.outputs.task_globs }} \
             -e experiments/smoke.yaml \
+            --type codex \
             --model "$AGENT_MODEL" \
             -j "$TASK_PARALLELISM" -v \
             --run-dir /tmp/runs \


### PR DESCRIPTION
Codex is the harness the nightly runs every day; claude runs twice a week. But the two places most people actually start a coder-eval run from — the PR smoke gate and the ad-hoc `Run Coder Eval` dispatch — both still defaulted to `claude-sonnet-5`. So the gate that decides whether a skill change is good measured a twice-weekly harness rather than the daily one, and every ad-hoc run cost roughly fifteen times what it needed to.

This points both defaults at codex, with the model coming from the `CODEX_MODEL` repo variable as before. That variable moves from `gpt-5.6-terra` to `gpt-5.6-luna` alongside this PR (a repo-settings change, not visible in the diff). Codex on luna measures at pass-rate parity with `claude-sonnet-5` and `claude-sonnet-4-6` on this suite, so this is a price change rather than a capability trade.

The evaluation side is deliberately untouched. `llm_judge`, the simulated user and the LLM reviewer stay on Bedrock Claude via `BEDROCK_MODEL`, so the grader does not move with the agent and scores stay comparable across harnesses.

Both workflows already supported codex — the experiment files are harness-agnostic and already pass the codex credentials through to the sandbox. What changes here is which one you get without asking.

Out of scope, on purpose: the ADO nightly's own `CODEX_MODEL` (still terra), the judge and simulated-user defaults, and every PR review workflow.

## Testing

Both defaults were run on this branch before asking for review.

**The smoke gate on this PR is itself the test.** A `smoke-skills.yml` edit trips the infra-trigger fan-out, so it selected a 40-task deterministic sample of the non-Windows tree and ran every one on codex + `gpt-5.6-luna`.

| | |
|---|---|
| Pass rate | **97.5% (39/40)**, against a 95% threshold |
| The one miss | `skill-datafabric-smoke-complex-fields`, a `pre_run` tenant-seeding failure (`could not seed value(s) on CE_SmokeTags`) at `iterations=0` — the agent never started |
| llm_review gate | reported all 40 above 0.7, but see the caveat below |

**Ad-hoc dispatch, run with no agent input so it took the new defaults:**

```
Running: coder-eval run tasks/uipath-admin/audit/audit_events_basic_smoke.yaml
  -e experiments/nightly.yaml --type codex --model gpt-5.6-luna -j 4
skill-admin-audit-events-basic-smoke: SUCCESS
1/1 PASS (linux)
```

One thing the run surfaced that is not caused by this change and is worth someone's attention separately: **not one of the 40 tasks carried an `llm_review` score** — every row is `llm=—`, and the reviewer logged skipped-or-errored on all of them. Two recent smoke runs from main-based branches show the same (0 of 1 scored, 0 of 16), so this predates the PR: the coder_eval reviewer only supports Anthropic direct or the LLM Gateway, not Bedrock, and the shared workspace quota is drained. The practical consequence is that the hard `llm_review >= 0.7` gate is currently passing vacuously, on claude as much as on codex.
