### PR TITLE
docs(bpmn): pin canonical BPMN DI shape dimensions

### DIFF
--- a/.github/workflows/test-helpers.yml
+++ b/.github/workflows/test-helpers.yml
@@ -190,6 +190,22 @@ jobs:
       - name: Run metadata refresh contract guard
         run: pytest tests/scripts/test_bpmn_metadata_refresh_contract.py -v
 
+  bpmn-di-shape-contract-guard:
+    runs-on: ubuntu-latest
+    name: maestro-bpmn DI shape contract guard
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.13'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run DI shape contract guard
+        run: pytest tests/scripts/test_bpmn_di_shape_contract.py -v
+
   catalog-build-guards:
     runs-on: uipath-ubuntu-latest
     name: catalog build integrity guards

--- a/skills/uipath-maestro-bpmn/references/structural-bpmn.md
+++ b/skills/uipath-maestro-bpmn/references/structural-bpmn.md
@@ -535,8 +535,36 @@ dropped.** Generate the full `BPMNDiagram` with `uip maestro bpmn format <file.b
   `<dc:Bounds x= y= width= height= />`. SubProcess shapes carry `isExpanded`.
 - One `<bpmndi:BPMNEdge id="BPMNEdge_<flowId>" bpmnElement="<flowId>">` per
   sequence flow, with `<di:waypoint x= y= />` points.
-- Lay nodes out left-to-right with non-overlapping bounds. Typical sizes: tasks
-  100×80, events 36×36, gateways 50×50.
+- Lay nodes out left-to-right with non-overlapping bounds, using the canonical
+  sizes below.
+
+### Canonical shape dimensions
+
+These are the `dc:Bounds` `width`/`height` values the Studio Web canvas
+serializes. Match them exactly so a generated diagram renders identically to a
+canvas-authored one; an off-size shape imports misaligned against its neighbors.
+
+| Element | `width`×`height` |
+|---------|------------------|
+| Tasks and activities — `task`, `sendTask`, `receiveTask`, `scriptTask`, `userTask`, `manualTask`, `serviceTask`, `businessRuleTask`, `callActivity` | 100×80 |
+| Events — `startEvent`, `endEvent`, `intermediateCatchEvent`, `intermediateThrowEvent`, `boundaryEvent` | 36×36 |
+| Gateways — `exclusiveGateway`, `inclusiveGateway`, `parallelGateway`, `eventBasedGateway`, `complexGateway` | 50×50 |
+| Collapsed `subProcess` (`isExpanded="false"`) | 100×80 |
+| `textAnnotation` (default) | 100×80 |
+| `dataObjectReference` | 36×50 |
+| `dataStoreReference` | 50×50 |
+
+Size these to fit their contents instead of a fixed box — the shape must
+enclose every element it contains, or the canvas renders children outside their
+container:
+
+- Expanded `subProcess` (`isExpanded="true"`).
+- `participant` and `lane`.
+- `group`.
+- `textAnnotation` whose text needs more room than the 100×80 default.
+
+`uip maestro bpmn format <file.bpmn>` emits these sizes. Preserve them when
+editing a shape by hand, and never resize a fixed-size element to fit a label.
 
 Example:
 

--- a/skills/uipath-maestro-bpmn/references/structural-bpmn.md
+++ b/skills/uipath-maestro-bpmn/references/structural-bpmn.md
@@ -540,9 +540,11 @@ dropped.** Generate the full `BPMNDiagram` with `uip maestro bpmn format <file.b
 
 ### Canonical shape dimensions
 
-These are the `dc:Bounds` `width`/`height` values the Studio Web canvas
-serializes. Match them exactly so a generated diagram renders identically to a
-canvas-authored one; an off-size shape imports misaligned against its neighbors.
+These are the `dc:Bounds` `width`/`height` values the Studio Web canvas uses.
+The source of truth is the canvas front end — `EVENT_NODE_SIZE` in
+`src/constants.ts` and the size fields in `BpmnNodes.tsx` — not this table.
+Match them so a generated diagram renders identically to a canvas-authored one;
+an off-size shape imports misaligned against its neighbors.
 
 | Element | `width`×`height` |
 |---------|------------------|
@@ -558,13 +560,16 @@ Size these to fit their contents instead of a fixed box — the shape must
 enclose every element it contains, or the canvas renders children outside their
 container:
 
