### PR TITLE
fix(planner): a gate reads the producing field, and the validator says so

### DIFF
--- a/skills/uipath-planner/references/case-design-layers-guide.md
+++ b/skills/uipath-planner/references/case-design-layers-guide.md
@@ -254,7 +254,7 @@ A row that relays one task's output to one consumer is the relay anti-pattern �
 
 ### Gate on the producer, never on a renamed field
 
-A task field lands in exactly one slot. `Action -> decision` puts the value in `decision` and leaves the `Action` slot empty; an equal-name row (`Action -> Action`) keeps one slot under one name, until a second row extracts `Action` elsewhere in the case and the allocator suffixes the later slot. A rule that fires on task completion reads the field's own slot, so a gate on a renamed field reads the empty one. The branch silently never fires, the stage stalls, and nothing errors.
+A task field lands in exactly one slot. `Action -> decision` puts the value in `decision` and leaves the `Action` slot empty; an equal-name row (`Action -> Action`) keeps one slot under one name, until a second row extracts `Action` elsewhere in the case and the allocator suffixes the later slot. A rule reads the field's own slot, so a gate on a renamed field reads the empty one, whenever that gate fires. The branch silently never fires, the stage stalls, and nothing errors.
 
 | Outputs row on `Decide` | `IF` reads | At gate time |
 |---|---|---|
