### PR TITLE
feat(uipath-insights): teach machine monitoring [IN-13530]

### DIFF
--- a/skills/uipath-insights/SKILL.md
+++ b/skills/uipath-insights/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: uipath-insights
-description: "UiPath Insights read-only monitoring via `uip insights`: job metrics, failure analysis, and process performance; queue totals, SLA risk, timelines, and failure drill-down; filter discovery of active folders, processes, queues, and machines; alert definition, history, delivery, and entitlement reads; Insights user, role, and group reads. Alert and RBAC writes are not covered. For Orchestrator job start/stop/logs→uipath-platform, root-cause analysis of specific errors→uipath-troubleshoot, RPA workflow authoring→uipath-rpa, org-level identity→uipath-admin."
-when_to_use: "User says 'job failures', 'automation health', 'job success rate', 'processing time', 'which processes fail the most', 'failure reasons', 'job trends', 'how many jobs ran', 'job metrics', 'uncompleted jobs', 'faulted jobs', 'job timeline', 'process details', 'which folders can you see', 'what processes are active', 'find the folder key', 'discover queues', 'which machines reported', 'filter-folders', 'filter-processes', 'queue backlog', 'queue SLA', 'why are queue items failing', 'queue retry success', 'Insights alert', 'which alerts exist', 'alert history', 'did an alert fire', 'alert delivery', 'alerting entitlement', 'who has Insights access', 'Insights roles', or 'Insights groups'. NOT for alert or RBAC writes, starting/stopping jobs or queue item CRUD (uipath-platform), or root-cause debugging of a specific job error (uipath-troubleshoot). Also 'uip insights', 'insights jobs', 'insights queues'."
+description: "UiPath Insights read-only monitoring via `uip insights`: job metrics, failure analysis, and process performance; queue totals, SLA risk, timelines, and failure drill-down; machine runtime mix, availability, fault ranking, and runtime minutes; filter discovery of active folders, processes, queues, and machines; alert definition, history, delivery, and entitlement reads; Insights user, role, and group reads. Alert and RBAC writes are not covered. For job start/stop/logs→uipath-platform, root-cause analysis→uipath-troubleshoot, workflow authoring→uipath-rpa, org-level identity→uipath-admin."
+when_to_use: "User says 'job failures', 'automation health', 'job success rate', 'processing time', 'which processes fail the most', 'failure reasons', 'job trends', 'how many jobs ran', 'job metrics', 'uncompleted jobs', 'faulted jobs', 'process details', 'which folders can you see', 'find the folder key', 'which machines reported', 'filter-folders', 'queue backlog', 'queue SLA', 'why are queue items failing', 'queue retry success', 'machine utilization', 'machine availability', 'machine status', 'Insights alert', 'which alerts exist', 'alert history', 'did an alert fire', 'alert delivery', 'alerting entitlement', 'who has Insights access', 'Insights roles', or 'Insights groups'. NOT for alert or RBAC writes, starting/stopping jobs or queue item and machine CRUD (uipath-platform), or root-cause debugging of a specific job error (uipath-troubleshoot). Also 'uip insights', 'insights jobs', 'insights queues', 'insights machines'."
 allowed-tools: Bash, Read
 ---
 
 # UiPath Insights
 
-Use `uip insights` for job monitoring, monitoring-scope discovery, read-only alert inspection, and Insights RBAC reads. Read the guide for the task before running commands.
+Use `uip insights` for job, queue, and machine monitoring, monitoring-scope discovery, read-only alert inspection, and Insights RBAC reads. Read the guide for the task before running commands.
 
 ## When to Use This Skill
 
@@ -17,15 +17,16 @@ Use `uip insights` for job monitoring, monitoring-scope discovery, read-only ale
 - Whether jobs are stuck, pending, or still running
 - Finding the exact folder key, process name, queue name, or machine name to scope a query by
 - Queue item throughput, backlog, SLA risk, failure reasons, or how retried items turned out
