### PR TITLE
fix(maestro-flow): budget and retry flow validate inside validate_flow.py

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/test_validate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_validate_flow.py
@@ -25,6 +25,8 @@ import validate_flow  # noqa: E402
 
 # Scaled down from the shipped 180/20/30 so the arithmetic stays checkable by
 # hand: 6s usable, so attempt 1 caps at 3.0s and its retry at what is left.
+# Applied to the default, with _BUDGET_ENV cleared, so these never depend on the
+# harness env of whoever runs pytest.
 _BUDGET = 8
 _HEADROOM = 2
 _MIN_ATTEMPT = 1
@@ -69,7 +71,8 @@ def _stub(monkeypatch, results, *, flows=("a.flow",)):
     monkeypatch.setattr(validate_flow.glob, "glob", lambda *a, **k: list(flows))
     monkeypatch.setattr(validate_flow.time, "sleep", lambda *_: None)
     monkeypatch.setattr(validate_flow.time, "monotonic", lambda: calls["clock"])
-    monkeypatch.setattr(validate_flow, "_CRITERION_BUDGET_SECONDS", _BUDGET)
+    monkeypatch.delenv(validate_flow._BUDGET_ENV, raising=False)
+    monkeypatch.setattr(validate_flow, "_DEFAULT_BUDGET_SECONDS", _BUDGET)
     monkeypatch.setattr(validate_flow, "_BUDGET_HEADROOM_SECONDS", _HEADROOM)
     monkeypatch.setattr(validate_flow, "_MIN_ATTEMPT_SECONDS", _MIN_ATTEMPT)
     calls["deadline"] = float(_BUDGET - _HEADROOM)
@@ -190,3 +193,38 @@ def test_no_attempt_outlives_the_budget(monkeypatch):
     validate_flow.main()
     assert calls["overruns"] == []
     assert sum(calls["timeouts"]) <= _BUDGET - _HEADROOM
+
+
+# ── Budget resolution ───────────────────────────────────────────────────────
+
+
+def test_budget_prefers_the_harness_over_the_default(monkeypatch):
+    """The default mirrors the task YAMLs by hand. The moment coder_eval starts
+    exporting a criterion's timeout, that must win without a code change."""
+    monkeypatch.setattr(validate_flow, "_DEFAULT_BUDGET_SECONDS", 180)
+    monkeypatch.setenv(validate_flow._BUDGET_ENV, "300")
+    assert validate_flow._budget_seconds() == 300
+
+
+def test_budget_falls_back_when_the_harness_is_silent(monkeypatch):
+    monkeypatch.setattr(validate_flow, "_DEFAULT_BUDGET_SECONDS", 180)
+    monkeypatch.delenv(validate_flow._BUDGET_ENV, raising=False)
+    assert validate_flow._budget_seconds() == 180
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "abc", "0", "-5"])
+def test_budget_ignores_junk_rather_than_trusting_it(monkeypatch, raw, capsys):
+    """A zero or unparseable budget would refuse every attempt and report
+    exhaustion for a flow nobody ever tried to validate."""
+    monkeypatch.setattr(validate_flow, "_DEFAULT_BUDGET_SECONDS", 180)
+    monkeypatch.setenv(validate_flow._BUDGET_ENV, raw)
+    assert validate_flow._budget_seconds() == 180
+    # Junk is announced; simply being unset is not worth a line of noise.
+    assert ("ignoring" in capsys.readouterr().err) == bool(raw.strip())
+
+
+def test_harness_budget_reaches_the_attempt_caps(monkeypatch):
+    calls = _stub(monkeypatch, [_timeout(), _timeout()])
+    monkeypatch.setenv(validate_flow._BUDGET_ENV, str(_BUDGET))
+    validate_flow.main()
+    assert calls["overruns"] == []

