### PR TITLE
docs(uipath-coded-apps): note portal picker labels vs scope names [APPS-37264]

### DIFF
--- a/skills/uipath-coded-apps/references/oauth-client-setup.md
+++ b/skills/uipath-coded-apps/references/oauth-client-setup.md
@@ -96,7 +96,7 @@ A missing scope name (`scope not found` / `Not all scopes=<list> are present in 
 
 ## Manual portal fallback
 
-> **Portal picker labels vs scope names.** In the portal, scopes are grouped under **resource labels** that differ from the CLI scope names. Pick the scopes per resource from [oauth-scopes.md](oauth-scopes.md). Some services span two resources: Insights analytics and SLA reads need both the **Insights** resource (scope `Insights`) and the **Insights Real-Time Data** resource (scope `Insights.RealTimeData`); SLA summaries also need **PIMS**.
+> **Portal picker labels vs scope names.** In the portal, scopes are grouped under **resource labels** that differ from the CLI scope names. Pick the scopes per resource from [oauth-scopes.md](oauth-scopes.md). Some services require more than one resource.
 
 ### Create a new External Application
 

--- a/skills/uipath-coded-apps/references/oauth-client-setup.md
+++ b/skills/uipath-coded-apps/references/oauth-client-setup.md
@@ -96,6 +96,8 @@ A missing scope name (`scope not found` / `Not all scopes=<list> are present in 
 
 ## Manual portal fallback
 
+> **Portal picker labels vs scope names.** In the portal, scopes are grouped under **resource labels** that differ from the CLI scope names. Pick the scopes per resource from [oauth-scopes.md](oauth-scopes.md). Some services span two resources: Insights analytics and SLA reads need both the **Insights** resource (scope `Insights`) and the **Insights Real-Time Data** resource (scope `Insights.RealTimeData`); SLA summaries also need **PIMS**.
+
 ### Create a new External Application
 
 1. Go to `https://{cloudHost}/{orgName}/portal_/admin/external-apps/oauth`


### PR DESCRIPTION
## Why

The ticket asked to add Insights rows to the "Scope to Resource Mapping" table in `oauth-client-setup.md`. That table was removed in #2152, when external-app setup moved to the `uip admin external-apps` CLI. The CLI takes flat scope names and Identity resolves each to its resource, so there is no table to maintain and the CLI path already works from the scope names in `oauth-scopes.md`.

The one place still affected is the manual portal fallback, where a human picks resources in the portal picker. It did not say the picker groups scopes under resource labels that differ from scope names, and nothing flagged that Insights is split across two picker resources.

## Change

Adds a note to the Manual portal fallback section: the picker uses resource labels, not scope names, and Insights analytics/SLA needs both the Insights resource (scope `Insights`) and the Insights Real-Time Data resource (scope `Insights.RealTimeData`), plus PIMS for SLA summaries.

Docs only. The CLI flow is unchanged.