@@ -262,7 +262,7 @@ A task field lands in exactly one slot. `Action -> decision` puts the value in `
 | `Action -> decision` | `vars.$xref(...,'Action')` — the emptied slot | ✗ `null` |
 | no Outputs row for `Action` | `vars.$xref(...,'Action')` — one slot, one name | ✓ populated |
 
-**Rule** — all four hold for a gate that fires on a task completing:
+**Rule** — all four hold for a gate whose `IF` reads a task's output:
 
 1. The `IF` reads the producing task's own field as `vars.$xref('<Stage>','<Task>','<field>')`.
 2. That field carries no renaming Outputs row — no row at all, or an equal-name row whose target is unique case-wide.

--- a/skills/uipath-planner/references/case-design-layers-guide.md
+++ b/skills/uipath-planner/references/case-design-layers-guide.md
@@ -254,7 +254,7 @@ A row that relays one task's output to one consumer is the relay anti-pattern â€
 
 ### Gate on the producer, never on a renamed field
 
-A task field lands in exactly one slot. `Action -> decision` puts the value in `decision` and leaves the `Action` slot empty; an equal-name row (`Action -> Action`) keeps one slot under one name, until a second row extracts `Action` elsewhere in the case and the allocator suffixes the later slot. A rule reads the field's own slot, so a gate on a renamed field reads the empty one, whenever that gate fires. The branch silently never fires, the stage stalls, and nothing errors.
+A task field lands in exactly one slot. `Action -> decision` puts the value in `decision` and leaves the `Action` slot empty; an equal-name row keeps one slot under one name â€” equal on the source path's last segment, so `Action -> Action` and `response.status -> status` both qualify, until a second row extracts `Action` elsewhere in the case and the allocator suffixes the later slot. A rule reads the field's own slot, so a gate on a renamed field reads the empty one, whenever that gate fires. The branch silently never fires, the stage stalls, and nothing errors.
 
 | Outputs row on `Decide` | `IF` reads | At gate time |
 |---|---|---|

--- a/skills/uipath-planner/references/case-design-layers-guide.md
+++ b/skills/uipath-planner/references/case-design-layers-guide.md
@@ -127,7 +127,7 @@ The case, each stage, and each task move through gates driven by **rules** in di
 2. `Marks Complete: Yes` pairs only with `required-*` rules (or `wait-for-connector`). A `Yes` + `selected-*` pair is a schema error.
 3. `required-*` rules are vacuous without an explicit `isRequired: true` member. Required status is explicit end-to-end — the SDD declares it per stage and task, and emission writes it verbatim. An absent flag equals `false` at the validator: `Case rule '<name>' has no required stage(s) selected` / `Stage exit rule '<name>' has no task(s) marked as required`.
 4. **Case completion is a root rule.** At least one case-exit row carries `Marks Case Complete: Yes` (normally `required-stages-completed`). A stage completing never closes the case by itself; alternate outcomes (Rejected, Withdrawn, Cancelled) are case-exit rows with `Marks Case Complete: No`. **Default:** the last primary stage completing closes the case unless the source describes another close-out.
-5. **A gate sees case state as of its own event.** The extract of the task that fired the gate has not run yet, so an `IF` that reads a case variable that task writes is stale — read the producing output instead ([Layer 3 § Gate on the producer](#gate-on-the-producer-never-on-the-variable-it-writes)).
+5. **A gate reads the producing field's own slot.** An Outputs row that renames a field moves the value off that slot, so an `IF` on a renamed field reads an empty one — read the field itself ([Layer 3 § Gate on the producer](#gate-on-the-producer-never-on-a-renamed-field)).
 6. **Evaluation precedence: case exit/completion → stage exit → stage completion → stage entry.** Two consequences: a stage entry identical to a case-exit row (same rule, selector, IF) leaves the stage permanently unreachable — differentiate the guards; an unguarded stage exit (`No`, empty IF) sharing its WHEN with a guarded completion (`Yes` + IF) always fires first and the stage never completes — the exit carries the completion's inverse IF. Both validator-enforced.
 
 ### Exit types
@@ -247,21 +247,22 @@ Declare a row ONLY when one of these holds:
 
 1. `In` / `Out` argument (the case boundary).
 2. Trigger-payload extraction (below — the only way a trigger field becomes referenceable).
-3. Case-level state read by a condition (`IF`) or by ≥ 2 consumers.
+3. Case-level state read by a condition (`IF`) or by ≥ 2 consumers. A task's own field is not case-level state — a gate reads it directly with `vars.$xref(...)` ([§ Gate on the producer](#gate-on-the-producer-never-on-a-renamed-field)).
 4. The value needs a rename or a custom `Default` / `Type` / `Description`.
 
 A row that relays one task's output to one consumer is the relay anti-pattern — flagged as `rev_relay_var` (§ Layer closure, advisory lens). Declaring a row does not make the value readable earlier — see next.
 
-### Gate on the producer, never on the variable it writes
+### Gate on the producer, never on a renamed field
 
-A rule is evaluated **before** the extract of the task that triggered it. So a gate keyed on a task's completion that reads the case variable that task's Outputs row feeds sees the value from the previous pass — `null` on the first one. The branch silently never fires, the stage stalls, and nothing errors.
+A task field lands in exactly one slot. `Action -> decision` puts the value in `decision` and leaves the `Action` slot empty; an equal-name row (`Action -> Action`) keeps one slot under one name, until a second row extracts `Action` elsewhere in the case and the allocator suffixes the later slot. A rule that fires on task completion reads the field's own slot, so a gate on a renamed field reads the empty one. The branch silently never fires, the stage stalls, and nothing errors.
 
-| Gate | `IF` reads | At gate time |
+| Outputs row on `Decide` | `IF` reads | At gate time |
 |---|---|---|
-| `selected-tasks-completed("Decide")` + `=js:vars.decision === "reject"`, where `Decide` declares `Action -> decision` | the case variable `Decide` writes | ✗ stale / `null` |
-| `selected-tasks-completed("Decide")` + `=js:vars.action === "reject"`, where `action` is `Decide`'s own output | the producing output | ✓ populated |
+| `Action -> decision` | `vars.decision` — the renamed slot | ✗ `null` |
+| `Action -> decision` | `vars.$xref(...,'Action')` — the emptied slot | ✗ `null` |
+| no Outputs row for `Action` | `vars.$xref(...,'Action')` — one slot, one name | ✓ populated |
 
-**Rule:** when a condition's WHEN names a task, its `IF` MUST read that task's own output. Keep the `->` extract whenever the value must persist (Case App, audit, a later stage reads it) — the extract is not what the gate reads. Applies wherever the WHEN names the producer: stage-exit `selected-tasks-completed`, task-entry `selected-tasks-completed`, and the `selected-stage-exited` lane entry paired with a diverting exit — that entry repeats the origin exit's guard, so it repeats the producer reference too. Guard pairs stay exact inverses of each other.
+**Rule:** a gate reads the producing task's own field as `vars.$xref('<Stage>','<Task>','<field>')`, and that field carries no renaming Outputs row — either no row at all, or an equal-name row whose target is unique case-wide. When the value is also consumed elsewhere (Case App, audit, a later stage), add a separate `=` row that copies it into a Case variable; a copy leaves the field's own slot intact. Applies to every WHEN that fires on a task completing: `required-tasks-completed`, stage-exit and task-entry `selected-tasks-completed`, `selected-stage-completed`, and the `selected-stage-exited` lane entry paired with a diverting exit — that entry repeats the origin exit's guard, so it repeats the producer reference too. Guard pairs stay exact inverses of each other.
 
 ### Trigger payloads
 
@@ -435,7 +436,7 @@ ONE checklist. Settle every item by assumption during Sketch; re-walk at Confirm
 2. **Reachability walk** — every stage reachable from a trigger or SLA source (walk entries forward); every primary stage's completion consumed downstream, referenced by another entry, or feeding a lane; ≥ 1 primary stage `Required: Yes`; `adhoc` never a stage entry. Decision-reachable lanes and duplicate-entry ambiguity per § Secondary-lane entry shapes.
 3. **Entry producer** — every non-start entry names its concrete producer (source stage/task, connector event, paired `wait-for-user` exit, declared SLA reference); at-risk rows name the escalation, breach rows the SLA alone.
 4. **Decision-routing closure** — every decision outcome routes somewhere: no dead-end status values; an outcome targeting a lane keys that lane's entry; every routing button's variable+value is consumed downstream or a declared terminal; a fully-orphaned decision variable on a decision task is blocking.
-5. **Gate reads the producer** — no condition whose WHEN names a task reads a case variable that task writes (§ Gate on the producer).
+5. **Gate reads the producer** — no condition firing on a task completing reads a field that an Outputs row renamed (§ Gate on the producer).
 6. **Data closure** — every configure/decide output lands in a variable or direct reference; every send/connector/agent required input maps to variables/literals/upstream outputs as far as knowable without schemas (rest resolves at build); thresholded policy in executable cells (§ Expressions).
 7. **Task-surface classification** — human-performed required work `action`, optional user-launched `adhoc`; no compliance trigger phrase paired with a non-`action` type without explicit user reconciliation (§ Task-type override priority).
 8. **Required-task presence** — a `required-tasks-completed` completion over a stage with zero `Required: Yes` tasks fails validate: `Stage exit rule '<name>' has no task(s) marked as required`; offer marking the terminal task required.

--- a/skills/uipath-planner/references/case-design-layers-guide.md
+++ b/skills/uipath-planner/references/case-design-layers-guide.md
@@ -262,7 +262,12 @@ A task field lands in exactly one slot. `Action -> decision` puts the value in `
 | `Action -> decision` | `vars.$xref(...,'Action')` — the emptied slot | ✗ `null` |
 | no Outputs row for `Action` | `vars.$xref(...,'Action')` — one slot, one name | ✓ populated |
 