+- Machine health: runtime split, current status and slots, availability over time, fault ranking, or runtime minutes
 - Which alerts exist, how one is configured, whether an alert fired, or how a triggered alert is delivered
 - Who has Insights access on a tenant, which roles exist and what they permit, and which groups hold them
 
 ## Critical Rules
 
-1. **Use `--output json`.** `jobs` commands return `{ Result, Code, Data }`. The `filter-*`, `queues`, and alert commands add `Instructions`; `filter-*`, every `queues` command except `summary`, `alerts list`, and `alert-history list` also add `Pagination`. Quote those `Instructions` in the explanation. A failure envelope carries `Result`, `Message`, `Instructions`, `ErrorCode`, and `Retry`, with no `Code` and no `Data`. Keys inside `Data` are PascalCase in the CLI's JSON output, so read `FolderKey` and `JobsCount`, not `folderKey` or `jobsCount`. The RBAC reads are the one exception to the flag: run them without `--output` so the CLI's safe projection stays on. The format still resolves to json, so the envelope is identical.
+1. **Use `--output json`.** `jobs` commands return `{ Result, Code, Data }`. The `filter-*`, `queues`, `machines`, and alert commands add `Instructions`; `filter-*`, every `queues` command except `summary`, every `machines` command except `runtime-mix`, `alerts list`, and `alert-history list` also add `Pagination`. Quote those `Instructions` in the explanation. A failure envelope carries `Result`, `Message`, `Instructions`, `ErrorCode`, and `Retry`, with no `Code` and no `Data`. Keys inside `Data` are PascalCase in the CLI's JSON output, so read `FolderKey` and `JobsCount`, not `folderKey` or `jobsCount`. The RBAC reads are the one exception to the flag: run them without `--output` so the CLI's safe projection stays on. The format still resolves to json, so the envelope is identical.
 2. **One subcommand per invocation, written literally.** Do not chain, loop, or parameterize `uip insights` commands: no `&&` or `;` chains, no `for` loops, and no shell variables holding the subcommand name or flag values. Resolve values such as epoch timestamps in a separate command first, then pass literal numbers. Never write `$(date ...)` or `$VAR` into a flag value.
 3. **Use only the flags the guides document.** Identity, organization, and tenant come from the active session. Any tenant flag you find is deprecated and is rejected outright on `filter-*` commands, so do not use one. If a filter is not in the guide's shared-options list, it does not exist.
-4. **Time ranges are required, and their units differ by family.** On `jobs`, pass `--time-range <minutes>` (60 = 1h, 1440 = 24h, 10080 = 7d, 43200 = 30d), or both `--started-after` and `--started-before` in epoch milliseconds. `queues` commands use those same two flag names and the same units as `jobs`. `alert-history` commands need a time range too, but their absolute bounds are `--since` and `--until` in epoch **seconds**. Omitting a time range is rejected locally: `jobs` exits 1, `queues` and `alert-history` exit 3. On `queues` the server also caps the window at 30 days by clamping it silently, so never report a longer window as the one queried. `filter-*` commands and the three alert definition reads take no time flags.
+4. **Time ranges are required, and their units differ by family.** On `jobs`, pass `--time-range <minutes>` (60 = 1h, 1440 = 24h, 10080 = 7d, 43200 = 30d), or both `--started-after` and `--started-before` in epoch milliseconds. `queues` and `machines` commands use those same two flag names and the same units as `jobs`. `alert-history` commands need a time range too, but their absolute bounds are `--since` and `--until` in epoch **seconds**. Omitting a time range is rejected locally: `jobs` exits 1, `queues`, `machines`, and `alert-history` exit 3. On `queues` and `machines` the server also caps the window at 30 days by clamping it silently, so never report a longer window as the one queried. `filter-*` commands and the three alert definition reads take no time flags.
 5. **Start with `summary`, then drill down.** After any scope discovery the task needs, begin a job investigation with `uip insights jobs summary` for the totals, then run the targeted subcommands. The summary supplies the denominator that makes a failure count meaningful.
 6. **Treat empty data as bounded evidence.** Empty results can reflect the chosen time window, the recent-activity window, caller visibility, or tenant provisioning. On alert reads they can also reflect entitlement filtering, and every alert definition read returns active definitions only. They do not prove that a resource or event never existed.
 7. **Use the CLI instead of raw Insights APIs.** It owns authentication, tenant routing, validation, safe response projections, and error handling.