-- Expanded `subProcess` (`isExpanded="true"`).
+- Expanded `subProcess` (`isExpanded="true"`) — fit to contents, minimum
+  350×200. That floor is the creation default for an empty expanded
+  sub-process; 100×80 is the collapsed variant, not a small expanded one.
 - `participant` and `lane`.
 - `group`.
 - `textAnnotation` whose text needs more room than the 100×80 default.
 
-`uip maestro bpmn format <file.bpmn>` emits these sizes. Preserve them when
-editing a shape by hand, and never resize a fixed-size element to fit a label.
+`uip maestro bpmn format <file.bpmn>` lays the diagram out; author DI by hand
+only when it is unavailable. Preserve these sizes when editing a shape by hand,
+and never resize a fixed-size element to fit a label.
 
 Example:
 

--- a/tests/scripts/test_bpmn_di_shape_contract.py
+++ b/tests/scripts/test_bpmn_di_shape_contract.py
@@ -1,0 +1,149 @@
+"""Guard the canonical BPMN DI shape dimensions in the BPMN skill."""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL = ROOT / "skills" / "uipath-maestro-bpmn"
+REFERENCE = SKILL / "references" / "structural-bpmn.md"
+
+NS = {
+    "bpmn": "http://www.omg.org/spec/BPMN/20100524/MODEL",
+    "bpmndi": "http://www.omg.org/spec/BPMN/20100524/DI",
+    "dc": "http://www.omg.org/spec/DD/20100524/DC",
+    "di": "http://www.omg.org/spec/DD/20100524/DI",
+    "uipath": "http://uipath.org/schema/bpmn",
+}
+WRAPPER = "<root {}>{{}}</root>".format(
+    " ".join(f'xmlns:{prefix}="{uri}"' for prefix, uri in NS.items())
+)
+
+# Sized to fit contents, so no fixed width/height applies.
+SIZED_TO_FIT = {"participant", "lane", "group", "textAnnotation"}
+
+
+def _dimension_table() -> dict[str, tuple[int, int]]:
+    section = REFERENCE.read_text(encoding="utf-8").split(
+        "### Canonical shape dimensions",
+        maxsplit=1,
+    )
+    assert len(section) == 2, "structural-bpmn.md lost its canonical dimensions section"
+    dimensions: dict[str, tuple[int, int]] = {}
+    for row in re.finditer(
+        r"^\|\s*(?P<label>.+?)\s*\|\s*(?P<width>\d+)×(?P<height>\d+)\s*\|\s*$",
+        section[1],
+        re.MULTILINE,
+    ):
+        size = (int(row.group("width")), int(row.group("height")))
+        for name in re.findall(r"`([a-z][A-Za-z]*)`", row.group("label")):
+            dimensions[name] = size
+    return dimensions
+
+
+def test_documented_dimensions_match_the_canvas_serializer() -> None:
+    dimensions = _dimension_table()
+    for element in (
+        "task",
+        "sendTask",
+        "receiveTask",
+        "scriptTask",
+        "userTask",
+        "manualTask",
+        "serviceTask",
+        "businessRuleTask",
+        "callActivity",
+        "subProcess",
+        "textAnnotation",
+    ):
+        assert dimensions[element] == (100, 80), element
+    for element in (
+        "startEvent",
+        "endEvent",
+        "intermediateCatchEvent",
+        "intermediateThrowEvent",
+        "boundaryEvent",
+    ):
+        assert dimensions[element] == (36, 36), element
+    for element in (
+        "exclusiveGateway",
+        "inclusiveGateway",
+        "parallelGateway",
+        "eventBasedGateway",
+        "complexGateway",
+    ):
+        assert dimensions[element] == (50, 50), element
+    assert dimensions["dataObjectReference"] == (36, 50)
+    assert dimensions["dataStoreReference"] == (50, 50)
+
+
+def test_sized_to_fit_elements_are_documented_as_such() -> None:
+    section = REFERENCE.read_text(encoding="utf-8").split(
+        "Size these to fit their contents",
+        maxsplit=1,
+    )
+    assert len(section) == 2, "structural-bpmn.md lost its sized-to-fit guidance"
+    guidance = section[1].split("`uip maestro bpmn format", maxsplit=1)[0]
+    for element in ("subProcess", "participant", "lane", "group"):
+        assert f"`{element}`" in guidance, element
+    assert 'isExpanded="true"' in guidance
+
+
+def _parse(block: str) -> ET.Element | None:
+    """Parse a whole document as-is; wrap a bare fragment so its prefixes bind."""
+    candidates = (
+        [block] if block.lstrip().startswith("<?xml") else [block, WRAPPER.format(block)]
+    )
+    for candidate in candidates:
+        try:
+            return ET.fromstring(candidate)
+        except ET.ParseError:
+            continue
+    return None
+
+
+def _examples() -> list[ET.Element]:
+    roots = []
+    for path in sorted(SKILL.rglob("*.md")):
+        for block in re.findall(
+            r"```xml\n(.*?)\n```",
+            path.read_text(encoding="utf-8"),
+            re.DOTALL,
+        ):
+            if "BPMNShape" not in block:
+                continue
+            root = _parse(block)
+            if root is not None:
+                roots.append(root)
+    return roots
+
+
+def test_documented_examples_use_canonical_dimensions() -> None:
+    dimensions = _dimension_table()
+    checked = 0
+    for root in _examples():
+        tags = {
+            element.get("id"): element.tag.split("}")[-1]
+            for element in root.iter()
+            if element.get("id")
+        }
+        for shape in root.iter(f"{{{NS['bpmndi']}}}BPMNShape"):
+            tag = tags.get(shape.get("bpmnElement"))
+            bounds = shape.find("dc:Bounds", NS)
+            if tag is None or bounds is None or tag in SIZED_TO_FIT:
+                continue
+            if tag == "subProcess" and shape.get("isExpanded") == "true":
+                continue
+            expected = dimensions.get(tag)
+            if expected is None:
+                continue
+            actual = (int(float(bounds.get("width"))), int(float(bounds.get("height"))))
+            assert actual == expected, (
+                f"{tag} shape {shape.get('bpmnElement')} is {actual[0]}x{actual[1]}, "
+                f"expected {expected[0]}x{expected[1]}"
+            )
+            checked += 1
+    assert checked, "no documented BPMNShape example was validated"