--- a/tests/tasks/uipath-maestro-flow/_shared/test_validate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_validate_flow.py
@@ -1,0 +1,192 @@
+"""Unit tests for validate_flow.py's timeout budget and retry.
+
+`uip maestro flow validate` refreshes the node manifest from the tenant on every
+invocation, so its wall time is bimodal: ~8-14s typical, 60-67s on the tail.
+Before this budget existed the harness kill was the only guard, and
+``coder_eval/sandbox.py`` discards partial stdout on timeout — so a stalled
+validate reported ``exit -1`` with an empty stdout and read like a broken flow.
+skill-flow-feet-inches failed that way on a flow that validates clean.
+
+These pin the behavior that replaced it: a stall is retried and then reported
+readably, a real fault is not retried, and no attempt outlives the criterion
+budget. Faked at ``subprocess.run`` like :mod:`test_flow_check`, so nothing here
+needs a tenant, a real ``uip``, or wall-clock sleeping.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import validate_flow  # noqa: E402
+
+# Scaled down from the shipped 180/20/30 so the arithmetic stays checkable by
+# hand: 6s usable, so attempt 1 caps at 3.0s and its retry at what is left.
+_BUDGET = 8
+_HEADROOM = 2
+_MIN_ATTEMPT = 1
+
+
+def _cp(returncode, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=["uip", "maestro", "flow", "validate"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _timeout(stdout=b"partial", stderr=b"stub stderr"):
+    return subprocess.TimeoutExpired(
+        cmd=["uip", "maestro", "flow", "validate"],
+        timeout=1,
+        output=stdout,
+        stderr=stderr,
+    )
+
+
+def _stub(monkeypatch, results, *, flows=("a.flow",)):
+    """Feed validate_flow a queue of results, stub discovery, sleep, and glob.
+
+    A queued ``BaseException`` is raised rather than returned, which is how the
+    ``subprocess.TimeoutExpired`` path is exercised.
+
+    ``time.monotonic`` is replaced by a counter the fake ``subprocess.run``
+    advances: a stalled attempt burns its whole cap, a returning one costs
+    almost nothing. Without that the budget never appears to shrink — real
+    attempts consume wall time and faked ones do not — and every deadline
+    assertion here would pass vacuously.
+
+    ``calls["deadline"]`` is what :func:`validate_flow.main` will compute, so
+    tests can assert no attempt was ever allowed to run past it."""
+    calls = {"n": 0, "timeouts": [], "flows": [], "clock": 0.0, "overruns": []}
+    queue = list(results)
+
+    monkeypatch.setattr(validate_flow, "find_project_dir", lambda: "/tmp/proj")
+    monkeypatch.setattr(validate_flow.glob, "glob", lambda *a, **k: list(flows))
+    monkeypatch.setattr(validate_flow.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(validate_flow.time, "monotonic", lambda: calls["clock"])
+    monkeypatch.setattr(validate_flow, "_CRITERION_BUDGET_SECONDS", _BUDGET)
+    monkeypatch.setattr(validate_flow, "_BUDGET_HEADROOM_SECONDS", _HEADROOM)
+    monkeypatch.setattr(validate_flow, "_MIN_ATTEMPT_SECONDS", _MIN_ATTEMPT)
+    calls["deadline"] = float(_BUDGET - _HEADROOM)
+
+    def fake_run(cmd, **kwargs):
+        calls["n"] += 1
+        timeout = kwargs.get("timeout")
+        calls["timeouts"].append(timeout)
+        calls["flows"].append(cmd[4])
+        if calls["clock"] + timeout > calls["deadline"]:
+            calls["overruns"].append((cmd[4], calls["clock"], timeout))
+        result = queue.pop(0)
+        if isinstance(result, BaseException):
+            calls["clock"] += timeout  # the stall ran out its cap
+            raise result
+        calls["clock"] += 0.1
+        return result
+
+    monkeypatch.setattr(validate_flow.subprocess, "run", fake_run)
+    return calls
+
+
+def test_valid_flow_exits_zero(monkeypatch, capsys):
+    calls = _stub(monkeypatch, [_cp(0, '{"Data":{"Status":"Valid"}}')])
+    assert validate_flow.main() == 0
+    assert calls["n"] == 1
+    assert '"Valid"' in capsys.readouterr().out
+
+
+def test_stall_is_retried_then_reported_readably(monkeypatch, capsys):
+    """The failure mode this module exists for: the report must name the file,
+    surface the CLI's partial output, and say the flow may still be valid."""
+    calls = _stub(monkeypatch, [_timeout(), _timeout()])
+
+    assert validate_flow.main() == 1
+    assert calls["n"] == 2
+
+    err = capsys.readouterr().err
+    assert "attempt 1/2" in err and "attempt 2/2" in err
+    assert "a.flow" in err
+    assert "partial" in err  # TimeoutExpired hands output back as bytes
+    assert "may well be valid" in err
+
+
+def test_stall_then_success_exits_zero(monkeypatch):
+    """One stalled manifest fetch must not fail a flow the retry validates."""
+    calls = _stub(monkeypatch, [_timeout(), _cp(0, '{"Data":{"Status":"Valid"}}')])
+    assert validate_flow.main() == 0
+    assert calls["n"] == 2
+
+
+def test_invalid_flow_fails_without_retry(monkeypatch, capsys):
+    """A schema or graph fault reproduces exactly, so retrying it only burns
+    budget that a genuinely stalled file may need."""
+    calls = _stub(monkeypatch, [_cp(1, '{"Result":"Failure"}')])
+    assert validate_flow.main() == 1
+    assert calls["n"] == 1
+    assert '"Failure"' in capsys.readouterr().out
+
+
+def test_every_flow_file_is_validated(monkeypatch):
+    calls = _stub(
+        monkeypatch,
+        [_cp(0), _cp(0)],
+        flows=("a.flow", "b.flow"),
+    )
+    assert validate_flow.main() == 0
+    assert calls["flows"] == ["a.flow", "b.flow"]
+
+
+def test_one_bad_file_fails_the_run(monkeypatch):
+    calls = _stub(monkeypatch, [_cp(0), _cp(1)], flows=("a.flow", "b.flow"))
+    assert validate_flow.main() == 1
+    assert calls["n"] == 2
+
+
+def test_budget_exhaustion_reports_instead_of_running(monkeypatch, capsys):
+    """When an earlier file consumed the budget, the next one must say so rather
+    than start an attempt the harness would SIGKILL mid-flight."""
+    # Only two runs queued: a.flow's two stalled attempts spend the whole
+    # budget, so a third call would pop an empty queue and fail this test.
+    calls = _stub(monkeypatch, [_timeout(), _timeout()], flows=("a.flow", "b.flow"))
+
+    assert validate_flow.main() == 1
+    assert calls["flows"] == ["a.flow", "a.flow"]  # b.flow never ran
+
+    err = capsys.readouterr().err
+    assert "budget exhausted" in err
+    assert "b.flow" in err
+    assert "-0s left" not in err  # negative remainder is clamped for display
+
+
+def test_no_flow_file_fails(monkeypatch, capsys):
+    _stub(monkeypatch, [], flows=())
+    assert validate_flow.main() == 1
+    assert "No .flow file found" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "remaining, attempts_left, expected",
+    [
+        (160.0, 2, 80.0),  # first of two attempts gets half, leaving room to retry
+        (75.0, 1, 75.0),  # last attempt may spend everything left
+        (0.5, 2, _MIN_ATTEMPT),  # never below the floor
+    ],
+)
+def test_attempt_cap_leaves_room_for_the_retry(
+    monkeypatch, remaining, attempts_left, expected
+):
+    monkeypatch.setattr(validate_flow, "_MIN_ATTEMPT_SECONDS", _MIN_ATTEMPT)
+    assert validate_flow._attempt_cap(remaining, attempts_left) == expected
+
+
+def test_no_attempt_outlives_the_budget(monkeypatch):
+    """No attempt may be allowed to run past the deadline, or the harness kill
+    beats this module to the failure and the diagnostic is lost again."""
+    calls = _stub(monkeypatch, [_timeout(), _timeout()])
+    validate_flow.main()
+    assert calls["overruns"] == []
+    assert sum(calls["timeouts"]) <= _BUDGET - _HEADROOM