@@ -65,14 +66,15 @@ uip login tenant set MyTenant                                      # same enviro
 | Choose a Jobs subcommand, flag, time range, or interpret its response fields | [`references/jobs-commands-guide.md`](references/jobs-commands-guide.md) |
 | Answer which folders, processes, queues, or machines are visible, or resolve an exact folder key, process name, or machine name to filter by | [`references/filter-discovery-guide.md`](references/filter-discovery-guide.md) |
 | Report on queue item totals, SLA risk, state over time, failures, or retry outcomes | [`references/queue-monitoring-guide.md`](references/queue-monitoring-guide.md) |
+| Report on machine runtime mix, status and slots, availability intervals, fault ranking, or runtime minutes | [`references/machine-monitoring-guide.md`](references/machine-monitoring-guide.md) |
 | Inspect alert definitions, alerting entitlement, trigger history, or delivery metadata | [`references/alerts-reads-guide.md`](references/alerts-reads-guide.md) |
 | Inspect Insights users, roles, or groups | [`references/rbac-reads-guide.md`](references/rbac-reads-guide.md) |
 
-Read only the guides the task needs. A job investigation that must first resolve a folder, process, or machine needs the filter guide, then the jobs guide. A queue question that names a queue needs the filter guide for the exact name, then the queue guide. An alert question needs the alert guide alone; it owns the full definition, history, and delivery sequence. An Insights access question needs the RBAC guide alone.
+Read only the guides the task needs. A job investigation that must first resolve a folder, process, or machine needs the filter guide, then the jobs guide. A queue question that names a queue needs the filter guide for the exact name, then the queue guide. A machine question that names a machine or a type label needs the filter guide for the exact value, then the machine guide. An alert question needs the alert guide alone; it owns the full definition, history, and delivery sequence. An Insights access question needs the RBAC guide alone.
 
 ## Scope Boundaries
 
-`uip insights` ships five command families: `jobs`, `queues`, the `filter-*` discovery commands, the alert reads (`alerts`, `alert-history`, `alert-deliveries`), and the RBAC reads (`users`, `roles`, `groups`). If a request needs anything else, say it is not available rather than guessing a subcommand.
+`uip insights` ships six command families: `jobs`, `queues`, `machines`, the `filter-*` discovery commands, the alert reads (`alerts`, `alert-history`, `alert-deliveries`), and the RBAC reads (`users`, `roles`, `groups`). If a request needs anything else, say it is not available rather than guessing a subcommand.
 
 | Request | Route |
 |---|---|
@@ -80,8 +82,8 @@ Read only the guides the task needs. A job investigation that must first resolve
 | Diagnose the root cause of a specific job error | `uipath-troubleshoot` |
 | Fix the workflow or agent that caused a failure | `uipath-rpa` or `uipath-agents` |
 | Add, retry, or delete an individual queue item | `uipath-platform`; `queues` reports on items and never changes one |
+| Create, edit, or delete a machine, or manage its runtimes | `uipath-platform`; `machines` reports on machines and never changes one |
 | Any alert or delivery write (see Critical Rule 12) | Insights UI; not in the shipped `uip insights` surface |
-| Machine or robot utilization | Not in the shipped `uip insights` surface |
 | Dashboards | Not in the shipped `uip insights` surface |
 | Any Insights RBAC write, such as assigning a role (see Critical Rule 15) | Insights UI; not in the shipped `uip insights` surface |
 | Manage org-level user accounts, groups, or roles outside Insights | `uipath-admin` |

--- a/skills/uipath-insights/SKILL.md
+++ b/skills/uipath-insights/SKILL.md
@@ -70,7 +70,7 @@ uip login tenant set MyTenant                                      # same enviro
 | Inspect alert definitions, alerting entitlement, trigger history, or delivery metadata | [`references/alerts-reads-guide.md`](references/alerts-reads-guide.md) |
 | Inspect Insights users, roles, or groups | [`references/rbac-reads-guide.md`](references/rbac-reads-guide.md) |
 
