### PR TITLE
fix(traces): segment-scope list_* graders; stop gating on default sort order

### DIFF
--- a/skills/uipath-platform/references/traces/feedback.md
+++ b/skills/uipath-platform/references/traces/feedback.md
@@ -37,14 +37,14 @@ uip traces feedback create \
 | `--category` | No | Repeatable. Built-in values: `"Output"`, `"Agent Error"`, `"Agent Plan Execution"` |
 | `--agent-id` | No | Agent reference GUID |
 | `--agent-version` | No | Max 100 chars |
-| `--tenant` | No | Defaults to authenticated tenant |
+| `--profile <name>` | No | Named login profile. Other tenant: `uip login tenant set <tenant>` first (`--tenant` is deprecated) |
 
 ## get
 
-`--folder-key` is optional. Positional `<id>` required.
+Positional `<id>` and `--folder-key` required.
 
 ```bash
-uip traces feedback get <feedback-id> --output json
+uip traces feedback get <feedback-id> --folder-key <folder-key> --output json
 ```
 
 ## list
@@ -88,7 +88,7 @@ uip traces feedback list detailed \
   --output json
 ```
 
-Additional flags over `list`: `--since <duration>`, `--after <ISO>`, `--before <ISO>`, `--category-id <guid>` (repeatable), `--sort-by <createdAt|updatedAt>`, `--sort-order <asc|desc>`. Max 200 items.
+Additional flags over `list`: `--since <duration>`, `--after <ISO>`, `--before <ISO>`, `--category-id <guid>` (repeatable), `--sort-by <createdAt|updatedAt>` (default `createdAt`), `--sort-order <asc|desc>` (default `desc`). Max 200 items.
 
 ## update
 

--- a/skills/uipath-platform/references/traces/traces.md
+++ b/skills/uipath-platform/references/traces/traces.md
@@ -41,7 +41,7 @@ uip traces spans get --job-key <job-key> --output json
 | `--job-key <guid>` | Orchestrator job key — alternative to trace-id |
 | `--folder-path <path>` | Folder path for context |
 | `--folder-key <guid>` | Folder key for context |
-| `-t, --tenant <name>` | Tenant override |
+| `--profile <name>` | Named login profile. Other tenant: `uip login tenant set <tenant>` first (`--tenant` is deprecated) |
 
 ## Related
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -415,6 +415,13 @@ Verify the agent ran a specific CLI command (matched by regex). From `init_valid
   pass_threshold: 1.0   # fraction of min_count required to pass
 ```
 
+**Scope lookaheads and excludes to ONE command segment.** The grader runs one `pattern.search()` per Bash tool call (`re.DOTALL`) and also matches a normalized haystack with newlines collapsed to spaces — so `(?=[\s\S]*--flag)` and `exclude_pattern` see every command batched into that call (codex chains `a && b` or stacks lines; a call-wide exclude then vetoes a correct command). Use the segment idiom `S = (?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*` ("rest of THIS command", stops at newline, `&&`, `||`, `;`, `|`, or the next `uip`) and inline negatives instead of `exclude_pattern`:
+
+```yaml
+# S expanded inline — YAML single quotes, no escaping needed
+command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--span-id)(?!(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--agent-id)'
+```
+
 ### `file_exists`
 
 Verify a file was created in the sandbox. From `init_validate.yaml`:

--- a/tests/tasks/uipath-platform/traces/traces_feedback_list_detailed_smoke.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_list_detailed_smoke.yaml
@@ -7,7 +7,9 @@ description: >
   `list detailed` subcommand is untested today. Choosing it over plain `list`
   is itself graded: the prompt asks for span context, which plain `list` cannot
   return. Criteria bind to the requested values, not just flag presence, so
-  `--sort-order asc` against a "newest first" ask does not score.
+  `--sort-order asc` against a "newest first" ask does not score, while omitting
+  the flag does (`desc` is the CLI default — grade the outcome, never a literal
+  flag). Graders are segment-scoped so batched calls grade per command.
   Auth/404 responses are acceptable outcomes — the graded behavior is command
   shape plus a captured CLI response envelope.
 tags: [uipath-platform, smoke, mode:diagnose, lifecycle:discover, traces, feedback]
@@ -33,8 +35,7 @@ success_criteria:
   - type: command_executed
     description: "Last-24-hours pass used the relative lookback (--since 24h)"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list\s+detailed(?=[\s\S]*--since[\s=]["'']?24h)'
-    exclude_pattern: '--before'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list\s+detailed(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--since[\s=]["'']?24h)(?!(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--before)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -42,16 +43,15 @@ success_criteria:
   - type: command_executed
     description: "Second pass bounded by the requested explicit --after/--before window"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list\s+detailed(?=[\s\S]*--after[\s=]["'']?2026-07-01)(?=[\s\S]*--before[\s=]["'']?2026-07-08)'
-    exclude_pattern: '--since'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list\s+detailed(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--after[\s=]["'']?2026-07-01)(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--before[\s=]["'']?2026-07-08)(?!(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--since)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Second pass filtered to the requested category and ordered newest-first (--sort-order desc)"
+    description: "Second pass filtered to the requested category and not explicitly re-ordered oldest-first (`desc` is the CLI default)"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list\s+detailed(?=[\s\S]*--category-id[\s=]["'']?3f9a2b71)(?=[\s\S]*--sort-order[\s=]["'']?desc)'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list\s+detailed(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--category-id[\s=]["'']?3f9a2b71)(?!(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--sort-order[\s=]["'']?asc)'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/traces/traces_feedback_list_filters_smoke.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_list_filters_smoke.yaml
@@ -7,6 +7,10 @@ description: >
   are exercised anywhere. The paging assertion is the sharp one: the second page
   of a five-per-page walk is `--limit 5 --offset 5`, so an agent that treats
   `--offset` as a page number rather than a zero-based item offset fails it.
+  Graders are segment-scoped (a lookahead stops at newline, `&&`, `;`, `|`, or the
+  next `uip`) so batched calls grade per command, and `list detailed` is accepted
+  for the paged cross-trace read — same filters, same data; the span read must
+  stay plain `list`.
   Auth/404 responses are acceptable outcomes — the graded behavior is command shape.
 tags: [uipath-platform, smoke, mode:diagnose, lifecycle:discover, traces, feedback]
 
@@ -31,8 +35,7 @@ success_criteria:
   - type: command_executed
     description: "Agent scoped the first read to a single span with --span-id"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?!\s+detailed)(?=[\s\S]*--span-id)'
-    exclude_pattern: '--agent-id'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?!\s+detailed)(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--span-id)(?!(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--agent-id)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -40,7 +43,7 @@ success_criteria:
   - type: command_executed
     description: "Cross-trace read filtered by sentiment and agent attribution"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?!\s+detailed)(?=[\s\S]*--negative)(?=[\s\S]*--agent-id)(?=[\s\S]*--agent-version)'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?:\s+detailed)?(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--negative)(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--agent-id)(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--agent-version)'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
@@ -48,7 +51,7 @@ success_criteria:
   - type: command_executed
     description: "Second page of that same filtered walk is --limit 5 --offset 5 (zero-based offset)"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?!\s+detailed)(?=[\s\S]*--negative)(?=[\s\S]*--limit[\s=]5(\s|$))(?=[\s\S]*--offset[\s=]5(\s|$))'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?:\s+detailed)?(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--negative)(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--limit[\s=]5(?:\s|$))(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--offset[\s=]5(?:\s|$))'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Motivation

Scorecard row LLMOPS/Traces, nightly `2026-08-24_04-51-47`: Troubleshoot 79, Tests 4/6 exec. Both failures are grader artefacts on the codex · gpt-5.6-terra nightly, not skill regressions — the same tasks pass 11/11 on claude-sonnet-5.

- `command_executed` runs one `pattern.search()` per Bash call (`re.DOTALL`) plus a shlex-normalized haystack with newlines collapsed. When the agent batches two correct `uip` reads into one call, `exclude_pattern: '--agent-id'` on read 2 vetoes read 1 → `list_filters` 0.692 (08-14, 08-19, 08-24).
- `list_detailed` gated on a literal `--sort-order desc` although `desc` is the CLI default → 0.667 (08-17, 08-24).

Fix: segment-scoped lookaheads (stop at newline, `&&`, `||`, `;`, `|`, next `uip`), inline negatives instead of `exclude_pattern`, no gate on the default flag, `list detailed` accepted for the paged cross-trace read (span read must stay plain `list`).

Doc corrections found on the way: `--tenant` is not a `spans get` / `feedback create` flag (deprecated; CLI points at `uip login tenant set`), `feedback get --folder-key` is required, sort defaults documented.

## Summary

| File | Change |
|---|---|
| `tests/tasks/uipath-platform/traces/traces_feedback_list_filters_smoke.yaml` | Segment-scoped lookaheads; drop `exclude_pattern`; accept `list detailed` on the cross-trace + paged reads |
| `tests/tasks/uipath-platform/traces/traces_feedback_list_detailed_smoke.yaml` | Segment-scoped lookaheads; drop `exclude_pattern`; category criterion fails only on explicit `--sort-order asc`, no longer requires literal `desc` |
| `skills/uipath-platform/references/traces/feedback.md` | `--sort-by` / `--sort-order` defaults; `get` requires `--folder-key`; `--tenant` row → `--profile` |
| `skills/uipath-platform/references/traces/traces.md` | `-t, --tenant` row → `--profile` |
| `tests/README.md` | Segment-scoping rule for `command_executed` + the `S` idiom |

## Tests performed

- `/lint-task` on both YAMLs: 0 Critical / 0 High / 0 Medium. One Low theme (shape-only smoke, rationale in `description`) — pre-existing on main. `scripts/check-cli-verbs.py`: clean.
- YAML parses; every `command_pattern` compiles under `re.DOTALL`. `scripts/check-task-driver.py tests/tasks`: OK. `scripts/check-skill-verbs.py skills/uipath-platform`: 0 blocking, no findings in touched files.
- Grader replay (`command_executed` helpers exec'd verbatim) over historical codex `task.json` files, graded with the YAMLs on this branch:

| Run | Task | Historical | Replayed (this branch) | Per-criterion |
|---|---|---|---|---|
| 2026-08-17_04-49-26 | feedback-list-detailed | FAILURE 0.667 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 c4=1.00 |
| 2026-08-18_04-51-58 | feedback-list-filters | FAILURE 0.308 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 |
| 2026-08-19_04-51-29 | feedback-list-detailed | FAILURE 0.733 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 c4=1.00 |
| 2026-08-19_04-51-29 | feedback-list-filters | FAILURE 0.692 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 |
| 2026-08-20_04-48-37 | feedback-list-detailed | SUCCESS 1.000 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 c4=1.00 |
| 2026-08-20_04-48-37 | feedback-list-filters | SUCCESS 1.000 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 |
| 2026-08-24_04-51-47 | feedback-list-detailed | FAILURE 0.667 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 c4=1.00 |
| 2026-08-24_04-51-47 | feedback-list-filters | FAILURE 0.692 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 |
| 2026-08-25_04-16-36 | feedback-list-detailed | SUCCESS 1.000 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 c4=1.00 |
| 2026-08-25_04-16-36 | feedback-list-filters | SUCCESS 1.000 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 |
| 2026-08-25_17-34-28 | feedback-list-detailed | SUCCESS 1.000 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 c4=1.00 |
| 2026-08-25_17-34-28 | feedback-list-filters | FAILURE 0.692 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 |
| 2026-08-26_04-13-33 | feedback-list-detailed | SUCCESS 1.000 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 c4=1.00 |
| 2026-08-26_04-13-33 | feedback-list-filters | SUCCESS 1.000 | **SUCCESS** 1.000 | c1=1.00 c2=1.00 c3=1.00 |

Synthetic controls:

| Task | Control | Expected | Replayed | Per-criterion | OK |
|---|---|---|---|---|---|
| feedback-list-filters | both filters merged into ONE command | FAILURE | FAILURE 0.692 | c1=0.00✗ c2=1.00 c3=1.00 | ✅ |
| feedback-list-filters | --offset 10 (page number, not zero-based offset) | FAILURE | FAILURE 0.692 | c1=1.00 c2=1.00 c3=0.00✗ | ✅ |
| feedback-list-filters | span read done with `list detailed` | FAILURE | FAILURE 0.692 | c1=0.00✗ c2=1.00 c3=1.00 | ✅ |
| feedback-list-filters | two reads chained with && in one call (08-19 shape) | SUCCESS | SUCCESS 1.000 | c1=1.00 c2=1.00 c3=1.00 | ✅ |
| feedback-list-detailed | category read re-ordered oldest-first (--sort-order asc) | FAILURE | FAILURE 0.667 | c1=1.00 c2=1.00 c3=0.00✗ c4=1.00 | ✅ |
| feedback-list-detailed | no --since 24h (absolute window used for the 24h read) | FAILURE | FAILURE 0.733 | c1=0.00✗ c2=1.00 c3=1.00 c4=1.00 | ✅ |
| feedback-list-detailed | both reads in one call, no explicit sort flags (CLI default desc) | SUCCESS | SUCCESS 1.000 | c1=1.00 c2=1.00 c3=1.00 c4=1.00 | ✅ |

- Same replay against `origin/main`: the 7 historical failures stay FAILURE and both batched-call controls wrongly FAIL. Three controls for `feedback-mutate`, `spans-discovery`, `traces_fetch` (flags-first / two-step shapes) fail on both main and this branch — pre-existing, out of scope here (see Follow-ups).
- No live codex run locally. The PR smoke gate runs the full `uipath-platform` smoke suite on codex (`--type codex --model $CODEX_MODEL`) because skill source changed; nightlies 08-27 → 08-29 confirm on the nightly codex model.

## Test plan

Monday 08-31 scorecard: Troubleshoot 79 → 100; Tests 6/6 exec · 11/11 known.

## Follow-ups

Separate PR — commits `592f0ab62`, `5f86bc5f4`, `7e0d97655` on the closed #2835 branch:

- Operate-mode traces tasks (`spans get` by trace id, `feedback get`, `list` by trace)
- Wider grader hardening: flags-first `update` / `delete` / `spans get` shapes; documented two-step `or jobs traces → spans get` flow in `traces_fetch`
- Coverage registration in `.claude/commands`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

LLMOPS-3091
