### PR TITLE
fix: repair 7 inert CODEOWNERS rules for flow skill plugin paths

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -100,8 +100,8 @@
 /tests/tasks/uipath-maestro-flow/ @UiPath/maestro-cli-team
 
 # Context grounding team — flow plugins (Summarize/Batch Transform) + tasks
-/skills/uipath-maestro-flow/references/author/references/plugins/summarize/ @gcuip @JeremyReist2 @cfauchere @CalebMartinUiPath @jordan-uipath @eteodorovici @pateljay43 @swathiJayav @UiPath/maestro-cli-team
-/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/ @gcuip @JeremyReist2 @cfauchere @CalebMartinUiPath @jordan-uipath @eteodorovici @pateljay43 @swathiJayav @UiPath/maestro-cli-team
+/skills/uipath-maestro-flow/references/author/plugins/summarize/ @gcuip @JeremyReist2 @cfauchere @CalebMartinUiPath @jordan-uipath @eteodorovici @pateljay43 @swathiJayav @UiPath/maestro-cli-team
+/skills/uipath-maestro-flow/references/author/plugins/batch-transform/ @gcuip @JeremyReist2 @cfauchere @CalebMartinUiPath @jordan-uipath @eteodorovici @pateljay43 @swathiJayav @UiPath/maestro-cli-team
 /tests/tasks/uipath-maestro-flow/context-grounding/ @gcuip @JeremyReist2 @cfauchere @CalebMartinUiPath @jordan-uipath @eteodorovici @pateljay43 @swathiJayav @UiPath/maestro-cli-team
 
 # Maestro BPMN skill
@@ -131,15 +131,15 @@
 
 # Flow skill — plugin guides (away team owned)
 # Add your team here when contributing a new plugin category
-/skills/uipath-maestro-flow/references/plugins/connector/ @chandusailella @UiPath/maestro-cli-team
-/skills/uipath-maestro-flow/references/plugins/connector-trigger/ @chandusailella @UiPath/maestro-cli-team
-/skills/uipath-maestro-flow/references/author/references/plugins/agent/ @UiPath/team-coded-agents @AlexandruCGhimisi @andreibalas-uipath @al3xanndru @UiPath/maestro-cli-team
-/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/ @AlexandruCGhimisi @andreibalas-uipath @al3xanndru @UiPath/maestro-cli-team
+/skills/uipath-maestro-flow/references/author/plugins/connector/ @chandusailella @UiPath/maestro-cli-team
+/skills/uipath-maestro-flow/references/author/plugins/connector-trigger/ @chandusailella @UiPath/maestro-cli-team
+/skills/uipath-maestro-flow/references/author/plugins/agent/ @UiPath/team-coded-agents @AlexandruCGhimisi @andreibalas-uipath @al3xanndru @UiPath/maestro-cli-team
+/skills/uipath-maestro-flow/references/author/plugins/inline-agent/ @AlexandruCGhimisi @andreibalas-uipath @al3xanndru @UiPath/maestro-cli-team
 /tests/tasks/uipath-maestro-flow/connector_features/ @chandusailella @mukundbayyaram @UiPath/maestro-cli-team
 /tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector @UiPath/DatafabricCodingAgent @UiPath/maestro-cli-team
 
 # IXP
-/skills/uipath-maestro-flow/references/author/references/plugins/ixp/ @UiPath/communications-mining @constantinmuraru @vlad-crisan @UiPath/maestro-cli-team
+/skills/uipath-maestro-flow/references/author/plugins/ixp/ @UiPath/communications-mining @constantinmuraru @vlad-crisan @UiPath/maestro-cli-team
 /tests/tasks/uipath-maestro-flow/ixp/ @UiPath/communications-mining @constantinmuraru @vlad-crisan @UiPath/maestro-cli-team
 
 # Review skill


### PR DESCRIPTION
## What

Seven flow-skill CODEOWNERS rules pointed at directories that no longer exist. GitHub matched nothing, so the listed owners were never requested and PRs fell through to the default `*` owners. No error, no warning.

## Which rules, and when they broke

**Broke in #2879** (the `references/` flatten, which didn't touch CODEOWNERS):

| Line | Stale path |
|------|-----------|
| 103 | `.../references/author/references/plugins/summarize/` |
| 104 | `.../references/author/references/plugins/batch-transform/` |
| 136 | `.../references/author/references/plugins/agent/` |
| 137 | `.../references/author/references/plugins/inline-agent/` |
| 142 | `.../references/author/references/plugins/ixp/` |

**Broke earlier**, when the plugins tree first moved under `author/` (traced to #189):

| Line | Stale path |
|------|-----------|
| 134 | `.../references/plugins/connector/` |
| 135 | `.../references/plugins/connector-trigger/` |

All seven now point at `references/author/plugins/<name>/`.

Owners who had silently lost review on their own files: context-grounding (@gcuip et al.), coded-agents, communications-mining, and @chandusailella.

## Scope

CODEOWNERS only, 7 lines. All 117 rules were audited — including `preview/`, `tests/`, and `skill-flavors/` — and nothing else is stale.

Independent of #2884, which fixes the broken links from the same flatten. No file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)