-**Rule:** a gate reads the producing task's own field as `vars.$xref('<Stage>','<Task>','<field>')`, and that field carries no renaming Outputs row — either no row at all, or an equal-name row whose target is unique case-wide. When the value is also consumed elsewhere (Case App, audit, a later stage), add a separate `=` row that copies it into a Case variable; a copy leaves the field's own slot intact. Applies to every WHEN that fires on a task completing: `required-tasks-completed`, stage-exit and task-entry `selected-tasks-completed`, `selected-stage-completed`, and the `selected-stage-exited` lane entry paired with a diverting exit — that entry repeats the origin exit's guard, so it repeats the producer reference too. Guard pairs stay exact inverses of each other.
+**Rule** — all four hold for a gate that fires on a task completing:
+
+1. The `IF` reads the producing task's own field as `vars.$xref('<Stage>','<Task>','<field>')`.
+2. That field carries no renaming Outputs row — no row at all, or an equal-name row whose target is unique case-wide.
+3. A value consumed elsewhere (Case App, audit, a later stage) gets a separate `=` row that copies it into a Case variable; a copy leaves the field's own slot intact.
+4. The WHENs this covers are `required-tasks-completed`, stage-exit and task-entry `selected-tasks-completed`, `selected-stage-completed`, and the `selected-stage-exited` lane entry paired with a diverting exit — that entry repeats the origin exit's guard, so it repeats the producer reference too. Guard pairs stay exact inverses of each other.
 
 ### Trigger payloads
 

