### PR TITLE
test(maestro-flow): add empty-result outcome case to billing_invoice_lookup

### DIFF
--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/check_billing_invoice_lookup.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/check_billing_invoice_lookup.py
@@ -2,13 +2,15 @@
 """BillingInvoiceLookup: the agent builds + validates only; this check runs
 `uip maestro flow debug` itself for three malformed invoice-number forms and
 asserts each resolves, via a real Data Service query, to invoice MCS-2026-04872
-with 8 line items.
+with 8 line items. A fourth case supplies a normalized-but-absent invoice and
+asserts the flow returns 0 line items — verifying it handles an empty result
+set, not just the happy path.
 
 The flow normalizes a raw `invoiceNumber` (trim, uppercase, ensure the "MCS-"
 prefix) and queries the seeded `BillingDisputeERP` entity. A Data Service query
 node is required (anti-hardcode): you cannot fake `lineItemCount == 8` for three
 different inputs without actually querying. The seeded invoice has exactly 8
-line items, so the count is a deterministic oracle.
+line items, so the count is a deterministic oracle; an absent invoice yields 0.
 """
 import os
 import sys
@@ -37,10 +39,16 @@ CASES = [
     (" MCS-2026-04872", "leading whitespace"),
 ]
 
+# A normalized-but-absent invoice: the query matches no rows. The flow must
+# return 0 line items (empty result handled) rather than erroring on "first row
+# of an empty set". MCS-9999-00000 is not seeded in BillingDisputeERP.
+NOT_FOUND = (" mcs-9999-00000 ", "absent invoice (empty result set)")
+EXPECTED_NOT_FOUND_COUNT = 0
+
 
 def main():
     # Must actually query Data Service — blocks hardcoding the answer, which
-    # would otherwise pass since all three cases expect the same output.
+    # would otherwise pass since all three happy cases expect the same output.
     assert_flow_has_node_type(["uipath-dataservice.query"])
 
     in_vars = read_flow_input_vars(find_project_dir())
@@ -56,7 +64,18 @@ def main():
         assert_output_value(payload, EXPECTED_LINE_COUNT)
         print(f"OK: [{label}] -> {EXPECTED_INVOICE}, {EXPECTED_LINE_COUNT} line items")
 
-    print(f"OK: all {len(CASES)} malformed forms normalized and queried correctly")
+    # Empty-result case: normalized to a valid MCS- form that matches nothing.
+    raw, label = NOT_FOUND
+    inputs = {var: raw}
+    print(f"[{label}] debug inputs: {inputs}")
+    payload = run_debug(inputs=inputs, timeout=180)
+    assert_output_value(payload, EXPECTED_NOT_FOUND_COUNT)
+    print(f"OK: [{label}] -> {EXPECTED_NOT_FOUND_COUNT} line items (empty result handled)")
+
+    print(
+        f"OK: all {len(CASES)} malformed forms normalized and queried correctly, "
+        "and the absent-invoice case returned 0 line items"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds a **new outcome-based evaluator** to the existing `multi_node/billing_invoice_lookup` task instead of shipping a duplicate task file (context: a near-identical copy was proposed and closed — #2861). This grows outcome coverage in-place.

**Change is checker-only** (`check_billing_invoice_lookup.py`) — the pinned prompt and the task YAML are untouched:

- After the three happy-path malformed inputs, adds a **fourth case**: a normalized-but-absent invoice (` mcs-9999-00000 ` → `MCS-9999-00000`, not seeded in `BillingDisputeERP`).
- Asserts the debug run returns **0 line items** — verifying the flow handles an **empty result set** (the query matches no rows) rather than only the happy path where a row always exists.

The existing `uipath-dataservice.query` node assertion and the deterministic 8-line oracle are unchanged; the new case adds a second, distinct oracle (0 rows).

## ⚠️ Same-ground campaign — @tmatup please review

`billing_invoice_lookup` carries the same-ground campaign contract (Tao, 2026-08-10) and is compared cross-arm. Notes:

- The edit is **checker-only and loop-neutral** — both arms share this file, so parity is preserved by construction (no prompt/limit-envelope change).
- **But** it changes the intersection criteria and may **lower the measured pass rate**: the pinned prompt does not explicitly ask for empty-result handling, so agent builds that don't gracefully handle a no-match query will now fail the fourth case. That is the intended signal (a real robustness gap), but it affects your campaign measurements — please confirm you're OK with it before merge, or tell me to hold / move it to a standalone task.

## Validation
Dispatching `run-coder-eval.yml` from this branch to confirm the enhanced task still passes end-to-end (all four cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
