### PR TITLE
test(maestro-flow): outcome-graded live-Jira create-issue e2e task

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -107,6 +107,7 @@ Tags drive `make` targets, coverage reports, and evalboard drilldown. The `tags:
 | **connector** | flat, present iff applicable | Marks tasks that use any IS connector. The specific connector is in the YAML body / file path. |
 | **windows** | flat, present iff applicable | Marks tasks that require a Windows host (e.g. RPA `.xaml`/`.cs` projects that need Studio Helm). Used by `smoke-rpa-skills.yml` to route the task to a `windows-latest` runner; Linux/macOS smoke runs skip it. |
 | **path-to-ga** | flat, optional | Marks exhaustive, difficult, currently blocked, or historically fragile tasks that represent must-pass scenarios on the path to GA. | `path-to-ga` |
+| **outcome-graded** | flat, optional | Marks tasks whose primary criterion grades a delivered runtime outcome — the flow runs under `flow debug` and the checker asserts real returned values / side effects — rather than static structure. | `outcome-graded` |
 | **feature** | `feature:X`, repeatable | Cross-cutting capability orthogonal to node/resource/connector. Closed vocabulary: `http`, `trigger`, `registry`, `transform`, `eval`, `approval-gate`, `write-back`, `escalation`, `connections`, `activities`, `records`, `entities`, `api-workflow`, `compliance`, `test-case`, `hooks`, `conversational`. Do not invent leaf names like `feature:ceql-where` or directory-name markers like `feature:connector-feature` — those duplicate the file path. |
 
 ### Rules
@@ -114,7 +115,7 @@ Tags drive `make` targets, coverage reports, and evalboard drilldown. The `tags:
 1. **Required on every task: `skill` + `tier` + `mode:*` + `lifecycle:*`.** These drive `make` targets, coverage, and evalboard dashboards.
 2. **One value per singular dimension** (`tier`, `mode`, `shape`). A task doesn't have two tiers.
 3. **`node:` and `feature:` are repeatable.** A flow exercising decision and switch nodes gets both `node:decision` and `node:switch`.