--- a/skills/uipath-planner/scripts/audit_sdd.py
+++ b/skills/uipath-planner/scripts/audit_sdd.py
@@ -232,7 +232,7 @@ _TASK_COMPLETION_WHENS = (
     "selected-stage-completed",
     "selected-stage-exited",
 )
-_RENAMING_EXTRACT = re.compile(r"^\|\s*`?([\w.]+)`?\s*\|\s*->\s*`?(\w+)`?\s*\|", re.M)
+_RENAMING_EXTRACT = re.compile(r"^\|\s*`?([\w.]+)`?\s*\|\s*->\s*`?(\w+)`?\s*\|")
 
 
 def gate_reads_renamed_findings(text: str) -> list[str]:
@@ -251,11 +251,13 @@ def gate_reads_renamed_findings(text: str) -> list[str]:
         if match:
             rows.append((match.group(1), match.group(2), line_no))
     leaf_counts = Counter(field.split(".")[-1] for field, _, _ in rows)
-    renamed: dict[str, tuple[str, int]] = {}
+    # Several rows may feed one target (a lane collecting a reason from four tasks).
+    # Keep every one, so the finding names each line a reader has to fix.
+    renamed: dict[str, list[tuple[str, int]]] = {}
     for field, target, line_no in rows:
         leaf = field.split(".")[-1]
         if leaf != target or leaf_counts[leaf] > 1:
-            renamed[target] = (field, line_no)
+            renamed.setdefault(target, []).append((field, line_no))
     if not renamed:
         return findings
 
@@ -268,11 +270,13 @@ def gate_reads_renamed_findings(text: str) -> list[str]:
         for name in dict.fromkeys(re.findall(r"vars\.([A-Za-z_]\w*)", line)):
             if name not in renamed:
                 continue
-            field, src_line = renamed[name]
+            sources = renamed[name]
+            where = ", ".join(f"line {src} (`{field} -> {name}`)" for field, src in sources)
+            first_field = sources[0][0]
             findings.append(
-                f"line {line_no}: gate reads {name!r}, which line {src_line} moves off its own "
-                f"slot with `{field} -> {name}`. Read the producing field itself — "
-                f"`vars.$xref('<Stage>','<Task>','{field}')` — and copy the value into "
+                f"line {line_no}: gate reads {name!r}, which {where} moves off its own slot. "
+                f"Read the producing field itself — "
+                f"`vars.$xref('<Stage>','<Task>','{first_field}')` — and copy the value into "
                 f"{name!r} with a separate `=` row when it is consumed elsewhere"
             )
     return findings

--- a/skills/uipath-planner/scripts/audit_sdd.py
+++ b/skills/uipath-planner/scripts/audit_sdd.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import re
 import sys
-from collections import Counter
 from pathlib import Path
 
 REQUIRED_HEADINGS = [
@@ -220,65 +219,6 @@ def lineage_findings(text: str) -> list[str]:
             f"variable {name!r} is consumed but never produced — keep its producer output row "
             f"(`-> {name}`), assignment, Default, or trigger source"
         )