--- a/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
@@ -38,10 +38,15 @@ import time
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from flow_check import find_project_dir  # noqa: E402
 
-# The criterion budget every task YAML gives this script. Kept in sync by hand;
-# there is no harness channel that exposes a criterion's timeout to the command
-# it runs.
-_CRITERION_BUDGET_SECONDS = 180
+# The criterion budget to self-terminate inside. coder_eval exports only
+# TASK_DIR to a criterion's command, not the criterion's own timeout, so there
+# is nothing authoritative to read yet — :data:`_BUDGET_ENV` is the proposed
+# contract and stays inert until the harness sets it, at which point this needs
+# no change. Until then the default mirrors the task YAMLs by hand, and
+# :func:`_budget_seconds` announces what it resolved so a drift shows up in the
+# criterion output instead of silently costing the retry.
+_BUDGET_ENV = "CODER_EVAL_COMMAND_TIMEOUT"
+_DEFAULT_BUDGET_SECONDS = 180
 
 # Reserved for interpreter start, project discovery, and writing the failure
 # message. Without it the last attempt can end exactly as the harness fires.
@@ -64,6 +69,29 @@ _BACKOFF_SECONDS = 5.0
 _MIN_ATTEMPT_SECONDS = 30
 
 
+def _budget_seconds() -> int:
+    """The criterion budget, from the harness if it says, else the default.
+
+    A malformed or non-positive value is treated as absent rather than trusted:
+    a zero budget would refuse every attempt and report exhaustion for a flow
+    nobody ever tried to validate.
+    """
+    raw = os.environ.get(_BUDGET_ENV, "").strip()
+    try:
+        budget = int(float(raw))
+    except ValueError:
+        budget = 0
+    if budget <= 0:
+        if raw:
+            print(
+                f"note: ignoring {_BUDGET_ENV}={raw!r}; using "
+                f"{_DEFAULT_BUDGET_SECONDS}s",
+                file=sys.stderr,
+            )
+        return _DEFAULT_BUDGET_SECONDS
+    return budget
+
+
 def _as_text(raw: bytes | str | None) -> str:
     """Decode captured child output. ``subprocess.TimeoutExpired`` carries it as
     bytes even under ``text=True``, unlike ``CompletedProcess``."""
