### PR TITLE
fix(ci): restore Maestro preview re-sync

### DIFF
--- a/scripts/sync-maestro-sdk-preview.mjs
+++ b/scripts/sync-maestro-sdk-preview.mjs
@@ -47,6 +47,16 @@ const oldSiblingParagraph = [
   '`@uipath/flow-sdk/bpmn`. Neither is needed to build a Flow.',
 ].join('\n');
 
+const currentSiblingParagraph = [
+  'The sibling authoring surfaces have their own:',
+  '[`references/case-api.md`](references/case-api.md) for `@uipath/flow-sdk/case`',
+  'and [`references/bpmn-api.md`](references/bpmn-api.md) for',
+  '`@uipath/flow-sdk/bpmn`; their runtime-only decisions are in',
+  '[`references/case-runtime.md`](references/case-runtime.md) and',
+  '[`references/bpmn-runtime.md`](references/bpmn-runtime.md). None are needed to',
+  'build a Flow.',
+].join('\n');
+
 const newSiblingParagraph = [
   'The sibling authoring surfaces have their own skills:',
   '`uipath-maestro-case` for `@uipath/flow-sdk/case` and `uipath-maestro-bpmn`',
@@ -173,7 +183,12 @@ function collectMappings(upstreamRoot, refs) {
     const referencesRoot = `${sourceRoot}/skill/references`;
     for (const source of gitFiles(upstreamRoot, ref, referencesRoot)) {
       const name = path.posix.basename(source);
-      if (!source.endsWith('.md') || ['case-api.md', 'bpmn-api.md'].includes(name)) continue;
+      if (!source.endsWith('.md') || [
+        'case-api.md',
+        'case-runtime.md',
+        'bpmn-api.md',
+        'bpmn-runtime.md',
+      ].includes(name)) continue;
       const relative = path.posix.relative(referencesRoot, source);
       add(source, `preview/uipath-maestro-flow/references/${relative}`);
     }
@@ -206,6 +221,12 @@ function collectMappings(upstreamRoot, refs) {
     `${sourceRoot}/skill/references/bpmn-api.md`,
     'preview/uipath-maestro-bpmn/references/api.md',
   );
+  for (const [source, target] of [
+    [`${sourceRoot}/skill/references/case-runtime.md`, 'preview/uipath-maestro-case/references/case-runtime.md'],
+    [`${sourceRoot}/skill/references/bpmn-runtime.md`, 'preview/uipath-maestro-bpmn/references/bpmn-runtime.md'],
+  ]) {
+    if (refs.some((ref) => gitObjectExists(upstreamRoot, ref, source))) add(source, target);
+  }
   return [...mappings.values()].sort((left, right) => left.target.localeCompare(right.target));
 }
 
@@ -293,6 +314,23 @@ function mergeMapping({ skillsRoot, upstreamRoot, oldPin, newCommit, mapping }) 
     fail(`Snapshot deleted ${mapping.target} while upstream still contains ${mapping.source}`);
   }
 