-    return findings
-
-
-# WHEN keywords whose rule fires on a task completing. The producing task's extract
-# has not landed when the rule is evaluated, so a gate reading the renamed target
-# reads the slot the extract left empty.
-_TASK_COMPLETION_WHENS = (
-    "required-tasks-completed",
-    "selected-tasks-completed",
-    "selected-stage-completed",
-    "selected-stage-exited",
-)
-_RENAMING_EXTRACT = re.compile(r"^\|\s*`?([\w.]+)`?\s*\|\s*->\s*`?(\w+)`?\s*\|")
-
-
-def gate_reads_renamed_findings(text: str) -> list[str]:
-    """A gate that fires on task completion must read the producing task's own field.
-
-    `<field> -> <other name>` moves the value off the field's own slot; the slot the
-    gate reads stays empty, the branch never fires, the stage stalls, nothing errors.
-    An equal-name row (`x -> x`) keeps one name, unless a second row extracts the same
-    field name elsewhere in the case — the allocator suffixes the later slot and the two
-    names split again, so a colliding equal-name row is reported too.
-    """
-    findings: list[str] = []
-    rows: list[tuple[str, str, int]] = []
-    for line_no, line in enumerate(text.splitlines(), 1):
-        match = _RENAMING_EXTRACT.match(line)
-        if match:
-            rows.append((match.group(1), match.group(2), line_no))
-    leaf_counts = Counter(field.split(".")[-1] for field, _, _ in rows)
-    # Several rows may feed one target (a lane collecting a reason from four tasks).
-    # Keep every one, so the finding names each line a reader has to fix.
-    renamed: dict[str, list[tuple[str, int]]] = {}
-    for field, target, line_no in rows:
-        leaf = field.split(".")[-1]
-        if leaf != target or leaf_counts[leaf] > 1:
-            renamed.setdefault(target, []).append((field, line_no))
-    if not renamed:
-        return findings
-
-    for line_no, line in enumerate(text.splitlines(), 1):
-        if not line.startswith("|"):
-            continue
-        first_cell = line.strip("|").split("|")[0].strip().strip("`")
-        if not first_cell.startswith(_TASK_COMPLETION_WHENS):
-            continue
-        for name in dict.fromkeys(re.findall(r"vars\.([A-Za-z_]\w*)", line)):
-            if name not in renamed:
-                continue
-            sources = renamed[name]
-            where = ", ".join(f"line {src} (`{field} -> {name}`)" for field, src in sources)
-            first_field = sources[0][0]
-            findings.append(
-                f"line {line_no}: gate reads {name!r}, which {where} moves off its own slot. "
-                f"Read the producing field itself — "
-                f"`vars.$xref('<Stage>','<Task>','{first_field}')` — and copy the value into "
-                f"{name!r} with a separate `=` row when it is consumed elsewhere"
-            )
     return findings
 
 
@@ -885,7 +825,6 @@ def audit(sdd_path: Path, draft_path: Path | None) -> list[str]:
     if degraded:
         findings.append(f"model checks disarmed: {degraded}")
     findings.extend(lineage_findings(text))
-    findings.extend(gate_reads_renamed_findings(text))
     findings.extend(model_findings(text, facts, carried))
     findings.extend(contract_findings(text, facts or {"gate_rules": {}, "yes_when": set(), "no_when": set()}))
 

--- a/skills/uipath-planner/scripts/audit_sdd.py
+++ b/skills/uipath-planner/scripts/audit_sdd.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import re
 import sys
+from collections import Counter
 from pathlib import Path
 
 REQUIRED_HEADINGS = [
@@ -219,6 +220,61 @@ def lineage_findings(text: str) -> list[str]:
             f"variable {name!r} is consumed but never produced — keep its producer output row "
             f"(`-> {name}`), assignment, Default, or trigger source"
         )
