### PR TITLE
test(maestro-flow): outcome-graded DevCon billing-dispute Slack-alert e2e task

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/billing_dispute_slack_alert.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/billing_dispute_slack_alert.yaml
@@ -72,7 +72,7 @@ success_criteria:
   # ── The delivered flow validates ────────────────────────────────────────
   - type: run_command
     description: "Generated BillingDisputeSlackAlert Flow validates without errors"
-    command: "uip maestro flow validate BillingDisputeSlackAlert/BillingDisputeSlackAlert/BillingDisputeSlackAlert.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 180
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/billing_dispute_slack_alert.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/billing_dispute_slack_alert.yaml
@@ -14,10 +14,9 @@ description: >
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, path-to-ga, outcome-graded]
 
 run_limits:
-  expected_turns: 55
-  max_turns: 120
-  task_timeout: 2400
-  turn_timeout: 1200
+  max_turns: 150
+  turn_timeout: 3000
+  task_timeout: 3600
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/seed.py"

--- a/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/billing_dispute_slack_alert.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/billing_dispute_slack_alert.yaml
@@ -1,0 +1,89 @@
+task_id: skill-flow-e2e-billing-dispute-slack-alert
+description: >
+  End-to-end, outcome-based slice of the DevCon billing-dispute scenario. The
+  agent builds a manual-trigger Flow that normalizes a messy invoice number,
+  looks up the disputed invoice's line items in the BillingDisputeERP Data
+  Service entity, and posts a Slack alert to the account manager. The grader
+  seeds one case, runs `uip maestro flow debug --inputs`, and verifies the
+  OUTCOME: the flow completes, the real Data Service query resolves the messy
+  invoice to MCS-2026-04872 with 8 line items, the correlationId is preserved,
+  and — the point of the test — the Slack "Send Message to channel" activity
+  actually posted (a real message ts surfaced as a flow output), carrying the
+  invoice number and correlationId. Grades the delivered third-party side
+  effect, not "did it run".
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, path-to-ga, outcome-graded]
+
+run_limits:
+  expected_turns: 55
+  max_turns: 120
+  task_timeout: 2400
+  turn_timeout: 1200
+
+pre_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/seed.py"
+    timeout: 30
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120
+
+initial_prompt: |
+  Build a UiPath Maestro Flow named "BillingDisputeSlackAlert" (inside a
+  solution of the same name) with a MANUAL trigger.
+
+  DevCon billing-dispute scenario: look up a disputed invoice's line items and
+  post a Slack alert to the account manager. Declare these flow inputs (in
+  variables associated with the manual trigger): `invoiceNumber` (string; the
+  caller may omit the "MCS-" prefix, use wrong casing, or add whitespace) and
+  `correlationId` (string).
+
+  Steps:
+  1. A Script node normalizes `invoiceNumber`: trim, uppercase, and prepend
+     "MCS-" if the prefix is absent.
+  2. Look up the matching rows in the existing `BillingDisputeERP` Data Service
+     entity, matching on the normalized invoice number. Capture the first
+     matched row's invoiceNumber and the number of rows returned.
+  3. Post a Slack alert to the channel "coding-agent-testing" using the Slack
+     "Send Message to channel" activity. Use the Slack connection named
+     "is-sandboxes" and send as `user`. The message must include the
+     correlationId, the matched invoice number, and the line-item count.
+  4. End the flow, mapping these `out` variables:
+     - matchedInvoiceNumber  (first matched row's invoiceNumber)
+     - lineItemCount         (number of rows returned)
+     - caseKey               = the incoming correlationId
+     - slackMessageId        = the identifier of the Slack message that was
+                               posted (from the Slack Send Message node's output)
+
+  Validate the flow. Do NOT run or debug the flow — the grader executes it with
+  seeded inputs. Do NOT ask for approval, confirmation, or feedback, and do NOT
+  pause between planning and implementation. Build the complete flow end-to-end
+  in a single pass. Before starting, load the uipath-maestro-flow skill and
+  follow its workflow.
+
+success_criteria:
+  # ── The agent validated the flow (convention adherence) ─────────────────
+  - type: command_executed
+    description: "Agent validated the generated Flow"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # ── The delivered flow validates ────────────────────────────────────────
+  - type: run_command
+    description: "Generated BillingDisputeSlackAlert Flow validates without errors"
+    command: "uip maestro flow validate BillingDisputeSlackAlert/BillingDisputeSlackAlert/BillingDisputeSlackAlert.flow --output json"
+    timeout: 180
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── OUTCOME: seeded run resolves the invoice via Data Service AND posts to Slack
+  - type: run_command
+    description: "Seeded debug run completes, the Data Service query resolves the messy invoice to MCS-2026-04872 with 8 line items, correlationId preserved, and the Slack alert was actually posted (real message ts) carrying the invoice + correlationId"
+    command: "python3 $TASK_DIR/check_billing_dispute_slack_alert.py"
+    timeout: 1000
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/check_billing_dispute_slack_alert.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/check_billing_dispute_slack_alert.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Execute the seeded billing-dispute case and verify BOTH outcomes.
+
+DevCon billing-dispute scenario, graded on delivered side effects (not "did it
+run"):
+
+  1. DATA SERVICE — a real ``uipath-dataservice.query`` node resolved the messy
+     seeded invoice to MCS-2026-04872 with 8 line items. The count is a
+     deterministic oracle; a required query node blocks hardcoding.
+  2. SLACK — the ``Send Message to channel`` activity actually posted. The flow
+     surfaces the posted message's ts as ``slackMessageId``, and a Slack API
+     call only returns a real ts when a message was delivered. The posted
+     message must carry the matched invoice number and the correlationId.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Walk up to the directory that holds `_shared` so the import works regardless
+# of how deep this task lives under tests/tasks/uipath-maestro-flow/.
+_directory = os.path.dirname(os.path.abspath(__file__))
+while _directory != os.path.dirname(_directory) and not os.path.isdir(
+    os.path.join(_directory, "_shared")
+):
+    _directory = os.path.dirname(_directory)
+sys.path.insert(0, _directory)
+
+from _shared.flow_check import (  # noqa: E402
+    assert_connector_send_identity,
+    assert_flow_has_node_type,
+    assert_flow_uses_connector_target,
+    assert_named_equals,
+    assert_output_value,
+    assert_slack_message_posted,
+    run_debug,
+)
+
+SLACK_KEY = "uipath-salesforce-slack"
+SLACK_CHANNEL = "C0B2FDZD1M3"  # coding-agent-testing
+EXPECTED_INVOICE = "MCS-2026-04872"
+EXPECTED_LINE_COUNT = 8
+
+
+def main() -> None:
+    # DevCon billing anchor + anti-hardcode: the flow must actually query Data
+    # Service (you cannot fake lineItemCount == 8 without querying).
+    assert_flow_has_node_type(["uipath-dataservice.query"])
+
+    # The flow must reach Slack through the real connector (or a connector-auth
+    # HTTP proxy), not a hand-rolled unauthenticated HTTP call, and send as
+    # `user` (not the default bot).
+    assert_flow_uses_connector_target(SLACK_KEY)
+    assert_connector_send_identity(
+        SLACK_KEY, expected="user", native_op_hint="send-message-to-channel"
+    )
+
+    seed_path = Path("seed.json")
+    if not seed_path.is_file():
+        raise SystemExit("FAIL: seed.json is missing; pre_run did not complete")
+    cases = json.loads(seed_path.read_text(encoding="utf-8")).get("cases")
+    if not isinstance(cases, list) or len(cases) != 1:
+        raise SystemExit("FAIL: seed.json must contain exactly one case")
+    case = cases[0]
+
+    # retries=1: this flow POSTS to the shared Slack channel, so a whole-flow
+    # retry on a transient poll/5xx failure would post a duplicate alert.
+    payload = run_debug(inputs=case["inputs"], timeout=300, retries=1)
+
+    # DATA SERVICE outcome: the messy invoice resolved to the seeded invoice
+    # with its exact line-item count, via the real query.
+    assert_named_equals(payload, "matchedInvoiceNumber", EXPECTED_INVOICE)
+    assert_output_value(payload, EXPECTED_LINE_COUNT)
+    assert_named_equals(
+        payload, "caseKey", case["inputs"]["correlationId"], case_sensitive=True
+    )
+
+    # SLACK outcome: verified against the executed send's own response — a real
+    # ts from an executed Slack SEND node, posted to coding-agent-testing, whose
+    # message carries the matched invoice number and the correlationId.
+    assert_slack_message_posted(
+        payload,
+        "slackMessageId",
+        expected_channel=SLACK_CHANNEL,
+        must_contain=[case["inputs"]["correlationId"], EXPECTED_INVOICE],
+    )
+
+    print(
+        f"OK: {case['name']} completed — Data Service resolved {EXPECTED_INVOICE} "
+        f"({EXPECTED_LINE_COUNT} line items), correlationId preserved, and the "
+        "Slack alert was posted (real message ts)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/check_billing_dispute_slack_alert.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/check_billing_dispute_slack_alert.py
@@ -66,9 +66,13 @@ def main() -> None:
         raise SystemExit("FAIL: seed.json must contain exactly one case")
     case = cases[0]
 
-    # retries=1: this flow POSTS to the shared Slack channel, so a whole-flow
-    # retry on a transient poll/5xx failure would post a duplicate alert.
-    payload = run_debug(inputs=case["inputs"], timeout=300, retries=1)
+    # Use run_debug's default transient-retry policy. The dominant failure mode
+    # here is a backend 5xx (e.g. HTTP 504 on POST /api/v1/debug-instances) at
+    # provisioning — BEFORE the flow runs, so nothing is posted to Slack and a
+    # retry is safe. The residual duplicate-post risk (a transient during
+    # post-execution polling) is tolerable on the sandbox coding-agent-testing
+    # channel and is far outweighed by the false-failure rate of retries=1.
+    payload = run_debug(inputs=case["inputs"], timeout=300)
 
     # DATA SERVICE outcome: the messy invoice resolved to the seeded invoice
     # with its exact line-item count, via the real query.

--- a/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/billing_dispute_slack_alert/seed.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Seed one DevCon billing-dispute case for the Slack-alert outcome eval.
+
+Writes seed.json with a single disputed-invoice case. The invoice number is
+supplied in a messy form (wrong casing, missing "MCS-" prefix) so the flow's
+normalization + real Data Service query are actually exercised — the seeded
+invoice MCS-2026-04872 has exactly 8 line items, a deterministic oracle. A fresh
+correlationId per run keeps the posted Slack message and the caseKey assertion
+isolated across runs. The grader (check_billing_dispute_slack_alert.py) runs
+`flow debug --inputs <inputs>` and asserts both the Data Service outcome and
+that a Slack message was actually posted.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+
+def build_seed() -> dict:
+    run_id = uuid4().hex[:12]
+    return {
+        "run_id": run_id,
+        "cases": [
+            {
+                "name": "disputed-invoice-messy-input",
+                "inputs": {
+                    "invoiceNumber": "mcs-2026-04872",
+                    "correlationId": f"BILL-{run_id}",
+                },
+                "expected": {
+                    "matchedInvoiceNumber": "MCS-2026-04872",
+                    "lineItemCount": 8,
+                    "caseKey": f"BILL-{run_id}",
+                },
+            }
+        ],
+    }
+
+
+def main() -> None:
+    path = Path("seed.json")
+    path.write_text(json.dumps(build_seed(), indent=2) + "\n", encoding="utf-8")
+    print(f"seeded {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Second **outcome-based** e2e task for `uipath-maestro-flow`, built from a **DevCon billing scenario** and graded on a real **third-party (Slack)** side effect (per the ask: a DevCon scenario, not a generic create-issue).

DevCon billing-dispute slice: normalize a messy invoice number → look up the disputed invoice's line items in the `BillingDisputeERP` Data Service entity → post a Slack alert to the account manager.

- **Prompt:** build `BillingDisputeSlackAlert` (manual trigger); inputs `invoiceNumber` (messy) + `correlationId`. Normalize (trim/upper/prepend `MCS-`), query `BillingDisputeERP`, then post to channel **coding-agent-testing** via the **is-sandboxes** Slack connection, **send-as user**. Map outputs `matchedInvoiceNumber`, `lineItemCount`, `caseKey`, `slackMessageId`.
- **Graded on two delivered outcomes** (seed one case, `flow debug --inputs`, then check):
  1. **Data Service:** the real `uipath-dataservice.query` node resolved the messy invoice to `MCS-2026-04872` with **8 line items** (deterministic oracle; required query node blocks hardcoding), `correlationId` preserved.
  2. **Slack:** the `Send Message to channel` activity **actually posted** — a real message `ts` surfaced as `slackMessageId`, verified against the executed send node's own response, and the posted message carries the invoice number + correlationId.
- **Reuse:** the Data Service half is the proven `billing_invoice_lookup_outcome` lookup; the Slack half reuses the `escalation_slack_alert` outcome helpers (`assert_slack_message_posted`, `assert_connector_send_identity`). Tags: `path-to-ga`, `outcome-graded` (already in the taxonomy on `main`).

## Success criteria
1. `command_executed` (1.5) — agent validated the flow
2. `run_command` (3.0) — `flow validate` passes
3. `run_command` (5.0) — outcome checker: Data Service result correct **and** Slack alert posted

## Supersedes
Replaces the earlier generic `jira_create_issue_outcome` variant (PR #2862), which was not a DevCon scenario.

## Validation
Dispatching `run-coder-eval.yml` from this branch to confirm it passes end-to-end (build + validate + real Data Service query + real Slack post + tenant-verified assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Evidence of passing run:** Ran `skill-flow-e2e-billing-dispute-slack-alert` on `run-coder-eval.yml` (claude, nightly experiment) — **passed 3/3, weighted score 1.000** (run 33104729678, duration ~1862s: real Data Service query resolved the messy invoice + a real Slack message posted to `coding-agent-testing`). Re-validated after switching the validate criterion to the shared `_shared/validate_flow.py` helper (run 33109761328).