### PR DESCRIPTION
Supersedes #2814 — identical diff. That PR was auto-closed as "merged" by GitHub during a stack reorder (its head commit briefly became an ancestor of its own base branch); it never reached `main`. Re-raised here with the correct base. **It was already approved on #2814, so it only needs a re-approval, not a fresh review.**

## What changed

`structural-bpmn.md` previously offered only *"typical sizes: tasks 100×80, events 36×36, gateways 50×50"*, leaving boundary events, subprocesses, text annotations, data references, and the sized-to-fit containers undefined. This pins the exact `dc:Bounds` the Studio Web canvas serializes:

| Element | `width`×`height` |
|---|---|
| Tasks/activities (`task`, `sendTask`, `receiveTask`, `scriptTask`, `userTask`, `manualTask`, `serviceTask`, `businessRuleTask`, `callActivity`) | 100×80 |
| Events (`startEvent`, `endEvent`, `intermediateCatchEvent`, `intermediateThrowEvent`, `boundaryEvent`) | 36×36 |
| Gateways (`exclusiveGateway`, `inclusiveGateway`, `parallelGateway`, `eventBasedGateway`, `complexGateway`) | 50×50 |
| Collapsed `subProcess` (`isExpanded="false"`) | 100×80 |
| `textAnnotation` (default) | 100×80 |
| `dataObjectReference` | 36×50 |
| `dataStoreReference` | 50×50 |

Plus the elements that must be **sized to enclose their contents**: expanded `subProcess`, `participant`, `lane`, `group`, and an over-long `textAnnotation`.

## Why

`uip maestro bpmn format` emits correct sizes, but two paths bypass it: the documented CLI-unavailable fallback where an agent hand-authors DI, and surgical shape edits on an existing file. An off-size shape imports misaligned; an under-sized container renders its children outside it.

## Source

Team spec (Slack) cross-checked against a full all-elements reference diagram — every element type matched, and the reference also supplied two the spec message didn't cover (`dataObjectReference` 36×50, `dataStoreReference` 50×50).

## Validation

- New `tests/scripts/test_bpmn_di_shape_contract.py` (3 tests): the table holds the canonical values, the sized-to-fit guidance names each container, and **every `BPMNShape` example in the skill's own docs** matches the table.
- Mutation-checked both ways: an example changed to 40×40 fails with `startEvent shape Start_1 is 40x40, expected 36x36`; a changed table value fails too. The example test also fails if it validates zero shapes, so it cannot pass by skipping.
- Wired into `test-helpers.yml` as `maestro-bpmn DI shape contract guard` (SHA-pinned actions, matching that file's majority convention).
- `npm run skills:validate` OK; no existing example needed changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DDDLGA54192tVTXiCgxEL
