### PR TITLE
chore(codeowners): own flow and BPMN via @UiPath/maestro-cli-team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,9 +18,9 @@
 /skill-flavors/studioweb/ @astridstaicu
 
 # preview skills
-/preview/uipath-maestro-flow/  @dmetzgar @tmatup
+/preview/uipath-maestro-flow/ @UiPath/maestro-cli-team
 /preview/uipath-maestro-case/ @dmetzgar @tmatup
-/preview/uipath-maestro-bpmn/ @dmetzgar @tmatup
+/preview/uipath-maestro-bpmn/ @UiPath/maestro-cli-team
 
 # Activity references (bundled inside uipath-rpa skill)
 /skills/uipath-rpa/references/activity-docs/ @DragosUnguru
@@ -95,18 +95,18 @@
 /tests/tasks/uipath-solution/ @UiPath/team-merlot @UiPath/team-orange
 
 # Flow skill
-/skills/uipath-maestro-flow/ @bai-uipath @rockymadden @gozhang2 @tmatup @akshaylive @jiyangzh @nikhil-maryala @baishalighosh @DevMomo @chandusailella @mukundbayyaram
+/skills/uipath-maestro-flow/ @chandusailella @mukundbayyaram @UiPath/maestro-cli-team
 # Flow test tasks (general) — more specific subfolder rules below override this
-/tests/tasks/uipath-maestro-flow/ @bai-uipath @rockymadden @gozhang2 @tmatup @akshaylive @jiyangzh @nikhil-maryala @baishalighosh @DevMomo
+/tests/tasks/uipath-maestro-flow/ @UiPath/maestro-cli-team
 
 # Context grounding team — flow plugins (Summarize/Batch Transform) + tasks
-/skills/uipath-maestro-flow/references/author/references/plugins/summarize/ @gcuip @JeremyReist2 @cfauchere @CalebMartinUiPath @jordan-uipath @eteodorovici @pateljay43 @swathiJayav
-/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/ @gcuip @JeremyReist2 @cfauchere @CalebMartinUiPath @jordan-uipath @eteodorovici @pateljay43 @swathiJayav
-/tests/tasks/uipath-maestro-flow/context-grounding/ @gcuip @JeremyReist2 @cfauchere @CalebMartinUiPath @jordan-uipath @eteodorovici @pateljay43 @swathiJayav
+/skills/uipath-maestro-flow/references/author/references/plugins/summarize/ @gcuip @JeremyReist2 @cfauchere @CalebMartinUiPath @jordan-uipath @eteodorovici @pateljay43 @swathiJayav @UiPath/maestro-cli-team
+/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/ @gcuip @JeremyReist2 @cfauchere @CalebMartinUiPath @jordan-uipath @eteodorovici @pateljay43 @swathiJayav @UiPath/maestro-cli-team
+/tests/tasks/uipath-maestro-flow/context-grounding/ @gcuip @JeremyReist2 @cfauchere @CalebMartinUiPath @jordan-uipath @eteodorovici @pateljay43 @swathiJayav @UiPath/maestro-cli-team
 
 # Maestro BPMN skill
-/skills/uipath-maestro-bpmn/ @bai-uipath @rockymadden @gozhang2 @tmatup @akshaylive @jiyangzh @nikhil-maryala @baishalighosh @DevMomo
-/tests/tasks/uipath-maestro-bpmn/ @bai-uipath @rockymadden @gozhang2 @tmatup @akshaylive @jiyangzh @nikhil-maryala @baishalighosh @DevMomo
+/skills/uipath-maestro-bpmn/ @UiPath/maestro-cli-team
+/tests/tasks/uipath-maestro-bpmn/ @UiPath/maestro-cli-team
 # API Workflow skill
 /skills/uipath-api-workflow/ @rares-baesu-uipath @liviubobocu @mirastroie
 /tests/tasks/uipath-api-workflow/ @rares-baesu-uipath @liviubobocu @mirastroie
@@ -131,16 +131,16 @@
 
 # Flow skill — plugin guides (away team owned)
 # Add your team here when contributing a new plugin category