-Read only the guides the task needs. A job investigation that must first resolve a folder, process, or machine needs the filter guide, then the jobs guide. A queue question that names a queue needs the filter guide for the exact name, then the queue guide. A machine question that names a machine or a type label needs the filter guide for the exact value, then the machine guide. An alert question needs the alert guide alone; it owns the full definition, history, and delivery sequence. An Insights access question needs the RBAC guide alone.
+Read only the guides the task needs. A job investigation that must first resolve a folder, process, or machine needs the filter guide, then the jobs guide. A queue question that names a queue needs the filter guide for the exact name, then the queue guide. A machine question that names a machine needs the filter guide for the exact name, then the machine guide. The machine guide also lists the five machine type labels, which `filter-machines list` does not report. An alert question needs the alert guide alone; it owns the full definition, history, and delivery sequence. An Insights access question needs the RBAC guide alone.
 
 ## Scope Boundaries
 

--- a/skills/uipath-insights/references/machine-monitoring-guide.md
+++ b/skills/uipath-insights/references/machine-monitoring-guide.md
@@ -1,0 +1,111 @@
+# Machine Monitoring Commands
+
+The `machines` commands report on machine health: attended versus unattended runtime, per-machine status and slot inventory, availability intervals, faulted-job ranking, and runtime minutes. They answer "how are these machines doing", not "which machines exist"; use `filter-machines list` for discovery and for the exact machine names and type labels these commands filter on.
+
+Every command needs a time range. Results are tenant-scoped: machine commands have no folder flag and no permission scoping, unlike the `queues` commands.
+
+Keys inside `Data` are PascalCase in the CLI's JSON output. Read `MachineName`, not `machineName`.
+
+## Shared Options
+
+```text
+--time-range <minutes>        Relative window ending now
+--started-after <epoch-ms>    Absolute window start, needs --started-before
+--started-before <epoch-ms>   Absolute window end, needs --started-after
+--machine-name <names...>     Machine names to restrict to, space separated
+--host-name <names...>        Host machine names to restrict to, space separated
+--machine-type <types...>     Machine type labels to restrict to, space separated
+--limit <number>              Rows to return, 1 to 10000 (default 50)
+--offset <number>             Rows to skip before returning results (default 0)
+--output <format>             Output format: table, json, yaml, plain (always use json)
+```
+
+`machines runtime-mix` returns a fixed two-row answer, so it takes no `--limit` or `--offset`. There is no `--folder-key` on any machine command.
+
+`--machine-type` takes the exact labels `filter-machines list` reports, such as `Standard Machine` or `Cloud Robot - Serverless`. Quote labels containing spaces.
+
+## Rules
+
+1. **A time range is required and its units are minutes or epoch milliseconds.** Same two forms and units as `queues`: `--time-range <minutes>` (60 = 1h, 1440 = 24h, 43200 = 30d), or both `--started-after` and `--started-before` in epoch milliseconds. Passing both forms is rejected. Omitting a time range is rejected locally and exits 3.
+2. **The server silently caps the window at 30 days**, the same clamping as `queues`. Never report a longer window as the window queried.
+3. **Results are tenant-scoped, not folder-scoped.** The backend ignores folders entirely on these routes, so there is no `--folder-key` and no permission-bounded subset. Do not carry the queue commands' folder reasoning over.
+4. **Repeat calls inside a minute return the same numbers, with no way around it.** The server caches each distinct request for 60 seconds and the machine routes expose no bypass at all. Say so before presenting a figure as current during a live incident.
+5. **Every page repeats the whole backend request.** These commands page the CLI's own copy of the list; read `Pagination.Total` and `Pagination.HasMore`.
+6. **A machine name and host pair is not a unique identity.** Two live machine keys can carry the same name, producing two rows that agree on `MachineName` and `HostMachineName`. Only `availability-timeline` returns `MachineKey`.
+7. **An empty string is an answer, not an error.** `CurrentProcess` is empty when no job is running and `MachineType` is empty when the type cannot be classified. Report the meaning, not a blank.
+8. **`top-errors` and `utilization` return at most ten rows**, ranked server-side. A machine missing from either list is not proof of zero; for `utilization` an omitted machine has no reconstructed runtime, which is not the same as a zero-minute row.
+9. **Row order is the server's on `availability-timeline`, `top-errors`, and `utilization`.** The CLI sorts only `details` (by machine, then host) before paging. Timeline timestamps are culture-formatted `GMT` strings; never parse or re-sort them.
+10. **These commands need a Cloud or Dedicated SaaS deployment.** On Automation Suite and Service Fabric they return `Result: ConfigError` with `ErrorCode: configuration_error` before the tenant is consulted. That is a deployment fact, not a permission or data answer, and retrying will not change it.
+
+## Errors
+
+`machines` failures use the same `Result` values and the same table as the `queues` guide: `ValidationError` exit 3 for local rejections, `AuthenticationError` exit 2, `ConfigError` for the deployment gate 404, and `Failure` with `permission_denied`, `rate_limited`, `timeout`, `server_error`, `network_error`, or `unknown_error`. One difference: a 403 here is a tenant-level Insights access boundary, never a folder answer, because machine routes have no folder scoping. Branch on `Retry` as described in SKILL.md Critical Rule 8.
+
+## Commands
+
+### machines runtime-mix
+
+Unattended versus attended job runtime and average per-robot runtime. Two fixed rows, no pagination.
+
+```bash
+uip insights machines runtime-mix --time-range 1440 --output json
+```
+
+`Data[]`: exactly two rows, `Unattended` then `Attended`, each with `ExecutionType`, `JobDurationMs`, `AverageUtilizationMs`.
+
+Both values are milliseconds. `AverageUtilizationMs` is the runtime divided by the distinct robot count, so it is also a duration, never a percentage. Do not compare either value against a percentage threshold.
+
+### machines details
+
+Per-machine and per-host status, current process, fault count, runtime, and slot inventory.
+
+```bash
+uip insights machines details --time-range 1440 --output json
+```
+
+`Data[]`: `MachineName`, `HostMachineName`, `Status`, `CurrentProcess`, `FaultedJobs`, `UtilizationMs`, `MachineType`, `RuntimeCount`, `InUseCount`, `NonProductionSlots`, `HeadlessSlots`, `AutomationCloudSlots`, `UnattendedSlots`, `TestAutomationSlots`, `AutomationCloudTestAutomationSlots`, `DevelopmentSlots`.
+
+This row mixes two time windows. `FaultedJobs` and `UtilizationMs` count only events inside the requested window, but `Status`, `CurrentProcess`, and `InUseCount` come from a fixed 30-day scan ending now. Present the first two as window figures and the rest as recent state.
+
+### machines availability-timeline
+
+Availability intervals per machine and host, reconstructed server-side from machine-session and job events.
+
+```bash
+uip insights machines availability-timeline --time-range 1440 --output json
+```
+
+`Data[]`: `MachineName`, `HostMachineName`, `MachineKey`, `Status`, `StartTime`, `EndTime`, `RunningJobs`, plus `EventTime` on deployments whose backend sends it.
+
+Four reading rules:
+
+- `Status` includes the interval markers `Job Start` and `Job End` alongside session states such as `Available`, `Unresponsive`, and `Disconnected`.
+- `RunningJobs` is the concurrent in-progress count for the interval and can be negative when a job started before the backend's 30-day lookback. Treat a negative value as unknown concurrency, not an error.
+- A machine that stayed `Unresponsive` or `Disconnected` for the entire window returns no rows at all, so an empty result never proves availability.
+- `StartTime` on an interval carried in from before the window is clamped to the window start. Where `EventTime` is present it is the real transition instant; prefer it when reporting when a state began.
+
+Timestamps end in ` GMT` and follow the service host's own formatting. Quote them verbatim; never parse, convert, or re-sort them.
+
+### machines top-errors
+
+Machines ranked by faulted jobs.
+
+```bash
+uip insights machines top-errors --time-range 43200 --output json
+```
+
+`Data[]`: `MachineName`, `HostMachineName`, `FaultedJobs`. At most ten rows in the server's own ranking; equal counts have no stable order across pages. Serverless machines report `N/A` as the host.
+
+Drill into a ranked machine's failures with the shipped Jobs commands: `uip insights jobs failures-by-reason --machine-name <name>` and `uip insights jobs failure-details --machine-name <name>` accept the `MachineName` value verbatim. Note the flag shape differs: `jobs` takes one repeatable `--machine-name` value, while `machines` commands take a space-separated list.
+
+### machines utilization
+
+Job runtime minutes per machine and host.
+
+```bash
+uip insights machines utilization --time-range 43200 --output json
+```
+
+`Data[]`: `MachineName`, `HostMachineName`, `UtilizationMinutes`. At most ten rows, minutes descending.
+
+`UtilizationMinutes` is runtime inside the window, rounded to two decimals. It is not a utilization percentage: the response has no capacity denominator, so never divide it into one or compare it against a percentage threshold. A machine with no running-job interval in the window is omitted, not reported as zero.

