### PR TITLE
fix(uipath-ixp): any Documents shortfall is REVIEW — drop the marker allowance

### DIFF
--- a/skills/uipath-ixp/references/improve-prompts-guide.md
+++ b/skills/uipath-ixp/references/improve-prompts-guide.md
@@ -278,8 +278,8 @@ That is 0.2 at `Annotations` = 5 — one flipped annotation is not evidence — 
 
 **A small `Annotations` has two causes with opposite remedies.** `Annotations` counts reviewed **extractions**, not documents — one document can contribute several — so it cannot be compared against a document count directly. Compare the field's own `Documents` against the project-level `ValidatedDocuments`:
 
-- **`Documents` equal to `ValidatedDocuments`, or short by one or two** → the sample is already as large as the labelled data allows (a small shortfall is missing markers — the field legitimately absent from a document — not an unreviewed field). Tag it **UPLOAD**.
-- **`Documents` materially below `ValidatedDocuments`** → some labelled documents carry no label for this field: never reviewed there, or reviewed and skipped because the prediction was wrong. Tag it **REVIEW** — those documents need the standard review pass ([Label Documents Guide](label-documents-guide.md)), which 2a-check's `Recall < 0.5` gate would never trigger here.
+- **`Documents` equal to `ValidatedDocuments`** → this field already has evidence on every labelled document; the sample is as large as the data allows. Tag it **UPLOAD**.
+- **`Documents` below `ValidatedDocuments`** → some labelled documents carry no evidence for this field, and the payload cannot say why — never reviewed there, or reviewed and skipped because the prediction was wrong. Tag it **REVIEW** — the review pass ([Label Documents Guide](label-documents-guide.md)) shows which in seconds, and 2a-check's `Recall < 0.5` gate would never trigger it. Even when the review finds nothing to add, confirming that costs a glance, while an unreviewed document left unfound caps the field for good.
 
 Both tags are **final-report lines, not loop actions**: the loop runs on to its normal stopping criteria — never pause mid-run to ask for documents or to review — and the report then says plainly that a tagged field's score cannot rise further until its sample grows.
 

--- a/tests/tasks/uipath-ixp/_shared/mock_template_shortfall/README.md
+++ b/tests/tasks/uipath-ixp/_shared/mock_template_shortfall/README.md
@@ -22,7 +22,7 @@ non-repeatable, target `F1` 0.7.
 | `cccc000000000001` | 5 | 5 | 0.400 | yes | **UPLOAD** |
 | `cccc000000000002` | 2 | 6 | 0.667 | yes | **REVIEW** |
 | `cccc000000000003` | 5 | 5 | 1.000 | no | — |
-| `cccc000000000004` | 4 | 4 | 0.500 | yes | **UPLOAD** (missing-marker allowance) |
+| `cccc000000000004` | 4 | 4 | 0.500 | yes | **REVIEW** |
 
 Every below-target field is genuinely unmeasurable-by-rewrite — their
 regression thresholds (`max(0.1, 1/Annotations)`) are 0.2, 0.167 and 0.25 — so
@@ -53,9 +53,10 @@ project-level `ValidatedDocuments`:
   labelled document; the sample is as large as the data allows → **UPLOAD**.
 - `…0002` — `Documents` 2 << `ValidatedDocuments` 5 → three labelled documents
   carry no label for this field → **REVIEW**.
-- `…0004` — `Documents` 4, short by exactly one → within the missing-marker
-  allowance (a field legitimately absent from a document is recorded as
-  missing, not left unconfirmed) → **UPLOAD**, not REVIEW.
+- `…0004` — `Documents` 4, short by exactly one → still **REVIEW**: the payload
+  cannot say what that one document is — unreviewed, or reviewed and skipped —
+  and only the review can. Rounding a small shortfall up to "complete" silently
+  caps the field if the document was in fact never reviewed.
 
 **`Annotations` is the trap, not the signal.** `…0002` carries the **largest**
 `Annotations` (6) of the three flagged fields while being reviewed on the

--- a/tests/tasks/uipath-ixp/_shared/mock_template_shortfall/mocks/uip
+++ b/tests/tasks/uipath-ixp/_shared/mock_template_shortfall/mocks/uip
@@ -12,9 +12,7 @@
 #   cccc000000000002     2    6  0.667   yes            reviewed on only 2   REVIEW
 #                                                       of the 5 documents
 #   cccc000000000003     5    5  1.000   no             -                    -
-#   cccc000000000004     4    4  0.500   yes            short by ONE doc =   UPLOAD
-#                                                       missing marker,
-#                                                       not unconfirmed
+#   cccc000000000004     4    4  0.500   yes            short by ONE doc     REVIEW
 #
 # Every below-target field has a sample too small for a rewrite to be
 # evaluated (regression_threshold = max(0.1, 1/Annotations): 0.2, 0.167 and
@@ -22,9 +20,10 @@
 # field's own Documents vs ValidatedDocuments:
 #
 #   ...0001  Documents 5 == ValidatedDocuments 5 -> sample as large as the data