-4. **`connector`, `resource`, `windows`, and `path-to-ga` are flat boolean markers**, not enumerations. Use them once per task; the specific connector/resource is identifiable from the file path, `task_id`, or YAML body. Adding `connector:slack` etc. is no longer the convention.
+4. **`connector`, `resource`, `windows`, `path-to-ga`, and `outcome-graded` are flat boolean markers**, not enumerations. Use them once per task; the specific connector/resource is identifiable from the file path, `task_id`, or YAML body. Adding `connector:slack` etc. is no longer the convention.
 5. **Use only the vocabularies above.** Propose new values in the PR — do not invent tags inline. New values should apply to at least two tasks in practice.
 6. **Don't repeat the skill name as a feature tag.** Don't tag a flow task with `rpa` (bare) or `uipath-rpa` as a feature.
 

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue_outcome/check_jira_create_issue_outcome.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue_outcome/check_jira_create_issue_outcome.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""JiraCreateIssueOutcome: structural + live + tenant checks (outcome-graded).
+
+Exits non-zero on the first failure (``FAIL: ...``); prints ``OK: ...`` per check.
+
+  1. A ``.flow`` file is valid JSON referencing the ``uipath-atlassian-jira``
+     connector.
+  2. LIVE: ``flow debug`` runs to ``Completed`` (this creates a real Jira issue)
+     and produces an issue key in its outputs.
+  3. TENANT: re-reading that key via ``curated_get_issue`` returns the seeded
+     summary — proof the flow hit Jira rather than fabricating an output.
+
+The confirmed key is recorded to ``.created_keys`` so post_run teardown deletes
+it even if a later step fails.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)  # local jira_is
+sys.path.insert(0, os.path.dirname(os.path.dirname(HERE)))  # …/uipath-maestro-flow (for _shared)
+from _shared.flow_check import collect_outputs, get_last_debug_raw, run_debug  # noqa: E402
+import jira_is  # noqa: E402
+
+JIRA_KEY = "uipath-atlassian-jira"
+ISSUE_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]*-\d+$")
+
+
+def _fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def main() -> None:
+    seed = json.loads(Path("seed.json").read_text())
+
+    flows = glob.glob("**/*.flow", recursive=True)
+    raw = next((r for p in flows for r in [open(p, encoding="utf-8").read()]
+                if JIRA_KEY in r and '"nodes"' in r), None)
+    if raw is None:
+        _fail(f"no .flow references the {JIRA_KEY} connector (found {flows})")
+    print(f"OK: flow references {JIRA_KEY}")
+
+    payload = run_debug(timeout=480)
+    print("OK: flow debug completed")
+
+    # Candidate issue keys: clean output leaves + a project-scoped scan of the
+    # raw debug payload (covers a key buried in a nested response blob).
+    project = seed["project_key"]
+    cands = [s for leaf in collect_outputs(payload) for s in [str(leaf).strip()] if ISSUE_KEY_RE.match(s)]
+    cands += re.findall(rf"\b{re.escape(project)}-\d+\b", get_last_debug_raw() or "")
+    cands = list(dict.fromkeys(cands))  # de-dup, keep order
+    if not cands:
+        _fail(f"no issue key (e.g. {project}-123) in flow debug outputs")
+    print(f"OK: candidate keys from debug: {cands}")
+
+    conn = jira_is.connection_id()
+    for key in cands:
+        fields = jira_is.get_issue(conn, key)
+        if fields and fields.get("summary") == seed["summary"]:
+            Path(".created_keys").write_text(key + "\n")  # for teardown
+            print(f"OK: Jira issue {key} exists with the seed summary")
+            print("PASS: all JiraCreateIssueOutcome checks passed")
+            return
+    _fail(
+        f"none of {cands} carries the seed summary {seed['summary']!r} — the "
+        "flow did not create the expected issue in Jira"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue_outcome/jira_create_issue_outcome.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue_outcome/jira_create_issue_outcome.yaml
@@ -1,0 +1,61 @@
+task_id: skill-flow-e2e-jira-create-issue-outcome
+description: >
+  E2E, outcome-based live Jira coverage — builds a Flow with a manual trigger
+  and an Atlassian Jira "Create Issue" connector node, then grades the delivered
+  third-party OUTCOME: the flow runs against a real Jira sandbox connection
+  (`flow debug`) and the created issue is re-read from the tenant. The
+  project/issue-type/summary come from `seed.json` (unique per run), so the
+  check verifies a real issue was created in Jira carrying the seeded summary,
+  not a fabricated output. The created issue is cleaned up in post_run.
+
+  Tenant prerequisite: a `uipath-atlassian-jira` connection in folder
+  `Shared/uipath-maestro-flow` (currently the single Jira connection there),
+  reaching the `CE` / "Coder Eval" project (issue type Task). Targets live in
+  the task's `jira_is.py`.
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:single-node, connector, uipath-atlassian-jira, ipe, path-to-ga, outcome-graded]
+
+run_limits:
+  expected_turns: 40
+  task_timeout: 1800
+  max_turns: 120
+  turn_timeout: 900
+
+pre_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue_outcome/seed_jira.py"
+    timeout: 60
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue_outcome/teardown_jira.py"
+    timeout: 120
+
+initial_prompt: |
+  Create a new Flow project called "JiraCreateIssueOutcome" with a manual trigger.
+  It should create a Jira issue using the Atlassian Jira "Create Issue"
+  connector activity, and expose the new issue's key as a flow output.
+
+  Read `seed.json` in the current directory for the issue details: use the
+  `project_key`, `issuetype_id`, and `summary` exactly as given (pass the
+  summary verbatim).
+
+  Use the Atlassian Jira connection available in the `Shared/uipath-maestro-flow`
+  folder. If the Atlassian Jira connector isn't available in your registry,
+  stop rather than falling back to a generic HTTP request.
+
+  Validate the final flow file.
+
+success_criteria:
+  - type: command_executed
+    description: "uip maestro flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "JiraCreateIssueOutcome checks: valid flow with Jira Create-Issue node, debug creates a real issue, and the tenant carries the seeded summary"
+    command: "python3 $TASK_DIR/check_jira_create_issue_outcome.py"
+    timeout: 900
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue_outcome/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue_outcome/jira_is.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Minimal live Jira helper for this task — wraps `uip is resources run`.
+
+Self-contained (no shared module). Assumes `uip` is on PATH and logged in and
+that the connection + CE project exist — this is a tenant-gated e2e task.
+
+The connection is scoped to the curated single-record ops, so we create by
+body / get by id / delete by id — never a JQL search.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+CONNECTOR = "uipath-atlassian-jira"
+FOLDER_PATH = "Shared/uipath-maestro-flow"
+CONNECTION_NAME = "is-sandboxes-test@uipath.com-uipath-sandbox-380"
+PROJECT_KEY = "CE"        # "Coder Eval" project on uipath-sandbox-380
+ISSUETYPE_ID = "11457"    # "Task" issue type, scoped to the CE project
+
+
+def _run(*args: str) -> dict:
+    out = subprocess.run(
+        ["uip", *args, "--output", "json"],
+        capture_output=True, text=True, timeout=120,
+    ).stdout
+    return json.loads(out)
+
+
+def connection_id() -> str:
+    folder_key = _run("or", "folders", "get", FOLDER_PATH)["Data"]["Key"]
+    conns = _run("is", "connections", "list", CONNECTOR, "--folder-key", folder_key, "--refresh")["Data"]
+    return next(c["Id"] for c in conns if c["Name"] == CONNECTION_NAME)
+
+
+def create_issue(conn_id: str, summary: str) -> str:
+    body = {"fields": {"project": {"key": PROJECT_KEY}, "issuetype": {"id": ISSUETYPE_ID}, "summary": summary}}
+    return _run(
+        "is", "resources", "run", "create", CONNECTOR, "curated_create_issue",
+        "--connection-id", conn_id, "--body", json.dumps(body),
+    )["Data"]["key"]
+
+
+def get_issue(conn_id: str, key: str) -> dict | None:
+    """Return the issue's `fields` dict, or None if it doesn't exist (404)."""
+    env = _run(
+        "is", "resources", "run", "get", CONNECTOR, "curated_get_issue",
+        "--connection-id", conn_id,
+        "--query", f"project={PROJECT_KEY}&issuetype={ISSUETYPE_ID}&issueId={key}",
+    )
+    if env.get("Result") == "Failure":
+        return None
+    return env["Data"].get("fields", {})
+
+
+def delete_issue(conn_id: str, key: str) -> None:
+    """Delete an issue by key. A 404 (already gone) is a no-op."""
+    _run(
+        "is", "resources", "run", "delete", CONNECTOR, "issue",
+        "--connection-id", conn_id, "--query", f"issueId={key}",
+    )

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue_outcome/seed_jira.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue_outcome/seed_jira.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""pre_run: write seed.json with the create targets (no live issue yet — the
+agent's flow creates it when the check runs `flow debug`). The unique tag in
+the summary lets the check locate this run's issue."""
+
+import json
+import secrets
+from pathlib import Path
+
+import jira_is
+
+tag = secrets.token_hex(4)
+summary = f"coder-eval jira flow e2e {tag}"
+seed = {
+    "tag": tag,
+    "summary": summary,
+    "project_key": jira_is.PROJECT_KEY,
+    "issuetype_id": jira_is.ISSUETYPE_ID,
+}
+Path("seed.json").write_text(json.dumps(seed, indent=2))
+print(f"OK: wrote seed targets (summary={summary!r}, project={jira_is.PROJECT_KEY})")

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue_outcome/teardown_jira.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue_outcome/teardown_jira.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""post_run: delete every issue the run created (keys in `.created_keys`).
+Idempotent and never fails the task."""
+
+import sys
+from pathlib import Path
+
+import jira_is
+
+try:
+    kf = Path(".created_keys")
+    keys = kf.read_text().split() if kf.is_file() else []
+    if keys:
+        conn = jira_is.connection_id()
+        for key in keys:
+            jira_is.delete_issue(conn, key)
+            print(f"OK: deleted {key}")
+    else:
+        print("OK: nothing to delete")
+except Exception as e:  # noqa: BLE001 — teardown must not fail the task
+    print(f"WARN: teardown ignored error: {e}")
+sys.exit(0)


### PR DESCRIPTION
## What

Second **outcome-based** e2e task for `uipath-maestro-flow` — this one grades a real **third-party (Jira)** side effect, per the ask to pick a scenario with a Slack/Jira/external app outcome. Derived from the existing `jira_create_issue` e2e task, promoted to the standardized outcome-graded pattern.

- **Prompt:** build `JiraCreateIssueOutcome` (manual trigger) with the Atlassian Jira **Create Issue** connector node; expose the new issue key as a flow output. Issue details (`project_key`, `issuetype_id`, `summary`) come from a per-run `seed.json`.
- **Graded on the delivered outcome:** the agent builds + validates only; the checker runs `uip maestro flow debug` (which **creates a real issue** in the `CE` sandbox project) and then **re-reads it from the tenant**, asserting the created issue carries the per-run seeded summary — proof the flow actually hit Jira, not a fabricated output.
- **Cleanup:** the created issue is deleted in `post_run` (`teardown_jira.py`, idempotent).
- **Tags:** standardized outcome markers `path-to-ga`, `outcome-graded`.
- Registers `outcome-graded` in the `tests/README.md` tag taxonomy as a flat boolean marker.

## Success criteria
1. `command_executed` (2.0) — agent called `flow validate`
2. `run_command` (5.0) — outcome checker: valid Jira Create-Issue flow → debug creates a real issue → tenant carries the seeded summary

## Tenant prerequisite
A `uipath-atlassian-jira` connection in `Shared/uipath-maestro-flow` reaching the `CE` / "Coder Eval" project (issue type Task). Targets live in `jira_is.py`.

## Validation
Dispatching `run-coder-eval.yml` from this branch to confirm the task passes end-to-end (agent build + validate + real Jira create + tenant read-back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