+    return findings
+
+
+# WHEN keywords whose rule fires on a task completing. The producing task's extract
+# has not landed when the rule is evaluated, so a gate reading the renamed target
+# reads the slot the extract left empty.
+_TASK_COMPLETION_WHENS = (
+    "required-tasks-completed",
+    "selected-tasks-completed",
+    "selected-stage-completed",
+    "selected-stage-exited",
+)
+_RENAMING_EXTRACT = re.compile(r"^\|\s*`?([\w.]+)`?\s*\|\s*->\s*`?(\w+)`?\s*\|", re.M)
+
+
+def gate_reads_renamed_findings(text: str) -> list[str]:
+    """A gate that fires on task completion must read the producing task's own field.
+
+    `<field> -> <other name>` moves the value off the field's own slot; the slot the
+    gate reads stays empty, the branch never fires, the stage stalls, nothing errors.
+    An equal-name row (`x -> x`) keeps one name, unless a second row extracts the same
+    field name elsewhere in the case — the allocator suffixes the later slot and the two
+    names split again, so a colliding equal-name row is reported too.
+    """
+    findings: list[str] = []
+    rows: list[tuple[str, str, int]] = []
+    for line_no, line in enumerate(text.splitlines(), 1):
+        match = _RENAMING_EXTRACT.match(line)
+        if match:
+            rows.append((match.group(1), match.group(2), line_no))
+    leaf_counts = Counter(field.split(".")[-1] for field, _, _ in rows)
+    renamed: dict[str, tuple[str, int]] = {}
+    for field, target, line_no in rows:
+        leaf = field.split(".")[-1]
+        if leaf != target or leaf_counts[leaf] > 1:
+            renamed[target] = (field, line_no)
+    if not renamed:
+        return findings
+
+    for line_no, line in enumerate(text.splitlines(), 1):
+        if not line.startswith("|"):
+            continue
+        first_cell = line.strip("|").split("|")[0].strip().strip("`")
+        if not first_cell.startswith(_TASK_COMPLETION_WHENS):
+            continue
+        for name in dict.fromkeys(re.findall(r"vars\.([A-Za-z_]\w*)", line)):
+            if name not in renamed:
+                continue
+            field, src_line = renamed[name]
+            findings.append(
+                f"line {line_no}: gate reads {name!r}, which line {src_line} moves off its own "
+                f"slot with `{field} -> {name}`. Read the producing field itself — "
+                f"`vars.$xref('<Stage>','<Task>','{field}')` — and copy the value into "
+                f"{name!r} with a separate `=` row when it is consumed elsewhere"
+            )
     return findings
 
 
@@ -825,6 +881,7 @@ def audit(sdd_path: Path, draft_path: Path | None) -> list[str]:
     if degraded:
         findings.append(f"model checks disarmed: {degraded}")
     findings.extend(lineage_findings(text))
+    findings.extend(gate_reads_renamed_findings(text))
     findings.extend(model_findings(text, facts, carried))
     findings.extend(contract_findings(text, facts or {"gate_rules": {}, "yes_when": set(), "no_when": set()}))
 

--- a/tests/tasks/uipath-maestro-case/aged_invoice_structural/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/aged_invoice_structural/fixtures/sdd.md
@@ -266,7 +266,7 @@
 
 | Field | Binding / Value |
 |-------|------------------|
-| Action | -> apDecision |
+| — | — |
 
 **Actions:**
 

--- a/tests/tasks/uipath-planner/case_finalize_draft_reject/check_reject_route.py
+++ b/tests/tasks/uipath-planner/case_finalize_draft_reject/check_reject_route.py
@@ -57,6 +57,22 @@ def positive_reject(cell: str) -> bool:
     return DECISION_VAR in flat and DECISION_VALUE in flat and "!=" not in cell
 
 
+def renaming_row_for(target_var: str) -> tuple[str, int] | None:
+    """The Outputs row that renames some field into `target_var`, if one exists.
+
+    An equal-name row keeps one slot under one name and is not a rename.
+    """
+    for line_no, line in enumerate(read_sdd().splitlines(), 1):
+        match = re.match(r"^\|\s*`?([\w.]+)`?\s*\|\s*->\s*`?(\w+)`?\s*\|", line)
+        if not match:
+            continue
+        field, target = match.group(1), match.group(2)
+        flat = re.sub(r"[^a-z0-9]", "", target.lower())
+        if flat == target_var and field.split(".")[-1] != target:
+            return field, line_no
+    return None
+
+
 def marks_complete(row: dict[str, str]) -> str:
     return column(row, "marks stage complete", "marks complete").strip().lower()
 
@@ -104,6 +120,19 @@ def main() -> None:
         for row in keyed:
             if not column(row, "interrupting").lower().startswith("y"):
                 fail(f"{LANE!r} decision-keyed entry row is not Interrupting: Yes")