+  if (skillMappings.some(({ target }) => target === mapping.target)) {
+    const oursText = ours.toString('utf8');
+    const baseText = snapshotBase.toString('utf8');
+    const theirsText = snapshotTheirs.toString('utf8');
+    const oursBody = bodyFromFirstHeading(oursText, mapping.target);
+    const baseBody = bodyFromFirstHeading(baseText, mapping.source);
+    const theirsBody = bodyFromFirstHeading(theirsText, mapping.source);
+    if (oursBody === theirsBody) return false;
+    if (oursBody === baseBody) {
+      const heading = oursText.indexOf('# ');
+      return writeIfChanged(
+        targetPath,
+        oursText.slice(0, heading) + theirsBody,
+      );
+    }
+  }
+
   const merged = mergeBuffers(ours, snapshotBase, snapshotTheirs, {
     ours: `${mapping.target} (snapshot)`,
     base: `${mapping.source}@${oldPin}`,
@@ -309,12 +347,17 @@ function replaceRequired(text, before, after, label) {
 
 export function adaptFlowSkill(text) {
   let adapted = text.replaceAll('`example/', '`examples/');
-  adapted = replaceRequired(
-    adapted,
-    oldSiblingParagraph,
-    newSiblingParagraph,
-    'Flow sibling-skill adaptation',
-  );
+  if (!adapted.includes(newSiblingParagraph)) {
+    const siblingParagraph = adapted.includes(currentSiblingParagraph)
+      ? currentSiblingParagraph
+      : oldSiblingParagraph;
+    adapted = replaceRequired(
+      adapted,
+      siblingParagraph,
+      newSiblingParagraph,
+      'Flow sibling-skill adaptation',
+    );
+  }
   adapted = replaceRequired(
     adapted,
     oldStagingParagraph,
@@ -327,13 +370,15 @@ export function adaptFlowSkill(text) {
 export function adaptCaseSkill(text) {
   return text
     .replaceAll('references/case-api.md', 'references/api.md')
-    .replaceAll('example/NotifyOnApproval.case.ts', 'examples/NotifyOnApproval.case.ts')
-    .replaceAll('example/case-bindings.json', 'examples/bindings.json');
+    .replaceAll('example/case-bindings.json', 'examples/bindings.json')
+    .replaceAll('`example/', '`examples/');
 }
 
 export function adaptBpmnSkill(text) {
-  let adapted = text.replaceAll('references/bpmn-api.md', 'references/api.md');
-  if (!adapted.includes(bpmnWorkedExample)) {
+  let adapted = text
+    .replaceAll('references/bpmn-api.md', 'references/api.md')
+    .replaceAll('`example/', '`examples/');
+  if (!adapted.includes('`examples/NotifyChannel.bpmn.ts`')) {
     adapted = replaceRequired(
       adapted,
       '## Authoring\n\n',
@@ -352,12 +397,22 @@ export function adaptCaseExample(text) {
   return text.replaceAll('example/case-bindings.json', 'examples/bindings.json');
 }
 
+function adaptCaseRuntime(text) {
+  return text.replaceAll('case-api.md', 'api.md');
+}
+
+function adaptBpmnRuntime(text) {
+  return text.replaceAll('bpmn-api.md', 'api.md');
+}
+
 const snapshotAdaptations = new Map([
   ['preview/uipath-maestro-flow/SKILL.md', adaptFlowSkill],
   ['preview/uipath-maestro-case/SKILL.md', adaptCaseSkill],
   ['preview/uipath-maestro-bpmn/SKILL.md', adaptBpmnSkill],
   ['preview/uipath-maestro-flow/references/api.md', adaptFlowApi],
   ['preview/uipath-maestro-case/examples/NotifyOnApproval.case.ts', adaptCaseExample],
+  ['preview/uipath-maestro-case/references/case-runtime.md', adaptCaseRuntime],
+  ['preview/uipath-maestro-bpmn/references/bpmn-runtime.md', adaptBpmnRuntime],
 ]);
 
 function snapshotAdaptationFor(target) {
@@ -417,6 +472,8 @@ function verifyExactMappings(skillsRoot, upstreamRoot, newCommit, mappings) {
   const adaptedTargets = new Map([
     ['preview/uipath-maestro-flow/references/api.md', adaptFlowApi],
     ['preview/uipath-maestro-case/examples/NotifyOnApproval.case.ts', adaptCaseExample],
+    ['preview/uipath-maestro-case/references/case-runtime.md', adaptCaseRuntime],
+    ['preview/uipath-maestro-bpmn/references/bpmn-runtime.md', adaptBpmnRuntime],
   ]);
   const skillTargets = new Set(skillMappings.map(({ target }) => target));
   for (const mapping of mappings) {

--- a/tests/scripts/sync-maestro-sdk-preview.test.mjs
+++ b/tests/scripts/sync-maestro-sdk-preview.test.mjs
@@ -270,6 +270,30 @@ test('syncSnapshots three-way merges drift and reapplies only snapshot adaptatio
         '| Script action | `core.action.script` |',
       ),
     );
+    write(
+      upstreamRoot,
+      'typescript/sdk/skill/SKILL-bpmn.md',
+      [
+        '# BPMN fixture v2',
+        '',
+        '[API](references/bpmn-api.md).',
+        '',
+        '## Capability router',
+        '',
+        '`example/NotifyChannel.bpmn.ts` is the worked example.',
+        '',
+      ].join('\n'),
+    );
+    write(
+      upstreamRoot,
+      'typescript/sdk/skill/references/case-runtime.md',
+      '# Case runtime\n\nSee [Case API](case-api.md).\n',
+    );
+    write(
+      upstreamRoot,
+      'typescript/sdk/skill/references/bpmn-runtime.md',
+      '# BPMN runtime\n\nSee [BPMN API](bpmn-api.md).\n',
+    );
     const newPin = commit(upstreamRoot, 'drift');
 
     const result = syncSnapshots({ skillsRoot, upstreamRoot });
@@ -300,6 +324,30 @@ test('syncSnapshots three-way merges drift and reapplies only snapshot adaptatio
     assert.match(
       read(skillsRoot, 'preview/uipath-maestro-case/SKILL.md'),
       /New upstream Case guidance/,
+    );
+    assert.match(
+      read(skillsRoot, 'preview/uipath-maestro-bpmn/SKILL.md'),
+      /# BPMN fixture v2[\s\S]*`examples\/NotifyChannel\.bpmn\.ts`/,
+    );
+    assert.doesNotMatch(
+      read(skillsRoot, 'preview/uipath-maestro-bpmn/SKILL.md'),
+      /representative process/,
+    );
+    assert.equal(
+      read(skillsRoot, 'preview/uipath-maestro-case/references/case-runtime.md'),
+      '# Case runtime\n\nSee [Case API](api.md).\n',
+    );
+    assert.equal(
+      read(skillsRoot, 'preview/uipath-maestro-bpmn/references/bpmn-runtime.md'),
+      '# BPMN runtime\n\nSee [BPMN API](api.md).\n',
+    );
+    assert.equal(
+      fs.existsSync(path.join(skillsRoot, 'preview/uipath-maestro-flow/references/case-runtime.md')),
+      false,
+    );
+    assert.equal(
+      fs.existsSync(path.join(skillsRoot, 'preview/uipath-maestro-flow/references/bpmn-runtime.md')),
+      false,
     );
     for (const skill of ['flow', 'case', 'bpmn']) {
       assert.match(


### PR DESCRIPTION
## Outcome

Restore the daily/manual Maestro SDK preview re-sync so upstream router changes produce reviewable snapshot PRs again.

## Root cause

The schedule still ran, but runs 32933854788 and 33051426231 failed before diff and PR creation. Flow SDK PR #589 replaced the long BPMN manual with a compact capability router that already points to `example/NotifyChannel.bpmn.ts`. The downstream adapter checked only for its translated `examples/...` spelling and otherwise tried to inject that link beneath the removed `## Authoring` heading.

The equivalent adapter update existed in #2837, but that PR merged into `campaign/same-ground-expansion`, not `main`, so the scheduled workflow never received it.

## Enabling-layer fix

- translate canonical example paths before enforcing the worked-example contract, removing the obsolete prose-anchor dependency for the compact router
- fast-forward an unchanged snapshot skill body when upstream intentionally rewrites the whole canonical document
- route the new Case/BPMN runtime references to their owning preview skills and adapt their renamed API links
- exercise the full BPMN router rewrite and family-specific runtime-reference routing in the sync regression

This changes the sync engine and its contract test only. The next scheduled run, or a manual dispatch after merge, will create the separate human-reviewed snapshot PR.

## Verification

- `node --test tests/scripts/sync-maestro-sdk-preview.test.mjs`: 2 passed
- real disposable sync from `efd27ce` to current `UiPath/flow-builder-sdk@main` (`9bab1a2`): all snapshot gates passed
- second sync at `9bab1a2`: clean no-op; all snapshot gates passed
- CLI verb gate on the generated Flow, Case, and BPMN snapshots: zero blocking findings
- `git diff --check`: passed
- `npm run skills:test`: focused sync coverage passed; aggregate was 50/52 because two unrelated packaging tests hit the known current-registry npm tag rejection (`prerelease` without `--tag`, and local `1.2.3` below published `latest` 1.200.0)

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)