-/skills/uipath-maestro-flow/references/plugins/connector/ @baishalighosh @chandusailella @bai-uipath @rockymadden @DevMomo
-/skills/uipath-maestro-flow/references/plugins/connector-trigger/ @baishalighosh @chandusailella @bai-uipath @rockymadden @DevMomo
-/skills/uipath-maestro-flow/references/author/references/plugins/agent/ @UiPath/team-coded-agents @AlexandruCGhimisi @andreibalas-uipath @al3xanndru
-/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/ @AlexandruCGhimisi @andreibalas-uipath @al3xanndru
-/tests/tasks/uipath-maestro-flow/connector_features/ @baishalighosh @chandusailella @mukundbayyaram
-/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector @UiPath/DatafabricCodingAgent
+/skills/uipath-maestro-flow/references/plugins/connector/ @chandusailella @UiPath/maestro-cli-team
+/skills/uipath-maestro-flow/references/plugins/connector-trigger/ @chandusailella @UiPath/maestro-cli-team
+/skills/uipath-maestro-flow/references/author/references/plugins/agent/ @UiPath/team-coded-agents @AlexandruCGhimisi @andreibalas-uipath @al3xanndru @UiPath/maestro-cli-team
+/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/ @AlexandruCGhimisi @andreibalas-uipath @al3xanndru @UiPath/maestro-cli-team
+/tests/tasks/uipath-maestro-flow/connector_features/ @chandusailella @mukundbayyaram @UiPath/maestro-cli-team
+/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector @UiPath/DatafabricCodingAgent @UiPath/maestro-cli-team
 
 # IXP
-/skills/uipath-maestro-flow/references/author/references/plugins/ixp/ @UiPath/communications-mining @constantinmuraru @vlad-crisan
-/tests/tasks/uipath-maestro-flow/ixp/ @UiPath/communications-mining @constantinmuraru @vlad-crisan
+/skills/uipath-maestro-flow/references/author/references/plugins/ixp/ @UiPath/communications-mining @constantinmuraru @vlad-crisan @UiPath/maestro-cli-team
+/tests/tasks/uipath-maestro-flow/ixp/ @UiPath/communications-mining @constantinmuraru @vlad-crisan @UiPath/maestro-cli-team
 
 # Review skill
 /skills/uipath-review/ @AlvinStanescu @gabrielavaduva @roalexandru


### PR DESCRIPTION
Unblocks #2853 and every future flow or BPMN sweep.

## Problem

CODEOWNERS matching is **last-match-wins, not additive**. A subfolder rule *replaces* the base rule rather than extending it. The file already flags this on line 97:

```
# Flow test tasks (general) — more specific subfolder rules below override this
```

Nine subfolders under the flow skill and its test tree are owned by away teams, so the flow team had no review rights on its own tree there. `main` enforces `requiredApprovingReviewCount: 1` with `requireCodeOwnerReview: true`, and GitHub requires an approval **per matching rule**, so any sweep across flow paths becomes one required approval per away team.

Concretely: #2853 is a one-line-per-file criterion timeout bump across 54 task YAMLs. Six files fell into these subfolders, which turned it into **4 required approvals and 20 requested reviewers** for a change that alters no task logic, prompt, criterion shape, or weight.

## No wildcard can fix this

Worth stating explicitly, since it is the obvious first instinct: there is **no wildcard that adds owners**. A wildcard can only replace them. `/skills/uipath-maestro-flow/** @team` placed after the subfolder rules would win for every flow file and strip the away teams' ownership entirely. That is a different and much bigger change than intended.

So each rule has to carry the team.

## Change

All 17 flow and BPMN rules now list `@UiPath/maestro-cli-team`, and every enumerated individual who is a team member collapses into that handle.