--- a/skills/uipath-insights/references/machine-monitoring-guide.md
+++ b/skills/uipath-insights/references/machine-monitoring-guide.md
@@ -1,6 +1,6 @@
 # Machine Monitoring Commands
 
-The `machines` commands report on machine health: attended versus unattended runtime, per-machine status and slot inventory, availability intervals, faulted-job ranking, and runtime minutes. They answer "how are these machines doing", not "which machines exist"; use `filter-machines list` for discovery and for the exact machine names and type labels these commands filter on.
+The `machines` commands report on machine health: attended versus unattended runtime, per-machine status and slot inventory, availability intervals, faulted-job ranking, and runtime minutes. They answer "how are these machines doing", not "which machines exist"; use `filter-machines list` for discovery and for the exact machine names these commands filter on.
 
 Every command needs a time range. Results are tenant-scoped: machine commands have no folder flag and no permission scoping, unlike the `queues` commands.
 
@@ -22,19 +22,19 @@ Keys inside `Data` are PascalCase in the CLI's JSON output. Read `MachineName`, 
 
 `machines runtime-mix` returns a fixed two-row answer, so it takes no `--limit` or `--offset`. There is no `--folder-key` on any machine command.
 
-`--machine-type` takes the exact labels `filter-machines list` reports, such as `Standard Machine` or `Cloud Robot - Serverless`. Quote labels containing spaces.
+`--machine-type` takes one or more of five labels the backend builds in SQL: `Standard Machine`, `Elastic Robot Pool`, `Cloud Robot - VM`, `Cloud Robot - Serverless`, `Machine Template`. Quote every label, since all five contain spaces. `filter-machines list` reports machine names and keys only, so it cannot confirm a type label; a mistyped label returns `Success` with zero rows.
 
 ## Rules
 
 1. **A time range is required and its units are minutes or epoch milliseconds.** Same two forms and units as `queues`: `--time-range <minutes>` (60 = 1h, 1440 = 24h, 43200 = 30d), or both `--started-after` and `--started-before` in epoch milliseconds. Passing both forms is rejected. Omitting a time range is rejected locally and exits 3.