@@ -83,7 +111,7 @@ def _attempt_cap(remaining: float, attempts_left: int) -> float:
     return max(_MIN_ATTEMPT_SECONDS, remaining / attempts_left)
 
 
-def _validate(flow: str, deadline: float) -> int:
+def _validate(flow: str, deadline: float, budget: int) -> int:
     """Validate one ``.flow``, retrying a stalled attempt. Returns its exit code.
 
     A non-zero exit is never retried: `flow validate` fails on schema and graph
@@ -94,7 +122,7 @@ def _validate(flow: str, deadline: float) -> int:
         remaining = deadline - time.monotonic()
         if remaining < _MIN_ATTEMPT_SECONDS:
             print(
-                f"FAIL: {flow} — {_CRITERION_BUDGET_SECONDS}s criterion budget "
+                f"FAIL: {flow} — {budget}s criterion budget "
                 f"exhausted before attempt {attempt} ({max(0.0, remaining):.0f}s left)",
                 file=sys.stderr,
             )
@@ -117,7 +145,7 @@ def _validate(flow: str, deadline: float) -> int:
             if attempt == _ATTEMPTS:
                 print(
                     f"FAIL: {flow} did not validate within "
-                    f"{_CRITERION_BUDGET_SECONDS}s across {_ATTEMPTS} attempts. "
+                    f"{budget}s across {_ATTEMPTS} attempts. "
                     "The flow file itself may well be valid — this is the CLI's "
                     "manifest fetch, not a schema fault.\n"
                     f"stdout: {_as_text(exc.stdout)}\n"
@@ -142,8 +170,9 @@ def main() -> int:
         print(f"FAIL: No .flow file found under {project_dir}", file=sys.stderr)
         return 1
 
-    deadline = time.monotonic() + (
-        _CRITERION_BUDGET_SECONDS - _BUDGET_HEADROOM_SECONDS
+    budget = _budget_seconds()
+    deadline = time.monotonic() + max(
+        _MIN_ATTEMPT_SECONDS, budget - _BUDGET_HEADROOM_SECONDS
     )
 
     rc = 0
@@ -151,7 +180,7 @@ def main() -> int:
         # Flushed: on an overrun the harness discards this process's buffered
         # stdout, and this line is what names the file that stalled.
         print(f"Validating {flow}", flush=True)
-        code = _validate(flow, deadline)
+        code = _validate(flow, deadline, budget)
         if code != 0:
             rc = code or 1
     return rc

--- a/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
@@ -17,6 +17,14 @@ Discovery mirrors the ``check_*.py`` execution checks: find the lone
 ``project.uiproj`` whose manifest declares ``ProjectType="Flow"`` (via
 :func:`flow_check.find_project_dir`), then validate every ``.flow`` file under
 it. Exit 0 iff every file validates; otherwise propagate the failing exit code.
+
+Timeouts are budgeted here rather than left to the harness. ``flow validate``
+refreshes the node manifest from the tenant on every invocation, so its wall
+time is network-bound and bimodal — see :data:`_ATTEMPTS`. Left unbudgeted, a
+stall runs past the criterion timeout, the harness SIGKILLs the shell, and the
+report shows exit -1 with an empty stdout: no indication of which file stalled,
+or that the flow itself was fine. This module self-terminates inside the
+criterion budget instead, with a diagnosable message.
 """
 
 from __future__ import annotations