```diff
-/tests/tasks/uipath-maestro-flow/ @bai-uipath @rockymadden @gozhang2 @tmatup @akshaylive @jiyangzh @nikhil-maryala @baishalighosh @DevMomo
+/tests/tasks/uipath-maestro-flow/ @UiPath/maestro-cli-team

-/tests/tasks/uipath-maestro-flow/ixp/ @UiPath/communications-mining @constantinmuraru @vlad-crisan
+/tests/tasks/uipath-maestro-flow/ixp/ @UiPath/communications-mining @constantinmuraru @vlad-crisan @UiPath/maestro-cli-team

-/tests/tasks/uipath-maestro-bpmn/ @bai-uipath @rockymadden @gozhang2 @tmatup @akshaylive @jiyangzh @nikhil-maryala @baishalighosh @DevMomo
+/tests/tasks/uipath-maestro-bpmn/ @UiPath/maestro-cli-team
```

Coverage:

| Area | Rules |
|---|---|
| `/skills/uipath-maestro-flow/` incl. plugin guides (summarize, batch-transform, connector, connector-trigger, agent, inline-agent, ixp) | 9 |
| `/tests/tasks/uipath-maestro-flow/` incl. context-grounding, connector_features, datafabric_connector, ixp | 4 |
| `/skills/uipath-maestro-bpmn/`, `/tests/tasks/uipath-maestro-bpmn/` | 2 |
| `/preview/uipath-maestro-flow/`, `/preview/uipath-maestro-bpmn/` | 2 |

Six rules collapse to the handle alone (no away owners): all three BPMN rules, `/preview/uipath-maestro-flow/`, and `/tests/tasks/uipath-maestro-flow/`.

**Additive on the eleven shared rules.** Every existing owner keeps review rights and away teams are still auto-requested on changes to their own plugin guides and tasks. Nobody is removed from a path they own today.

Using a handle instead of a roster also stops the drift: the 9 names were duplicated across 8 lines and went stale whenever someone joined or left.

## Deliberately out of scope

Several other rules name a `@UiPath/maestro-cli-team` member individually — `song-zhao-25` on planner and maestro-case, `dushyant-uipath` on human-in-the-loop, `baishalighosh` on integration-service, `tmatup` on `/commands/` and preview-case, `bai-uipath`/`akshaylive` on `/.github/`.

Those are **left alone on purpose.** Being on this team is incidental there; those people own those paths in a different capacity, and collapsing them to the handle would hand this team ownership of another team's area. "Team member listed individually" is not the same as "should be the team handle."

## Repo access

A CODEOWNERS entry naming a team **without repo access is silently ignored** — no error, the rule just does not apply. `@UiPath/maestro-cli-team` was not a collaborator here, so it has been granted `push`, matching every other team already used in this file (`communications-mining`, `team-coded-agents`, `team-merlot`, `team-orange`, `DatafabricCodingAgent`, `llmops-team`, all `push`).

Confirmed working: the team now resolves as a review request on this PR.

## Pre-merge item

`@bai-uipath` and `@akshaylive` are named in the current flow and BPMN rules but are not yet members of `@UiPath/maestro-cli-team`. They must be added before merge, or they lose review rights on:

- `/skills/uipath-maestro-flow/`, `/tests/tasks/uipath-maestro-flow/`
- `/skills/uipath-maestro-bpmn/`, `/tests/tasks/uipath-maestro-bpmn/`
- `/skills/uipath-maestro-flow/references/plugins/connector/` and `connector-trigger/` (bai-uipath)

Every other individual this PR removes is already a team member, verified against the live roster. @rockymadden is handling the membership add.

## Verification

- Rule count unchanged at 118; none added or removed.
- All 54 files changed in #2853 resolve to a rule owning `@UiPath/maestro-cli-team`. Before: 48 of 54.
- Diffed the before/after owner set for every rule in the file: the only owners losing rights anywhere are the two named above.
- No flow or BPMN rule still names a team member individually, checked against the live roster.
- 17 insertions, 17 deletions, CODEOWNERS only.

## Sequencing

GitHub evaluates CODEOWNERS from the **base** branch, so this does not retroactively change #2853's requirements. Merge this first, then #2853 needs a push to re-evaluate and collapses to one `@UiPath/maestro-cli-team` approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