-2. **The server silently caps the window at 30 days**, the same clamping as `queues`. Never report a longer window as the window queried.
+2. **The server silently caps the window at 30 days**, the same clamping as `queues`. A longer `--time-range` is clamped to exactly 30 days, while an absolute bound is moved forward only once it is a full 31 days old. Never report a longer window as the window queried.
 3. **Results are tenant-scoped, not folder-scoped.** The backend ignores folders entirely on these routes, so there is no `--folder-key` and no permission-bounded subset. Do not carry the queue commands' folder reasoning over.
 4. **Repeat calls inside a minute return the same numbers, with no way around it.** The server caches each distinct request for 60 seconds and the machine routes expose no bypass at all. Say so before presenting a figure as current during a live incident.
 5. **Every page repeats the whole backend request.** These commands page the CLI's own copy of the list; read `Pagination.Total` and `Pagination.HasMore`.
 6. **A machine name and host pair is not a unique identity.** Two live machine keys can carry the same name, producing two rows that agree on `MachineName` and `HostMachineName`. Only `availability-timeline` returns `MachineKey`.
 7. **An empty string is an answer, not an error.** `CurrentProcess` is empty when no job is running and `MachineType` is empty when the type cannot be classified. Report the meaning, not a blank.
 8. **`top-errors` and `utilization` return at most ten rows**, ranked server-side. A machine missing from either list is not proof of zero; for `utilization` an omitted machine has no reconstructed runtime, which is not the same as a zero-minute row.
