### PR TITLE
test(maestro-flow): align Data Fabric same-ground tasks

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_file_activities.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_file_activities.py
@@ -94,6 +94,7 @@ def main() -> int:
             t = n.get("type", "")
             detail = n.get("inputs", {}).get("detail", {})
             pp = detail.get("pathParameters") or {}
+            query = detail.get("queryParameters") or {}
             body = detail.get("bodyParameters") or {}
             if resolve_entity(pp.get("entityName"), globals_by_id) != ENTITY:
                 continue
@@ -101,7 +102,7 @@ def main() -> int:
                 create_node = n
             for suffix in REQUIRED:
                 if t.endswith(suffix):
-                    seen[suffix] = body.get("_fieldName")
+                    seen[suffix] = query.get("_fieldName") or body.get("_fieldName")
                     if suffix == ".download-file-from-record-field":
                         download_node = n
                     elif suffix == ".upload-file-to-record-field":

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_file_activities.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_file_activities.py
@@ -17,7 +17,7 @@ import sys
 
 ENTITY = "FlowCodeEvalEntity"
 FIELD = "file1"
-SOURCE_ID = "8B4A3EEA-5E92-F111-9B33-00224822208B"
+UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 REQUIRED = {
     ".upload-file-to-record-field",
     ".download-file-from-record-field",
@@ -125,12 +125,11 @@ def main() -> int:
                   f"upload file values: {upload_file_values}", file=sys.stderr)
             return 1
 
-        # Download's recordId must be bound (literal, =js: expression, or
-        # variable). Smoke does not enforce the exact SOURCE_ID literal — that
-        # semantic belongs in integration/e2e.
+        # Download's recordId is a concrete UUID so either authoring path can
+        # choose its own neutral fixture value.
         dl_recid = (download_node.get("inputs", {}).get("detail", {}).get("queryParameters") or {}).get("recordId", "")
-        if not str(dl_recid).strip():
-            print(f"FAIL: {path} — download recordId is empty", file=sys.stderr)
+        if not UUID_RE.fullmatch(str(dl_recid)):
+            print(f"FAIL: {path} — download recordId is not a UUID literal: {dl_recid!r}", file=sys.stderr)
             return 1
 
         # create-entity-record on ENTITY must exist and upload+delete recordId must reference its output
@@ -163,7 +162,7 @@ def main() -> int:
                 print(f"FAIL: {path} — {label} recordId {rid!r} does not reference create output ({create_id})", file=sys.stderr)
                 return 1
 
-        print(f"OK: {path} — download(src={SOURCE_ID}) + create + upload/delete(recId=create.out) on {ENTITY}/{FIELD}; upload has variable binding")
+        print(f"OK: {path} — download(valid UUID) + create + upload/delete(recId=create.out) on {ENTITY}/{FIELD}; upload has variable binding")
         return 0
     print(f"FAIL: no .flow has all 3 file activities on {ENTITY}", file=sys.stderr)
     return 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_query_filter.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_query_filter.py