+
+        # The guard above is only reachable if the decision still sits in the field the
+        # producing task writes. An Outputs row that renames it moves the value elsewhere
+        # and leaves that field empty, so the guard reads nothing and the lane never opens
+        # (references/case-design-layers-guide.md § Gate on the producer).
+        renamed = renaming_row_for(DECISION_VAR)
+        if renamed:
+            field, line_no = renamed
+            fail(
+                f"line {line_no} renames {field!r} into the variable the decision guard reads; "
+                f"a renamed field is empty when the gate evaluates. Read the field itself with "
+                f"vars.$xref(...) and copy it with a separate `=` row if it is needed elsewhere"
+            )
 
         if scope == "lane":
             print(f"OK: {LANE} is entered from the decision fact, not the stage picker")


### PR DESCRIPTION
## What goes wrong

A case built from an SDD stalls right after a person makes a decision. The buyer approves, both of that stage's required tasks finish, and then nothing happens. The stage stays open, the next stage never opens, and the case sits there. There is no incident, no error, and `uip maestro case validate` calls the case valid.

The runtime shows the guard on that stage's exit evaluating to false at the moment the value it reads is present:

```json
{"expression": false, "expressionString": "vars.buyerDecision === \"approve\""}
```

Once it evaluates false, nothing moves again: the event that would trigger the next evaluation is the very one the case is waiting for.

## Why it happens

A task field lands in exactly one slot. The SDD wrote `Action -> buyerDecision`, which gives one value two names: the engine stores it under `buyerDecision`, while a task-output reference resolves to the minted `action2`. Neither name reaches every scope a guard is evaluated in, so the branch never fires.

Two frontend sites pick different slots, which is why a renaming row splits them:

- [`CaseManagementTasksEventSubprocessUtils.ts:153,155`](https://github.com/UiPath/PO.Frontend/blob/b1ed4e8b37188fd7d2482899d884abfde747dbe9/src/services/serialization/converters/case-converter/case-mgmt/generate-adhoc-case/tasks-event-subprocess/shared/lifecycle/CaseManagementTasksEventSubprocessUtils.ts#L153-L155) hoists the value out of the task with `` `=js:vars.${output.var ?? output.id}` `` — the renamed slot whenever a row renames.
- [`CaseManagementOrchestrationTaskFlowUtils.ts:205`](https://github.com/UiPath/PO.Frontend/blob/b1ed4e8b37188fd7d2482899d884abfde747dbe9/src/services/serialization/converters/case-converter/case-mgmt/generate-adhoc-case/main-event-subprocess/shared/utils/CaseManagementOrchestrationTaskFlowUtils.ts#L205) builds the state the rules evaluator reads with `` `=js:vars.${output.id}` `` — always the field's own slot.

A field with no renaming row keeps one name for both, so both sites agree and the guard reads a populated slot.

A runtime record bears this out. Across thirteen variable scopes in two instances of a case carrying this shape, every `id` slot is null in every scope, while the `var` name is carried by the case globals and the task-completion scope and absent from the rest. Neither half is dependable wherever a guard happens to be evaluated.

**The platform side of this is a known open defect** — renamed values are not visible to rule evaluation, tracked as MST-10838, unresolved since June. This PR does not fix that. It stops the coding agent from authoring the shape that triggers it, and the real fix belongs on the platform.

This is the third attempt at that from the skills side:

| | Fix | What it did |
|---|---|---|
| Jun 15 | [#1471](https://github.com/UiPath/skills/pull/1471) | Introduced `vars.$xref('Stage','Task','field')` so a gate could name a task's own field instead of the case variable |
| Aug 20 | [#2718](https://github.com/UiPath/skills/pull/2718) | Reorganised the case guidance after the last report of this bug, writing the § Gate on the producer section that carries the sentence below |
| this PR | | Closes the gap both left, and adds the mechanical checks so a fourth report does not depend on wording alone |

## Why the guidance produced that shape

**First, the stated reason invited an exemption.** A case built while this PR was open reached the same shape, and its build log records how. The agent adopted the reason the sentence below gives, that "the extract of the task that fired the gate has not run yet, so an `IF` that reads a case variable that task writes is stale", and concluded that a gate firing after a whole stage completes is therefore safe. It wrote that exemption down, built a classifier around it, and the classifier reported all seventeen of the case's gates clean. Two of them were the stalling shape. Timing is not the mechanism: the record above holds in every scope of both instances, so a later evaluation reaches no populated slot either. A reason phrased as "not yet" licenses an exemption for anything that fires later; the replacement states what holds at every moment.

**Second, two instructions pointed opposite ways.**

§ When to declare a Case Variables row offered "case-level state read by a condition (`IF`)" as a reason to declare a row, and never said that a task's own field is not case-level state. Declaring a row means an Outputs row moves the value into it.

§ Gate on the producer then said the `->` extract can stay, because the extract is not what the gate reads. It is exactly what the gate reads — the gate reads the slot the extract emptied.

An author following both instructions produces a renamed field with a gate pointed at it.

## What changes

- The Case-Variables rule keeps its three existing reasons and gains the boundary it was missing: a task's own field is not case-level state, and a gate reads it with `vars.$xref(...)`. State produced by a `Default`, an `=` row, or a decision button is still declared and still read by an `IF` — five variables across the existing fixtures do exactly that.
- A value that is also needed elsewhere is copied with a separate `=` row. A copy leaves the field's own slot intact; a rename does not.
- The WHEN list gains `required-tasks-completed` and `selected-stage-completed`. The scheduler recognises six event types ([`Constants.cs:35-43`](https://github.com/UiPath/dmnscheduler/blob/bfeec30a8eaa6478df2073479a781df1a6d6cc29/Scheduler/Core/Constants.cs#L35-L43)) and a stage completing is not among them — a stage completes because its last required task did, so both of these evaluate on a `TaskCompleted` pass exactly like the two already listed.
- The rule is scoped by what the `IF` reads rather than by what fires the gate. A scope worded as "a gate that fires on a task completing" excludes `selected-stage-completed` on its face, which is how an agent holding item 4's own list still stepped over it.
- The rule becomes four numbered obligations instead of one sentence carrying four.

This guidance has been restated twice and a case reached the same shape both times, so the change is not only wording. `audit_sdd.py` now reports any gate reading a renamed field, naming the line that renamed it and the shape to use instead, and reads both the bare and backticked WHEN cell styles the fixtures use. `check_reject_route.py` gains the same rule at the point where it already asserts the rejection route exists, so an SDD passes by carrying the gate **and** leaving the field unrenamed — a criterion that only asked "no finding" would have passed an agent that authored nothing at all.

Two fixtures carry the shape today. `aged_invoice_structural` gates on a field its own decision buttons already write, so the renaming row was redundant and is dropped. `case_finalize_draft` gates on a field whose renaming row is its only producer; removing it would break lineage, so it is reported for its owner rather than rewritten here.

## Verification

- All nineteen SDD fixtures audited before and after, with both script versions colocated so the model-driven checks arm identically: byte-identical output on eighteen, the nineteenth differing only by the two new findings.
- Eleven hand-built cases. Reported: a renamed field read by each of the four WHENs, in bare and in backticked cells, and an equal-name row whose field is extracted twice. Silent: an equal-name unique row, a renamed field with no reader, one read by a task input rather than a gate, one read under `case-entered`, and a dotted equal-name path.
- `check_reject_route.py` exits 0 on a finalized SDD carrying the gate, 1 with a rename spliced in, and 1 on the unfinalized draft — doing nothing does not pass.
- `load_model_facts` still returns `degraded: None` with all five facts populated; one edited line sits inside a section it parses, and a silent failure there would disarm three other checks.
- `expressionIsValidLength` ([`Tools.ts:686-692`](https://github.com/UiPath/PO.Frontend/blob/b1ed4e8b37188fd7d2482899d884abfde747dbe9/src/utils/Tools.ts#L686-L692)) rejects only an empty string, so no guard is dropped for length.
- `npm run skills:validate` OK · `check-skill-status.py` OK · `validate-skill-descriptions.sh` clean · `pytest tests/tasks/uipath-maestro-case/_shared/` 52 passed, 14 skipped · all five in-file anchors resolve · no flavor override or marker on any changed file.