-#   ...0002  Documents 2 <<  ValidatedDocuments 5 -> unreviewed for this field
-#   ...0004  Documents 4, short by ONE -> within the missing-marker allowance
-#            (a field legitimately absent from a document), NOT unconfirmed
+#   ...0002  Documents 2 <  ValidatedDocuments 5 -> no evidence on 3 documents
+#   ...0004  Documents 4 <  ValidatedDocuments 5 -> no evidence on 1 document;
+#            ANY shortfall is REVIEW - the payload cannot say what that
+#            document is, and only the review can
 #
 # Annotations does NOT separate them, and is the trap. ...0002 has the LARGEST
 # Annotations (6) of the three despite being reviewed on the fewest documents,

--- a/tests/tasks/uipath-ixp/smoke/metrics_annotations_shortfall.yaml
+++ b/tests/tasks/uipath-ixp/smoke/metrics_annotations_shortfall.yaml
@@ -2,21 +2,22 @@ task_id: skill-ixp-metrics-annotations-shortfall-smoke
 description: >
   Smoke: for fields whose samples are too small for an instruction rewrite to
   be evaluated, the agent tells a genuinely small sample (upload more
-  documents) from unconfirmed labels (confirm what is already there).
+  documents) from documents missing evidence for the field (review them).
 
   The fixture puts three fields below the 0.7 target with ValidatedDocuments 5,
   every one with a sample too small to measure a rewrite against
   (regression_threshold 0.2, 0.167 and 0.25). The separating signal is the
-  field's own Documents: 5 of 5 (UPLOAD), 2 of 5 (REVIEW), and 4 of 5 —
-  short by exactly one, which is the missing-marker allowance, so UPLOAD, not
-  REVIEW.
+  field's own Documents: 5 of 5 is UPLOAD (evidence on every labelled
+  document); 2 of 5 and 4 of 5 are both REVIEW — any shortfall means
+  documents without evidence for the field, and the payload cannot say why.
 
-  Annotations is the trap. The REVIEW field carries the LARGEST Annotations
-  (6) of the three while being reviewed on the fewest documents, because
-  Annotations counts reviewed extractions and that field averages three per
-  document. An agent that treats Annotations as a document count, or takes the
-  smallest Annotations as the smallest sample, swaps the fixes. Recall does not
-  separate them either — the REVIEW field sits at 0.667, above the 0.5 gate on
+  Two traps. Annotations: the 2-of-5 field carries the LARGEST Annotations
+  (6) of the three while being reviewed on the fewest documents (it averages
+  three extractions per document), so treating Annotations as a document
+  count swaps the answers. Rounding: the 4-of-5 field baits "short by one,
+  close enough, UPLOAD" — but the payload cannot say what that one document
+  is, so it is REVIEW. Recall does not
+  separate anything — the 2-of-5 field sits at 0.667, above the 0.5 gate on
   step 2a-check.
 tags: [uipath-ixp, smoke, mode:diagnose, lifecycle:improve]
 
@@ -75,16 +76,16 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  # The allowance. Documents 4 of 5 — short by exactly one — is a missing
-  # marker, not unconfirmed labels; flagging it REVIEW sends the user to
-  # re-confirm labels that do not exist.
+  # The rounding trap. Documents 4 of 5 — short by exactly one — still means
+  # one document without evidence for the field; "close enough to complete"
+  # silently caps the field if that document was never reviewed.
   - type: json_check
-    description: "Treated the one-document shortfall (…0004) as the missing-marker allowance — UPLOAD, not REVIEW"
+    description: "Did not round the one-document shortfall (…0004) up to complete — REVIEW, not UPLOAD"
     path: "remedy.json"
     assertions:
       - expression: '"cccc000000000004"'
         operator: equals
-        expected: "UPLOAD"
+        expected: "REVIEW"
     weight: 2.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Problem

The shortfall smoke's missing-marker case failed three consecutive CI runs under three wordings: agents kept tagging a `Documents` 4-of-5 field REVIEW where the guide's allowance ("short by one or two is missing markers") demanded UPLOAD.

The source shows the payload cannot carry the answer. In `ixp-platform` (`mls/user-model-store/.../metrics/entity.py`), the per-field document count is *"user model documents containing at least one assigned entity"*, with no empty-value filter at the scoring layer — and no CLI read exposes per-document annotation state. Whether a marker-only document counts is not traceable from the metrics code (markers could be stored as assigned entries or as dismissed negatives), which is the point: **from the numbers alone, the agent cannot know why a document is missing from a field's count**. The allowance was a bet the data cannot back, and the smoke graded a guess as if it had one right answer.

## Change

The rule becomes decision-free, and the cost asymmetry favors it:

- **`Documents` equal to `ValidatedDocuments`** → the sample is as large as the labelled data allows → **UPLOAD**.
- **`Documents` below `ValidatedDocuments`** → documents without evidence for the field, and the payload cannot say why → **REVIEW** — the review shows which in seconds, while an unreviewed document left unfound caps the field for good.

The smoke's 4-of-5 field flips to REVIEW, and its criterion now guards the opposite mistake — rounding a small shortfall up to "complete". The `Annotations` trap (largest `Annotations` on the fewest documents) is unchanged. Rule, test, and observed agent behavior now agree, so the grading is deterministic.

Based on `main` so the fix merges independently; #2825 (the overlay consolidation) rebases on top of this afterwards.
