### PR TITLE
fix(maestro-flow): raise validate criterion timeout to 180s (cross-team tasks)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
@@ -48,7 +48,7 @@ success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
     command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
-    timeout: 30
+    timeout: 180
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/batch_transform.yaml
+++ b/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/batch_transform.yaml
@@ -52,7 +52,7 @@ success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
     command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
-    timeout: 30
+    timeout: 180
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/context-grounding/summarize/summarize.yaml
+++ b/tests/tasks/uipath-maestro-flow/context-grounding/summarize/summarize.yaml
@@ -54,7 +54,7 @@ success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
     command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
-    timeout: 30
+    timeout: 180
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
@@ -64,7 +64,7 @@ success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on InvoiceRouter.flow"
     command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
-    timeout: 30
+    timeout: 180
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
@@ -61,7 +61,7 @@ success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on Smoke.flow"
     command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
-    timeout: 30
+    timeout: 180
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
@@ -65,7 +65,7 @@ success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on ReceiptIntake.flow"
     command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
-    timeout: 30
+    timeout: 180
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0


### PR DESCRIPTION
Split out of #2853. Identical change, 6 files.

These tasks sit under subdirectories with their own CODEOWNERS rules, which override the base `/tests/tasks/uipath-maestro-flow/` rule. With `requireCodeOwnerReview: true` on `main`, each rule is a separate required approval, so keeping them in the main PR made 48 unrelated files wait on three extra teams.

| Files | CODEOWNERS rule |
|---|---|
| `context-grounding/batch_transform`, `context-grounding/summarize` | `/tests/tasks/uipath-maestro-flow/context-grounding/` |
| `ixp/integration_handle_routing`, `ixp/scaffold_minimal`, `ixp/scaffold_multinode` | `/tests/tasks/uipath-maestro-flow/ixp/` |
| `connector_features/generic_dynamic_node` | `/tests/tasks/uipath-maestro-flow/connector_features/` |

## Change

```diff
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
     command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
-    timeout: 30
+    timeout: 180
```

Timeout-only. No task logic, prompt, criterion shape, or weight changed.

## Why

`uip maestro flow validate` refreshes the node manifest from the tenant on **every** invocation. `flow-tool`'s validate command hardcodes `validateCurrentManifests: true`, which reaches `loadCurrentManifestMapUncached()` → `ManifestClient.getManifest()`:

```
[ManifestClient] fetchDynamicNodes ok: total=3304 ... orchestrator nodes=3277 IXP nodes=14
```

No `--governance` needed, not gated by `~/.uipath/maestro/registry.json`, no offline flag. Wall time is network-bound and bimodal. 13 runs against one valid, unchanged flow:

| | seconds |
|---|---|
| typical | 8.3, 8.6, 9, 10.6, 11.2, 12.2, 12.6, 12.8, 14 |
| tail | **60.7, 61.4, 67.2** |

Roughly a quarter of runs exceed 30s and score 0.0 on a gating criterion for a flow that validates clean. Observed on `skill-flow-feet-inches`: criterion 1 killed at 30s (`exit -1`, empty stdout), both debug criteria passed, `weighted_score: 0.769`, `FAILURE`. That run's agent had validated the identical file in 3.12s, so the budget sat inside the variance rather than above it.

30s was never chosen for this command. It is coder_eval's `run_command` default, and #2213 swapped the criterion from a bare CLI call to a python wrapper (interpreter start, recursive project glob, nested subprocess) without re-baselining. `tests/experiments/default.yaml` sets no per-criterion timeout, so there is no single-place fix.

## Verification

Ran the criterion's exact command against the preserved `skill-flow-feet-inches` artifact from the failing run:

```
$ python3 tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
Validating FeetInches/FeetInches/FeetInches.flow
{"Result": "Success", "Code": "FlowValidate", "Data": {"Status": "Valid"}}
exit 0
```

Two runs, 12.7s and 67.2s. Both exit 0, both inside the new 180s budget; the second would have been killed under the old one.

Not claimed: a full `coder-eval` run of these 6 tasks. The command is unchanged and only its budget moved, so the reproduction above covers the failure mode directly.

## Reviewers

One approval per rule unblocks this. If any team needs longer, say so and I will split this further so the other two are not held up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