-9. **Row order is the server's on `availability-timeline`, `top-errors`, and `utilization`.** The CLI sorts only `details` (by machine, then host) before paging. Timeline timestamps are culture-formatted `GMT` strings; never parse or re-sort them.
+9. **Row order is the server's on `availability-timeline`, `top-errors`, and `utilization`.** The CLI sorts only `details` (by machine, then host) before paging. That sort has no tie-break: the backend adds no order of its own and returns no machine key for `details`, so two rows agreeing on both fields can swap between one `--offset` page and the next once the 60-second cache expires. Page through the whole list inside that minute when the split across pages matters. Timeline timestamps are culture-formatted `GMT` strings; never parse or re-sort them.
 10. **These commands need a Cloud or Dedicated SaaS deployment.** On Automation Suite and Service Fabric they return `Result: ConfigError` with `ErrorCode: configuration_error` before the tenant is consulted. That is a deployment fact, not a permission or data answer, and retrying will not change it.
 
 ## Errors
@@ -53,7 +53,9 @@ uip insights machines runtime-mix --time-range 1440 --output json
 
 `Data[]`: exactly two rows, `Unattended` then `Attended`, each with `ExecutionType`, `JobDurationMs`, `AverageUtilizationMs`.
 
-Both values are milliseconds. `AverageUtilizationMs` is the runtime divided by the distinct robot count, so it is also a duration, never a percentage. Do not compare either value against a percentage threshold.
+Both values are milliseconds. `AverageUtilizationMs` divides the runtime by the window's distinct robot count, counted across attended and unattended robots together, so the `Unattended` row is not a per-unattended-robot average. It is a duration, never a percentage; do not compare either value against a percentage threshold.
+
+Both aggregates are coalesced to zero server-side. A `0`/`0` pair therefore means no job runtime matched the filters, which is not the same as a confirmed idle machine. Re-check the filter values with `filter-machines list` before reporting zeros as a finding.
 
 ### machines details
 

--- a/tests/tasks/activation/uipath-insights.jsonl
+++ b/tests/tasks/activation/uipath-insights.jsonl
@@ -39,3 +39,7 @@
 {"id": "uipath-insights-039", "prompt": "Which queues are at risk of breaching their SLA?", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-040", "prompt": "Why are items failing in the Invoices queue?", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-041", "prompt": "Of the queue items we retried this month, how many went on to succeed?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-042", "prompt": "How much runtime did our unattended robots log versus attended this week?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-043", "prompt": "Which machines had the most faulted jobs this month?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-044", "prompt": "Was the FinanceVM machine available overnight or did it drop?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-045", "prompt": "Show me runtime minutes per machine for the last 30 days.", "expected_skill": "uipath-insights"}


### PR DESCRIPTION
https://uipath.atlassian.net/browse/IN-13530

Also related to https://uipath.atlassian.net/browse/IN-13527: the activation rows here are that ticket's skills-side test layer.