@@ -25,9 +33,106 @@ import glob
 import os
 import subprocess
 import sys
+import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from flow_check import find_project_dir  # noqa: E402
+
+# The criterion budget every task YAML gives this script. Kept in sync by hand;
+# there is no harness channel that exposes a criterion's timeout to the command
+# it runs.
+_CRITERION_BUDGET_SECONDS = 180
+
+# Reserved for interpreter start, project discovery, and writing the failure
+# message. Without it the last attempt can end exactly as the harness fires.
+_BUDGET_HEADROOM_SECONDS = 20
+
+# `flow validate` has no `--timeout` flag of its own — unlike `flow debug`,
+# which self-terminates with a parseable envelope. The subprocess cap is the
+# only guard, so an overrun is reported from here.
+#
+# Two attempts, not three: the stall is a hung tenant manifest fetch inside
+# `ManifestClient.getManifest` (~3.3k dynamic nodes, measured 8-14s typical and
+# 60-67s on the tail), and a second cold call clears it. A third would only eat
+# budget that the first two already need.
+_ATTEMPTS = 2
+_BACKOFF_SECONDS = 5.0
+
+# Below this an attempt cannot outlast even a typical manifest fetch, so
+# spending the remaining budget on it just converts a readable timeout into a
+# misleading one.
+_MIN_ATTEMPT_SECONDS = 30
+
+
+def _as_text(raw: bytes | str | None) -> str:
+    """Decode captured child output. ``subprocess.TimeoutExpired`` carries it as
+    bytes even under ``text=True``, unlike ``CompletedProcess``."""
+    if raw is None:
+        return ""
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return raw
+
+
+def _attempt_cap(remaining: float, attempts_left: int) -> float:
+    """Seconds to allow one attempt, so the retries after it still fit.
+
+    Splitting what is left rather than pre-dividing the budget per file lets a
+    fast file hand its unused share to a slow one.
+    """
+    return max(_MIN_ATTEMPT_SECONDS, remaining / attempts_left)
+
+
+def _validate(flow: str, deadline: float) -> int:
+    """Validate one ``.flow``, retrying a stalled attempt. Returns its exit code.
+
+    A non-zero exit is never retried: `flow validate` fails on schema and graph
+    faults, which a second run reproduces exactly. Only a subprocess timeout —
+    the hung manifest fetch — is worth another attempt.
+    """
+    for attempt in range(1, _ATTEMPTS + 1):
+        remaining = deadline - time.monotonic()
+        if remaining < _MIN_ATTEMPT_SECONDS:
+            print(
+                f"FAIL: {flow} — {_CRITERION_BUDGET_SECONDS}s criterion budget "
+                f"exhausted before attempt {attempt} ({max(0.0, remaining):.0f}s left)",
+                file=sys.stderr,
+            )
+            return 1
+
+        try:
+            result = subprocess.run(
+                ["uip", "maestro", "flow", "validate", flow, "--output", "json"],
+                capture_output=True,
+                text=True,
+                timeout=_attempt_cap(remaining, _ATTEMPTS - attempt + 1),
+            )
+        except subprocess.TimeoutExpired as exc:
+            cap = _attempt_cap(remaining, _ATTEMPTS - attempt + 1)
+            print(
+                f"attempt {attempt}/{_ATTEMPTS} on {flow} exceeded {cap:.0f}s "
+                "(tenant node-manifest refresh stalled)",
+                file=sys.stderr,
+            )
+            if attempt == _ATTEMPTS:
+                print(
+                    f"FAIL: {flow} did not validate within "
+                    f"{_CRITERION_BUDGET_SECONDS}s across {_ATTEMPTS} attempts. "
+                    "The flow file itself may well be valid — this is the CLI's "
+                    "manifest fetch, not a schema fault.\n"
+                    f"stdout: {_as_text(exc.stdout)}\n"
+                    f"stderr: {_as_text(exc.stderr)}",
+                    file=sys.stderr,
+                )
+                return 1
+            time.sleep(_BACKOFF_SECONDS)
+            continue
+
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        return result.returncode
+
+    return 1  # unreachable; keeps the return type honest
 
 
 def main() -> int:
