### PR TITLE
test(maestro-flow): outcome-graded DevCon billing-invoice-lookup e2e task

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/billing_invoice_lookup_outcome/billing_invoice_lookup_outcome.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/billing_invoice_lookup_outcome/billing_invoice_lookup_outcome.yaml
@@ -1,0 +1,67 @@
+task_id: skill-flow-e2e-billing-invoice-lookup-outcome
+description: >
+  End-to-end, outcome-based build of the DevCon billing-invoice-lookup scenario
+  (Jiyang's BillingInvoiceLookup). The agent builds + validates a ~4-node Flow
+  that normalizes a messy invoice number and queries the BillingDisputeERP Data
+  Service entity. The grader runs `uip maestro flow debug` itself over three
+  malformed invoice-number forms and verifies the OUTCOME: each resolves, via a
+  real Data Service query, to invoice MCS-2026-04872 with 8 line items. Grades
+  the delivered runtime result, not "did it validate".
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node, connector, path-to-ga, outcome-graded]
+
+run_limits:
+  max_turns: 120
+  turn_timeout: 2400
+  task_timeout: 3600
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 90
+
+initial_prompt: |
+  Build a Maestro Flow "BillingInvoiceLookupOutcome" (in a solution of the same
+  name) that looks up a disputed invoice's line items, tolerating messy input.
+
+  - Input: trigger variable `invoiceNumber` (string). Callers may omit the
+    "MCS-" prefix, use wrong casing, or add whitespace.
+  - Normalize the input (trim, uppercase, prepend `MCS-` if absent), then look
+    up the matching rows in the existing `BillingDisputeERP` Data Service
+    entity.
+  - Outputs: `matchedInvoiceNumber` (string, first matched row's invoiceNumber)
+    and `lineItemCount` (number of rows returned).
+
+  Validate the final flow file — the task is not complete until `uip maestro
+  flow validate` passes. Grading then runs the flow under debug against live
+  tenant data, so build it to actually run, not merely validate. Do not run
+  debug yourself.
+
+  Build the complete flow
+  without stopping to ask me.
+
+success_criteria:
+  # ── Convention adherence: the agent validated the flow (advisory) ────────
+  - type: command_executed
+    description: "Agent validated the generated Flow"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # ── The delivered flow validates ────────────────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate BillingInvoiceLookupOutcome/BillingInvoiceLookupOutcome/BillingInvoiceLookupOutcome.flow --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── OUTCOME: three malformed inputs each resolve via a real Data Service query
+  - type: run_command
+    description: "Debug run over three malformed inputs: each resolves to MCS-2026-04872 with 8 line items via a real Data Service query"
+    command: "python3 $TASK_DIR/check_billing_invoice_lookup_outcome.py"
+    timeout: 600
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/billing_invoice_lookup_outcome/check_billing_invoice_lookup_outcome.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/billing_invoice_lookup_outcome/check_billing_invoice_lookup_outcome.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""BillingInvoiceLookupOutcome (DevCon billing scenario, outcome-graded).
+
+The agent builds + validates only; this check runs `uip maestro flow debug`
+itself for three malformed invoice-number forms and asserts each resolves, via
+a real Data Service query, to invoice MCS-2026-04872 with 8 line items.
+
+The flow normalizes a raw `invoiceNumber` (trim, uppercase, ensure the "MCS-"
+prefix) and queries the seeded `BillingDisputeERP` entity. A Data Service query
+node is required (anti-hardcode): you cannot fake `lineItemCount == 8` for three
+different inputs without actually querying. The seeded invoice has exactly 8
+line items, so the count is a deterministic oracle.
+"""
+import os
+import sys
+
+# Walk up to the skill's tests root (the dir holding the _shared package) so
+# this resolves regardless of how deeply the task is nested under tests/tasks/.
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
+    assert_output_value,
+    find_project_dir,
+    read_flow_input_vars,
+    run_debug,
+)
+
+EXPECTED_INVOICE = "MCS-2026-04872"
+EXPECTED_LINE_COUNT = 8
+
+# raw input form the caller might send -> human label for failure messages
+CASES = [
+    ("2026-04872", "missing MCS- prefix"),
+    ("mcs-2026-04872", "wrong casing"),
+    (" MCS-2026-04872", "leading whitespace"),
+]
+
+
+def main():
+    # Must actually query Data Service — blocks hardcoding the answer, which
+    # would otherwise pass since all three cases expect the same output.
+    assert_flow_has_node_type(["uipath-dataservice.query"])
+
+    in_vars = read_flow_input_vars(find_project_dir())
+    if not in_vars:
+        sys.exit("FAIL: flow declares no input variable for the invoice number")
+    var = in_vars[0]
+
+    for raw, label in CASES:
+        inputs = {var: raw}
+        print(f"[{label}] debug inputs: {inputs}")
+        payload = run_debug(inputs=inputs, timeout=180)
+        assert_output_value(payload, EXPECTED_INVOICE)
+        assert_output_value(payload, EXPECTED_LINE_COUNT)
+        print(f"OK: [{label}] -> {EXPECTED_INVOICE}, {EXPECTED_LINE_COUNT} line items")
+
+    print(f"OK: all {len(CASES)} malformed forms normalized and queried correctly")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds one **outcome-based** e2e task for `uipath-maestro-flow`, derived from Jiyang's DevCon **BillingInvoiceLookup** scenario (prompt reused near-verbatim), to grow our outcome-graded Flow coverage.

- **Prompt (DevCon scenario):** build `BillingInvoiceLookupOutcome` — normalize a messy `invoiceNumber` (trim, uppercase, prepend `MCS-`) and query the `BillingDisputeERP` Data Service entity; return `matchedInvoiceNumber` + `lineItemCount`.
- **Graded on outcome, not structure:** the agent builds + validates only; the checker runs `uip maestro flow debug` itself over three malformed inputs (missing prefix, wrong casing, leading whitespace) and asserts each resolves — via a **real Data Service query** — to `MCS-2026-04872` with **8 line items**. A required `uipath-dataservice.query` node + deterministic 8-line oracle block hardcoding.
- **Tags:** standardized outcome markers `path-to-ga`, `outcome-graded`.
- Registers `outcome-graded` in the `tests/README.md` tag taxonomy as a flat boolean marker.

## Success criteria
1. `command_executed` (advisory, 1.5) — agent validated the flow
2. `run_command` (3.0) — `flow validate` passes
3. `run_command` (5.0) — outcome checker: 3 malformed inputs each → `MCS-2026-04872`, 8 line items

## Validation
Dispatching `run-coder-eval.yml` from this branch to confirm the task passes end-to-end (agent build + validate + debug outcome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
