### PR TITLE
chore(tests): complete required tag coverage for uipath-maestro-case tasks

### DIFF
--- a/tests/tasks/uipath-maestro-case/hitl/quality_01_action_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_01_action_schema_design.yaml
@@ -6,7 +6,7 @@ description: >
   (skeleton path), the agent still records the planning fields in tasks.md
   and writes valid JSON. Tests action-task field design (priority enum,
   recipient handling, taskTitle requirement).
-tags: [uipath-maestro-case, integration, lifecycle:generate, shape:multi-node, node:hitl]
+tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:multi-node, node:hitl]
 initial_prompt: |
   Create a UiPath Case Management project named "VendorPOReviewCase" with
   this shape:

--- a/tests/tasks/uipath-maestro-case/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_02_result_downstream.yaml
@@ -3,7 +3,7 @@ description: >
   Quality test: agent correctly references a HITL action task's output in a
   downstream task using the `=vars.<varId>` runtime path. Tests cross-task
   binding from an action task to a follow-up task in a later stage.
-tags: [uipath-maestro-case, integration, lifecycle:generate, shape:multi-node, node:hitl]
+tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:multi-node, node:hitl]
 initial_prompt: |
   Create a UiPath Case Management project named "ExpenseApprovalCase" with
   this shape:

--- a/tests/tasks/uipath-maestro-case/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_03_boolean_decision.yaml
@@ -5,7 +5,7 @@ description: >
   field-level expression syntax (boolean variable name in `conditionExpression`)
   and that both true and false branches are wired to distinct downstream
   stages with consistent entry conditions.
-tags: [uipath-maestro-case, integration, lifecycle:generate, shape:multi-node, node:hitl]
+tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:multi-node, node:hitl]
 initial_prompt: |
   Create a UiPath Case Management project named "VendorApprovalCase" for
   vendor onboarding with this shape:

--- a/tests/tasks/uipath-maestro-case/hitl/quality_04_skeleton_completion_report.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_04_skeleton_completion_report.yaml
@@ -9,7 +9,7 @@ description: >
   register before the skeleton can be upgraded. Greenfield generation
   path (Rule 6 regenerate-from-scratch); in-place brownfield edits are a
   separate journey (see references/brownfield.md).
-tags: [uipath-maestro-case, integration, lifecycle:generate, shape:multi-node, node:hitl, skeleton]
+tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:multi-node, node:hitl, skeleton]
 initial_prompt: |
   Create a UiPath Case Management project named "ContractReviewCase" with
   this shape:

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_01_action_task_placed.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_01_action_task_placed.yaml
@@ -5,7 +5,7 @@ description: >
   the action task is written into caseplan.json with type "action" and the
   case validates. Action-app likely unresolved in test env — skeleton task
   (empty data) is acceptable.
-tags: [uipath-maestro-case, smoke, lifecycle:generate, shape:single-node, node:hitl]
+tags: [uipath-maestro-case, smoke, mode:build, lifecycle:generate, shape:single-node, node:hitl]
 
 run_limits:
   task_timeout: 2100

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_02_stage_exit_on_action.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_02_stage_exit_on_action.yaml
@@ -4,7 +4,8 @@ description: >
   using `selected-tasks-completed` referencing the action TaskId, and routes
   to a downstream stage. Verifies the exit-condition rule type and that the
   TaskId is referenced from the rule.
-tags: [uipath-maestro-case, lifecycle:generate, shape:multi-node, node:hitl]
+tags: [uipath-maestro-case, smoke, mode:build, lifecycle:generate, shape:multi-node, node:hitl]
+
 initial_prompt: |
   Create a UiPath Case Management project named "PurchaseApprovalCase" with
   this shape:

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_03_multi_outcome_routing.yaml
@@ -5,7 +5,8 @@ description: >
   decision. Verifies two `selected-tasks-completed` exits with different
   `IF` expressions on the same source stage, and that both downstream
   stages have correct entry conditions.
-tags: [uipath-maestro-case, lifecycle:generate, shape:multi-node, node:hitl]
+tags: [uipath-maestro-case, smoke, mode:build, lifecycle:generate, shape:multi-node, node:hitl]
+
 initial_prompt: |
   Create a UiPath Case Management project named "LeaveRequestCase" with this
   shape:

--- a/tests/tasks/uipath-maestro-case/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-case/init_validate.yaml
@@ -6,7 +6,7 @@ description: >
   — CLI (`uip solution init` + `uip solution project add`) or the JSON
   strategy (writing project files directly). The test asserts on the
   resulting artifacts and the validate step, not on the scaffolding method.
-tags: [uipath-maestro-case, init, validate]
+tags: [uipath-maestro-case, smoke, mode:build, lifecycle:generate]
 
 run_limits:
   expected_turns: 70

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/branching_exit.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/branching_exit.yaml
@@ -16,7 +16,7 @@ description: >
   exit rules, the user-selected-stage entry rule, condition-driven branch
   routing via exitToStageId with conditionExpression discrimination, wide
   fan-out, and skeleton placeholder tasks (edges retired).
-tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:conditions, feature:wait-for-user, feature:wide-fanout, feature:tasks, feature:task-entry, feature:skeleton-task]
+tags: [uipath-maestro-case, e2e, mode:build, lifecycle:generate, shape:multi-node, feature:conditions, feature:wait-for-user, feature:wide-fanout, feature:tasks, feature:task-entry, feature:skeleton-task]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/case_exit_full.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/case_exit_full.yaml
@@ -6,7 +6,7 @@ description: >
   case-exit conditions covering three rule-types and both marks-case-complete
   shapes: required-stages-completed (true) + selected-stage-exited on Audit
   (false) + selected-stage-completed on Archive (false).
-tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:case-exit, feature:conditions, feature:stages]
+tags: [uipath-maestro-case, e2e, mode:build, lifecycle:generate, shape:multi-node, feature:case-exit, feature:conditions, feature:stages]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/exception_stage.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/exception_stage.yaml
@@ -17,7 +17,7 @@ description: >
   terminal exit-only secondary stage, secondary-stage SLA, sla-breached
   escalation, UserGroup recipient scope, a task embedded inside a
   secondary stage, and the wait-for-timer plugin's timeDate branch.
-tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:exception-stage, feature:multi-exception, feature:conditions, feature:sla, feature:escalation, feature:wait-for-timer]
+tags: [uipath-maestro-case, e2e, mode:build, lifecycle:generate, shape:multi-node, feature:exception-stage, feature:multi-exception, feature:conditions, feature:sla, feature:escalation, feature:wait-for-timer]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
@@ -16,7 +16,7 @@ description: >
   the condition-driven diamond reachability (Triage→{Validate,Enrich}→Join,
   edges retired), both entry rules on Join, and the skeleton task types
   each in its assigned stage.
-tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:conditions, feature:fan-in, feature:tasks, feature:skeleton-task, feature:rpa, feature:api-workflow, feature:agent, feature:case-management-task]
+tags: [uipath-maestro-case, e2e, mode:build, lifecycle:generate, shape:multi-node, feature:conditions, feature:fan-in, feature:tasks, feature:skeleton-task, feature:rpa, feature:api-workflow, feature:agent, feature:case-management-task]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/multi_trigger.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/multi_trigger.yaml
@@ -15,7 +15,7 @@ description: >
   (unresolved process → type "rpa", empty data) so the sink stage is not
   empty. Validates and asserts on the trigger nodes, Run's case-entered
   entry, plus the rpa task in Run.
-tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:trigger, feature:timer, feature:multi-trigger, feature:bounded-timer, feature:scheduled-timer]
+tags: [uipath-maestro-case, e2e, mode:build, lifecycle:generate, shape:multi-node, feature:trigger, feature:timer, feature:multi-trigger, feature:bounded-timer, feature:scheduled-timer]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/sla_with_escalation.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/sla_with_escalation.yaml
@@ -22,7 +22,7 @@ description: >
   (≥2 recipients on one notification), regular-Stage data.slaRules,
   stage-level conditional-rule placement, and the d + w + m + min duration units. Recipient UUIDs are
   unresolved and stay as UNRESOLVED skeletons per the skill rules.
-tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:sla, feature:escalation, feature:conditional-sla, feature:stage-sla]
+tags: [uipath-maestro-case, e2e, mode:build, lifecycle:generate, shape:multi-node, feature:sla, feature:escalation, feature:conditional-sla, feature:stage-sla]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-case/registry_discovery.yaml
@@ -4,7 +4,7 @@ description: >
   explore available case task resources via the registry. Tests whether the
   skill teaches the correct discovery workflow (pull + direct cache-file
   inspection at ~/.uip/case-resources/, not relying on registry search).
-tags: [uipath-maestro-case, registry]
+tags: [uipath-maestro-case, integration, mode:build, lifecycle:discover, feature:registry]
 
 run_limits:
   expected_turns: 11

--- a/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
@@ -5,7 +5,7 @@ description: >
   agent-index.json, and direct caseplan.json write of a `type: "agent"`
   task. Validates the resulting case file and runs `uip maestro case debug`
   end-to-end, asserting only that the case finalStatus is `Completed`.
-tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
+tags: [uipath-maestro-case, e2e, mode:operate, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
@@ -5,7 +5,7 @@ description: >
   api-index.json, and direct caseplan.json write of a `type: "api-workflow"`
   task. Validates the resulting case file and runs `uip maestro case debug`
   end-to-end, asserting only that the case finalStatus is `Completed`.
-tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
+tags: [uipath-maestro-case, e2e, mode:operate, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
@@ -7,7 +7,7 @@ description: >
   CaseTest child case. Validates the resulting case file and runs
   `uip maestro case debug` end-to-end, asserting the case finalStatus is
   `Completed`.
-tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
+tags: [uipath-maestro-case, e2e, mode:operate, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -5,7 +5,7 @@ description: >
   via process-index.json, and direct caseplan.json write of a `type: "rpa"`
   task. Validates the resulting case file and runs `uip maestro case debug`
   end-to-end, asserting only that the case finalStatus is `Completed`.
-tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
+tags: [uipath-maestro-case, e2e, mode:operate, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/sla_response/notify_only_default/notify_only.yaml
+++ b/tests/tasks/uipath-maestro-case/sla_response/notify_only_default/notify_only.yaml
@@ -7,7 +7,8 @@ description: >
   is unchanged, no sla-status-change rule exists anywhere in the file, and no follow-up
   task was minted. Edits a staged solution, so no scaffolding, registry, or tenant is
   needed; grading is caseplan.json + local validate only.
-tags: [uipath-maestro-case, mode:build, lifecycle:generate, shape:multi-node, feature:sla, feature:escalation]
+tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:multi-node, feature:sla, feature:escalation]
+
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/sla_response/start_task_same_stage/start_task_same_stage.yaml
+++ b/tests/tasks/uipath-maestro-case/sla_response/start_task_same_stage/start_task_same_stage.yaml
@@ -10,7 +10,8 @@ description: >
   answer (work in a separate lane); the rule authored as a Review STAGE-entry row, which
   re-enters Review and re-runs every task whose shouldRunOnlyOnce is false — the default;
   and a task with no entry condition, which the runtime never triggers.
-tags: [uipath-maestro-case, mode:build, lifecycle:generate, shape:multi-node, feature:sla, feature:escalation, feature:approval-gate]
+tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:multi-node, feature:sla, feature:escalation, feature:approval-gate]
+
 max_iterations: 1
 
 run_limits:


### PR DESCRIPTION
## Why

`mode:` and `lifecycle:` are **required** by the tag taxonomy ([tests/README.md § Tag Taxonomy](../blob/main/tests/README.md)), but **19 of the skill's 61 tasks had no `mode:` at all**, and 6 were missing a tier or lifecycle.

Untagged tasks contribute no basis to the [Coding Agents Scorecard](https://uipath.atlassian.net/wiki/spaces/CA/pages/91024950335)'s Build / Operate / Troubleshoot columns. Case Management currently renders **Operate 92\*** and **Troubleshoot 92\***, where the board defines `*` as *"no `mode:<x>`-tagged tasks for that column, so the skill's overall mean is shown."* Two of three columns were echoing the build number rather than measuring anything.

Before: `build 39 · operate 1 · diagnose 2 · untagged 19`

## What

**Tags only.** No prompt, criteria, sandbox, or weight changes — the diff is 21 files, tag lines exclusively.

| | count | rationale |
|---|---|---|
| → `mode:build` | 15 | Author a caseplan and grade with `case validate`. All seven HITL tasks explicitly instruct *"Do NOT run `uip maestro case debug`"* — they are authoring tests. |
| → `mode:operate` | 4 | `single_node/{agent,api_workflow,case_management,rpa}` are `e2e` and actually invoke `case debug` — they deploy and run rather than stopping at validate. |

`tier` / `lifecycle` follow **sibling convention rather than invention**: `smoke` for `hitl/smoke_02`+`03` (sibling `smoke_01` is smoke), `integration` for the two `sla_response` tasks (3 of 4 siblings are integration), `smoke` + `lifecycle:generate` for `init_validate`, `integration` + `lifecycle:discover` for `registry_discovery` — the only genuine `discover` in the skill.

**Non-vocabulary tags:** `init` and `validate` are **dropped** rather than converted to `feature:` leaves — both would duplicate the file path, an explicit anti-pattern in [`.claude/rules/test-writing.md`](../blob/main/.claude/rules/test-writing.md). `registry` maps to `feature:registry`, which already exists on the `single_node` tasks, so that reuses vocabulary instead of minting it.

After: **61/61 compliant** — `build 54 · operate 5 · diagnose 2`, tier `integration 27 / e2e 28 / smoke 6`, lifecycle `generate 52 / edit 6 / setup 2 / discover 1`.

## What this does NOT do

Stating plainly so the scorecard impact isn't oversold:

- **Troubleshoot stays at 2 tasks and stays asterisked.** That column needs new tasks, not tags.
- **Eval scores are untouched.** Build 90 / Operate 92 / Troubleshoot 92 are set by the six failing tests, and no tag moves them.
- **`registry_discovery` fits no mode cleanly.** It creates nothing, runs nothing, and investigates no fault. `build` is the least-wrong option. The real gap is that `mode:` has no slot for read-only discovery while `lifecycle:` does — worth raising with the taxonomy owners rather than papering over.

## Scope

`tests/tasks/uipath-planner` is **intentionally untouched** — different team. It has 34 tasks with 27 build / 0 operate / 0 diagnose / 7 untagged and no scorecard row at all, but that's theirs to fix.

## Verification

Compliance checked by parsing every YAML (not regex — tasks use both flat `[...]` and block list forms, and a regex-only checker gives false positives on the block form). All 61 files parse; 0 non-compliant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)