@@ -37,18 +142,18 @@ def main() -> int:
         print(f"FAIL: No .flow file found under {project_dir}", file=sys.stderr)
         return 1
 
+    deadline = time.monotonic() + (
+        _CRITERION_BUDGET_SECONDS - _BUDGET_HEADROOM_SECONDS
+    )
+
     rc = 0
     for flow in flows:
-        print(f"Validating {flow}")
-        result = subprocess.run(
-            ["uip", "maestro", "flow", "validate", flow, "--output", "json"],
-            capture_output=True,
-            text=True,
-        )
-        sys.stdout.write(result.stdout)
-        sys.stderr.write(result.stderr)
-        if result.returncode != 0:
-            rc = result.returncode or 1
+        # Flushed: on an overrun the harness discards this process's buffered
+        # stdout, and this line is what names the file that stalled.
+        print(f"Validating {flow}", flush=True)
+        code = _validate(flow, deadline)
+        if code != 0:
+            rc = code or 1
     return rc
 
 


### PR DESCRIPTION
Follow-up to #2853. Stacked behind it, but safe to merge in either order.

## Problem

`_shared/validate_flow.py` passed no `timeout=` to `subprocess.run` and had no retry, so the harness kill was the only guard. On overrun `coder_eval/sandbox.py` returns `(-1, "", err)` and **discards partial stdout**:

```
Command: python3 $SKILLS_REPO_PATH/.../validate_flow.py
Exit code: -1 (expected: 0)
Stdout: (empty)
Stderr: Command '...' timed out after 30 seconds
```

That report tells you nothing. Not which `.flow` stalled, not that the script had already printed `Validating <path>`, and not that the flow itself was fine. It reads like a broken flow.

It was not. `skill-flow-feet-inches` scored **0.769 / FAILURE** on exactly this: criterion 1 killed at 30s, both debug criteria passed, and the preserved artifact validates clean when run by hand. The same run's agent had validated the identical file in 3.12s.

`flow validate` refreshes the node manifest from the tenant on **every** invocation — `flow-tool` hardcodes `validateCurrentManifests: true`, which reaches `ManifestClient.getManifest()` for ~3.3k dynamic nodes. Wall time is network-bound and bimodal. 13 measured runs on one valid, unchanged flow:

| | seconds |
|---|---|
| typical | 8.3, 8.6, 9, 10.6, 11.2, 12.2, 12.6, 12.8, 14 |
| tail | **60.7, 61.4, 67.2** |

## Change

Budget the work in the script rather than leaving it to the harness kill.

- **Wall-clock deadline** from the criterion budget less headroom, shared across every `.flow` under the project.
- **Two attempts per file**, each capped at a share of what is left, so a fast file hands its unused share to a slow one instead of the budget being pre-divided.
- **Retry a stall, never a fault.** A subprocess timeout is the hung manifest fetch and gets one more try after 5s backoff. A non-zero exit is a schema or graph fault that a second run reproduces exactly, so it propagates immediately without burning budget.
- **Readable overrun.** Names the file, the cap it blew, the CLI's partial stdout and stderr, and says plainly that the flow may be valid and this is the manifest fetch.
- `Validating <path>` is now flushed, since that line is what identifies the stalling file if this process is killed anyway.

Mirrors `flow_check.run_debug`, which already caps its subprocess, retries transient faults, and fails real ones immediately. One difference is load-bearing: `flow validate` has **no `--timeout` flag**, so unlike `debug` it cannot self-terminate with a parseable envelope. The subprocess cap is the only guard and the diagnostic has to be written here.

## Verification

Against the preserved `skill-flow-feet-inches` artifact:

```
$ python3 validate_flow.py
Validating FeetInches/FeetInches/FeetInches.flow
{"Result": "Success", "Code": "FlowValidate", "Data": {"Status": "Valid"}}
rc=0, 8.8s
```

Failure paths, driven with a stubbed `uip` on PATH and the constants scaled down so a stall is observable in seconds:

| Case | Result |
|---|---|
| stalled validate | 2 attempts (6s, 5s), self-terminated at **12.0s inside a 14s budget**, partial stdout preserved |
| invalid flow | exit 1 at **0.0s**, no retry burned, CLI message propagated |
| two files, both stall | first consumes budget; second reports `criterion budget exhausted` instead of hanging; total stays inside budget |
| two files, both valid | both validated, exit 0 |