The commands ship in two stacked cli PRs: [UiPath/cli#3849](https://github.com/UiPath/cli/pull/3849) (runtime-mix, details) and [UiPath/cli#4111](https://github.com/UiPath/cli/pull/4111) (availability-timeline, top-failures, utilization). This half waits for the second to merge and publish `@uipath/cli@dev`, which the smoke gate installs. Stacked on #2839 (queue monitoring); the diff against that branch is the three files below.

## What

Teaches the `uipath-insights` skill the five machine monitoring commands.

- New `references/machine-monitoring-guide.md` with the command catalog, shared flags, the error table, and the per-command output shapes.
- `SKILL.md` generalized from the queue family to cover machines. `description` and `when_to_use` are 551 and 943 characters, so the combined listing text is 1,494 against the 1,536-character cap. Critical Rule 5 also names where a machine investigation starts, since the family has no `summary` command.
- Four activation rows in `tests/tasks/activation/uipath-insights.jsonl`.
- New `tests/tasks/uipath-insights/machines/smoke.yaml`: all five commands driven from a prompt that names none of them, a `--help` reality gate per subcommand, and negatives for the guide's own traps. Ships skipped, see below.

## Why

WS2.2 M1 adds machine monitoring to the CLI. Agents need the matching guide to pick the right command and to read the outputs that are easiest to misreport.

## Verification

Every behavioral claim was read from the CLI on the two branches above and from `MachinesQuery.cs` in `UiPath/Insights-monitoring` at `e17accd8`, rather than inferred from field names. Six claims changed as a result.

`CurrentProcess` carries the last job event's process whatever state that job ended in, so a `Status` of `In Use` is the only running-now signal. The CLI ships that sentence in its own `Instructions`.

The `details` row spans three windows rather than two. Only the non-`In Use` `Status` values come from the fixed 30-day session scan, and `Available` is the query's fallback when no session row exists at all.

Two filters reach less than their names suggest: `--host-machine-name` narrows only the job-derived columns of `details`, and `--machine-type` never reaches `availability-timeline`'s job markers.

An absolute window whose end is also past the 30-day cap collapses to about a millisecond and returns an empty result that is an artifact of the clamp, not an absence of data.

The `N/A` serverless host placeholder cannot be fed back to `--host-machine-name` on `top-failures` or `utilization`, which compare the raw column.

`AverageUtilizationMs` divides by a robot count spanning both execution types, so the Unattended row is not a per-unattended-robot average.

The Errors section carries its own table rather than pointing at the queues guide, since SKILL.md tells an agent to read only the guides its task needs.

Ran locally, all passing on both flavors (27 skills): `npm run skills:validate`, `npm run skills:build`, `npm run skills:check-links`, `npm run skills:test` (56 tests), `hooks/validate-skill-descriptions.sh`, `python3 scripts/check-skills-sh.py`, and `npm run version:check`.

CI's `Run skill smoke tests` is green on this branch and it does not cover this change. The eight tasks it runs are the existing ones, and none of them names a machine command, `smoke_all_commands.yaml` included.

**The new machine smoke task ships skipped**, which is why the suite is still eight. The catalog snapshot at `uip 1.203.0-dev.8703` carries `insights filter-machines` and no `insights machines` verb, so every `--help` gate fails today and would take the smoke check red on a PR whose skill content is fine. A skipped task lands in `RunSummary.skipped_tasks` at resolution time and never reaches the orchestrator (coder_eval 0.12.1, `models/tasks.py:466`, the version `tests/.coder-eval-version` pins), so it writes no `task.json` and stays out of the workflow's pass-rate denominator. Unskip in the PR that first runs against a dev build carrying the commands, which needs both cli PRs above to merge.

The task validates against that pinned `TaskDefinition` schema, and its twelve regexes were exercised against 55 crafted commands under `re.DOTALL`, the way the grader compiles them, with no misses and no false positives.

The four activation rows are unexercised, and the reason is worth recording. `activation-gate.yml:85` skips the gate job on a draft PR, but that is not the only barrier: `uipath-insights` is absent from `BASELINES_PCT` in `tests/scripts/activation_gate.py`, so the script prints `SKIP: no baseline` and exits 0 even on a ready PR. A manual `workflow_dispatch` against this branch confirmed it. Twenty-two other skills have a baseline, so every green Skill activation gate this skill has ever shown was that skip. Adding a baseline needs a measured full activation run.