@@ -5,9 +5,10 @@ The Flow author may persist a filter as a runtime expression or as the
 structured FilterBuilder tree used by the design-time activity. The test
 checks either representation so the prompt does not prescribe serialization.
 """
-import glob, json, sys
+import glob, json, re, sys
 
 
+UUID_RE = re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b")
 EXPECTED = {
     "boolean": ("active", ("true",), ()),
     "decimal": ("score", ("8.5",), ("greaterthanorequal", ">=")),
@@ -16,7 +17,7 @@ EXPECTED = {
     "multiline": ("description", ("sci-fi",), ("contains",)),
     "date": ("releasedate", ("2025-01-01",), ("lessthan", "<")),
     "datetime": ("lastupdated", ("2024-01-01",), ("greaterthanorequal", ">=")),
-    "uuid": ("externalid", ("11111111-1111-1111-1111-111111111111",), ()),
+    "uuid": ("externalid", (), ()),
     "null": ("description", (), ("isnull", "is null")),
 }
 
@@ -60,6 +61,7 @@ def node_filter_text(detail):
 def has_expected_filter(text, field, tokens, operators):
     return (field in text
             and all(token.lower() in text for token in tokens)
+            and (field != "externalid" or UUID_RE.search(text))
             and (not operators or any(op.lower() in text for op in operators)))
 
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_query_filter.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_query_filter.py
@@ -101,11 +101,13 @@ if len(all_query_details) != 3:
 def qp(detail):
     return detail.get("queryParameters", {}) or {}
 
-def bp(detail):
-    return detail.get("bodyParameters", {}) or {}
+def sort_field(detail):
+    query = qp(detail)
+    body = detail.get("bodyParameters", {}) or {}
+    return query.get("_sortFieldName") or body.get("_sortFieldName")
 
 ascending_pages = [d for d in all_query_details
-                   if bp(d).get("_sortFieldName") == "score"
+                   if sort_field(d) == "score"
                    and str(qp(d).get("isAscending")).lower() == "true"
                    and str(qp(d).get("limit")) == "2"]
 if not any(str(qp(d).get("start")) == "0" for d in ascending_pages):
@@ -116,7 +118,7 @@ if not any(str(qp(d).get("start")) == "2" for d in ascending_pages):
     sys.exit(1)
 
 descending_active = [d for d in all_query_details
-                     if bp(d).get("_sortFieldName") == "score"
+                     if sort_field(d) == "score"
                      and str(qp(d).get("isAscending")).lower() == "false"
                      and str(qp(d).get("limit")) == "4"
                      and "active" in node_filter_text(d)

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/integration_create_get.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/integration_create_get.yaml
@@ -29,7 +29,7 @@ initial_prompt: |
     * active: true
     * releaseDate: '2023-08-20'
     * lastUpdated: '2023-08-20T14:00:00'
-    * externalId: 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff'
+    * externalId: any valid UUID value of your choice
   Retrieve it by Id and delete when done.
 
   C-02 — Expansion depth:
@@ -44,28 +44,28 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Create Entity Record node added at least twice (one per scenario)"
+    description: "Advisory: live-v1 agent added Create Entity Record nodes"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add\s+\S+\s+"?uipath\.connector\.uipath-uipath-dataservice\.create-entity-record'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Get Entity Record By Id node added at least 4 times (1 for C-01 + 3 expansionLevels for C-02)"
+    description: "Advisory: live-v1 agent added Get Entity Record By Id nodes"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add\s+\S+\s+"?uipath\.connector\.uipath-uipath-dataservice\.get-entity-record-by-id'
     min_count: 1
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Delete Entity Record node added at least twice"
+    description: "Advisory: live-v1 agent added Delete Entity Record nodes"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add\s+\S+\s+"?uipath\.connector\.uipath-uipath-dataservice\.delete-entity-record'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
     description: "Flow file was validated"

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_activation_negative.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_activation_negative.yaml
@@ -10,8 +10,8 @@ initial_prompt: |
 
 success_criteria:
   - type: skill_triggered
-    description: "uipath-rpa handles the RPA-Studio Data Fabric prompt (not uipath-maestro-flow)"
+    description: "Advisory: uipath-rpa handles the RPA-Studio Data Fabric prompt"
     skill_name: uipath-maestro-flow
     expected_skill: ""
     weight: 3.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_activation_positive.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_activation_positive.yaml
@@ -10,8 +10,8 @@ initial_prompt: |
 
 success_criteria:
   - type: skill_triggered
-    description: "uipath-maestro-flow activates for a DataFabric-in-Flow prompt"
+    description: "Advisory: uipath-maestro-flow activates for a DataFabric-in-Flow prompt"
     skill_name: uipath-maestro-flow
     expected_skill: uipath-maestro-flow
     weight: 3.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_create_all_types.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_create_all_types.yaml
@@ -28,7 +28,7 @@ initial_prompt: |
   * active: true (BOOLEAN)
   * releaseDate: "2024-03-10" (DATE)
   * lastUpdated: "2024-03-10T09:00:00" (DATETIME)
-  * externalId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" (UUID)
+  * externalId: any valid UUID value of your choice
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_error.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_error.yaml
@@ -29,19 +29,19 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Create attempted on NonExistentEntity"
+    description: "Advisory: live-v1 agent added the NonExistentEntity Create node"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add\s+\S+\s+"?uipath\.connector\.uipath-uipath-dataservice\.create-entity-record'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
   - type: command_executed
-    description: "Two follow-up Query nodes present"
+    description: "Advisory: live-v1 agent added the follow-up Query nodes"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add\s+\S+\s+"?uipath\.connector\.uipath-uipath-dataservice\.query-entity-records'
     min_count: 1
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
   - type: command_executed
     description: "Flow validated"
     tool_name: "Bash"

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_file_activities.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_file_activities.yaml
@@ -23,9 +23,9 @@ initial_prompt: |
   `FlowCodeEvalEntity` entity, `file1` field. Do NOT indirect the entity name
   or field name through workflow variables. Chain four operations in order:
 
-  1. DownloadFileFromRecordFieldV2 — source recordId is fixed:
-     `8B4A3EEA-5E92-F111-9B33-00224822208B`. Assign the download output to a
-     workflow-level variable of type `file`.
+  1. DownloadFileFromRecordFieldV2 — use a valid UUID literal of your choice
+     for the source recordId. Assign the download output to a workflow-level
+     variable of type `file`.
   2. CreateEntityRecord — create a new FlowCodeEvalEntity record. Populate
      the body with plausible sample values on at least `title` (STRING),
      `description` (MULTILINE_TEXT), and `score` (DECIMAL). Deterministic

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_query.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_query.yaml
@@ -31,7 +31,7 @@ initial_prompt: |
   - description contains "sci-fi" (multiline text)
   - releaseDate is less than 2025-01-01 (date)
   - lastUpdated is greater than or equal to 2024-01-01T00:00:00 (datetime)
-  - externalId equals "11111111-1111-1111-1111-111111111111" (UUID)
+  - externalId equals any valid UUID value of your choice
   - description is null
 
   Query 1 must retrieve the first 2 records sorted by score ascending, with
@@ -46,12 +46,12 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Query Entity Records node added"
+    description: "Advisory: live-v1 agent added a Query Entity Records node"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add\s+\S+\s+"?uipath\.connector\.uipath-uipath-dataservice\.query-entity-records'
     min_count: 1
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
   - type: command_executed
     description: "Flow validated"
     tool_name: "Bash"

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_update_existing_flow.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_update_existing_flow.yaml
@@ -39,12 +39,12 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "flow node configure invoked >=2 times on MovieReportFlow (edit + revert leave a CLI trace)"
+    description: "Advisory: live-v1 agent invoked flow node configure for the edit and revert"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+configure.*MovieReportFlow'
     min_count: 2
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: run_command
     description: "Final MovieReportFlow validates cleanly"


### PR DESCRIPTION
## Summary

- make live-v1 authoring-command and skill-trigger telemetry advisory for the newly inherited Data Fabric tasks
- replace prompt-pinned UUID fixtures with arm-neutral valid UUID requirements
- preserve UUID shape checks in the authored Flow artifacts
- read connector sort and field-name inputs from canonical query parameters while retaining legacy body-parameter compatibility

## Verification

- `uv run --with pytest pytest -q tests/scripts/test_stage_shared.py tests/scripts/test_stage_preview_sdk_workspace.py tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py` — 24 passed
- `node --test tests/scripts/sync-maestro-sdk-preview.test.mjs` — 2 passed
- targeted `coder-eval plan` — all 8 modified task YAMLs valid
- GitHub `Run skill smoke tests` (run 33045213813) — 8/8 passed
- `npm run skills:validate`
- `npm run skills:build`
- `npm run skills:pack`
- `git diff --check`

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)