Sample of the stall output, which is the whole point of the change:

```
attempt 1/2 on FeetInches/FeetInches/FeetInches.flow exceeded 6s (tenant node-manifest refresh stalled)
attempt 2/2 on FeetInches/FeetInches/FeetInches.flow exceeded 5s (tenant node-manifest refresh stalled)
FAIL: FeetInches/FeetInches/FeetInches.flow did not validate within 14s across 2 attempts.
The flow file itself may well be valid — this is the CLI's manifest fetch, not a schema fault.
stdout: partial stdout before the stall
```

Existing suite: `pytest tests/tasks/uipath-maestro-flow/` — **207 passed**, now **227** with the new tests.

## Tests

`_shared/test_validate_flow.py`, 20 tests, faked at `subprocess.run` like `test_flow_check`'s `_stub_debug` — no tenant, no real `uip`, no wall-clock sleeping, 0.02s.

One addition to that pattern is load-bearing: `time.monotonic` is a counter the fake advances by an attempt's cap when it stalls. Real attempts consume wall time and faked ones do not, so without it the remaining budget never appears to shrink and every deadline assertion passes vacuously. That is not hypothetical — the first draft did exactly that, asserting a cap sum of 9s against a 6s budget, and failed correctly.

**Mutation-checked rather than assumed to bite:**

| Mutation | Tests that failed |
|---|---|
| `_ATTEMPTS = 1` (no retry) | both stall tests + budget exhaustion |
| `_attempt_cap` ignores `attempts_left` | those three + cap arithmetic |
| retry on non-zero exit | both real-fault tests |

Running the new tests against the pre-change module fails all 12, though on harness setup rather than assertions, since the old module has neither `time` nor the constants. The mutation table above is the real evidence that the assertions bind.

## Where the budget comes from

The first draft hardcoded `_CRITERION_BUDGET_SECONDS = 180`, duplicating the task YAMLs in a second file with nothing tying them together. That is a silent-drift trap: whoever edits a criterion's `timeout:` has no reason to know this file exists, and if it ends up too high the harness kill beats the diagnostic — the exact failure this module exists to prevent.

`coder_eval`'s `_build_run_command_env` enumerates what a criterion's command gets: PATH layers, `NODE_PATH`, `NPM_CONFIG_PREFIX`, `PLUGIN_TOOLS_DIR`, and `TASK_DIR`. A criterion's own timeout is not there, so nothing authoritative exists to read.

So this reads `CODER_EVAL_COMMAND_TIMEOUT` as the proposed contract — inert until the harness sets it, and needing no change here when it does — with the default carrying the value meanwhile. A junk or non-positive setting is announced and ignored rather than trusted, since a zero budget would refuse every attempt and report exhaustion for a flow nobody ever tried to validate.

**This narrows the coupling, it does not remove it.** The removal is upstream and is one line beside the existing `TASK_DIR` export:

```python
if timeout is not None:
    env["CODER_EVAL_COMMAND_TIMEOUT"] = str(timeout)
```

Happy to raise that against `coder_eval` if you want it; then the default here becomes dead weight and can go.

## Interaction with #2853

`_DEFAULT_BUDGET_SECONDS = 180` is what #2853 sets those YAMLs to.

Merged **after** #2853, this works as described. Merged **before**, behavior is unchanged rather than worse: the YAMLs still say 30, so the outer kill fires first and you get today's opaque failure. No regression either way, but the benefit only lands once both are in.

## Still open upstream

Two, in priority order.

**1. `coder_eval` discards partial output on timeout.** `sandbox.py`'s handler returns `(-1, "", err)`, throwing away the `exc.stdout` that Python already collected. Surfacing it would fix the empty-stdout blindness for *every* `run_command` criterion in the repo, not just this one, and is strictly more valuable than what this PR does. This PR works around that; it does not fix it.

**2. The CLI itself.** Add a request timeout inside `ManifestClient.getManifest` so a stall degrades to the warn-and-continue path that already exists (`"Could not load current OOTB node manifests; skipping stale-handle validation"`), or make the refresh cache-backed against `~/.uipath/maestro/registry.json`. Schema validity should not need a tenant round trip. Once that ships, both this budget and #2853's can come down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


