### PR TITLE
test(maestro-flow): DevCon billing-resolution Slack-notify outcome e2e task

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/billing_resolution_slack_notify/billing_resolution_slack_notify.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/billing_resolution_slack_notify/billing_resolution_slack_notify.yaml
@@ -1,0 +1,86 @@
+task_id: skill-flow-e2e-billing-resolution-slack-notify
+description: >
+  End-to-end, outcome-based extension of the DevCon billing-resolution-writer
+  scenario. The agent builds a manual-trigger Flow whose inline low-code agent
+  (uipath.agent.autonomous) drafts a customer-facing billing-dispute resolution,
+  then posts that resolution to Slack. The grader seeds one case, runs `uip
+  maestro flow debug --inputs`, and verifies the OUTCOME: the flow completes,
+  the drafted emailBody cites the disputed invoice and the approved credit, and
+  — the point of the test — the Slack "Send Message to channel" activity
+  actually posted (a real message ts surfaced as a flow output), carrying the
+  correlationId and the invoice number. Grades the delivered Slack side effect,
+  not "did it draft".
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, node:inline-agent, connector, path-to-ga, outcome-graded]
+
+run_limits:
+  max_turns: 150
+  turn_timeout: 3000
+  task_timeout: 3600
+
+pre_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/billing_resolution_slack_notify/seed.py"
+    timeout: 30
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120
+
+initial_prompt: |
+  Build a UiPath Maestro Flow "BillingResolutionSlackNotify" (in a solution of
+  the same name) with a MANUAL trigger. It drafts a customer-facing
+  billing-dispute resolution with an inline low-code agent, then posts that
+  resolution to Slack.
+
+  Trigger inputs (variables associated with the manual trigger): `customerName`
+  (string), `invoiceNumber` (string), `creditAmount` (number), `correlationId`
+  (string).
+
+  Steps:
+  1. An inline low-code agent (`uipath.agent.autonomous`) embedded in the flow
+     project (scaffold it inline, not a separately published agent) reads the
+     inputs and returns two strings: the email `subject` and `body`. The body
+     must state the invoice number and the approved credit amount.
+  2. Post the resolution to Slack using the Slack "Send Message to channel"
+     activity: channel "coding-agent-testing", the Slack connection named
+     "is-sandboxes", send as `user`. The message must include the correlationId,
+     the invoice number, and the approved credit amount.
+  3. End the flow, mapping these `out` variables:
+     - emailSubject   (the agent's subject)
+     - emailBody      (the agent's body — cites the invoice and the credit)
+     - caseKey        = the incoming correlationId
+     - slackMessageId = the identifier of the Slack message that was posted
+                        (from the Slack Send Message node's output)
+
+  Validate the flow. Do NOT run or debug the flow — the grader executes it with
+  seeded inputs. Do NOT ask for approval, confirmation, or feedback, and do NOT
+  pause between planning and implementation. Build the complete flow end-to-end
+  in a single pass. Before starting, load the uipath-maestro-flow skill and
+  follow its workflow.
+
+success_criteria:
+  # ── The agent validated the flow (convention adherence) ─────────────────
+  - type: command_executed
+    description: "Agent validated the generated Flow"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # ── The delivered flow validates ────────────────────────────────────────
+  - type: run_command
+    description: "Generated BillingResolutionSlackNotify Flow validates without errors"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 180
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── OUTCOME: seeded run drafts via the inline agent AND posts to Slack ────
+  - type: run_command
+    description: "Seeded debug run completes; inline agent present; emailBody cites the invoice + approved credit; and the Slack alert was actually posted (real message ts) carrying the correlationId + invoice"
+    command: "python3 $TASK_DIR/check_billing_resolution_slack_notify.py"
+    timeout: 900
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/billing_resolution_slack_notify/check_billing_resolution_slack_notify.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/billing_resolution_slack_notify/check_billing_resolution_slack_notify.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Inline-agent writer flow that ALSO posts to Slack — outcome-graded.
+
+Extends the DevCon billing-resolution-writer scenario with a real third-party
+side effect. Three layers, so nothing can be faked:
+
+  1. Structural: the flow contains an inline `uipath.agent.autonomous` node
+     (a Script cannot stand in for the agent) AND a real Slack connector send.
+  2. Draft behavior: `flow debug` completes and the drafted email — landed in
+     the mapped `emailBody` output — cites the invoice and the approved credit.
+     Scoped to the `emailBody` global, not the whole payload (the trigger echoes
+     `invoiceNumber` back, so a whole-payload match is a false pass).
+  3. Slack outcome: the `Send Message to channel` activity actually posted — the
+     flow surfaces the posted message's ts as `slackMessageId`, verified against
+     the executed send node's own response, and the message carries the
+     correlationId and the invoice number.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Walk up to the directory that holds `_shared` so the import works regardless
+# of how deep this task lives under tests/tasks/uipath-maestro-flow/.
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+from _shared.flow_check import (  # noqa: E402
+    assert_connector_send_identity,
+    assert_flow_has_node_type,
+    assert_flow_uses_connector_target,
+    assert_named_output_contains,
+    assert_output_nonempty,
+    assert_slack_message_posted,
+    run_debug,
+)
+
+SLACK_KEY = "uipath-salesforce-slack"
+SLACK_CHANNEL = "C0B2FDZD1M3"  # coding-agent-testing
+INVOICE = "MCS-2026-04872"
+CREDIT = ["1610", "1,610"]
+
+
+def main() -> None:
+    # Structural anti-hardcode: a real inline agent AND a real Slack send node.
+    assert_flow_has_node_type(["uipath.agent.autonomous"])
+    assert_flow_uses_connector_target(SLACK_KEY)
+    assert_connector_send_identity(
+        SLACK_KEY, expected="user", native_op_hint="send-message-to-channel"
+    )
+    print("OK: inline agent + Slack send node present")
+
+    seed_path = Path("seed.json")
+    if not seed_path.is_file():
+        raise SystemExit("FAIL: seed.json is missing; pre_run did not complete")
+    cases = json.loads(seed_path.read_text(encoding="utf-8")).get("cases")
+    if not isinstance(cases, list) or len(cases) != 1:
+        raise SystemExit("FAIL: seed.json must contain exactly one case")
+    case = cases[0]
+
+    # Default run_debug retry policy: a transient backend 5xx at provisioning
+    # (e.g. HTTP 504 on create-debug-instance) fires before the flow runs, so a
+    # retry is safe and does not risk a duplicate Slack post.
+    payload = run_debug(inputs=case["inputs"], timeout=540)
+
+    # Draft behavior — scoped to the mapped emailBody output.
+    assert_output_nonempty(payload, "emailSubject")
+    assert_named_output_contains(payload, "emailBody", INVOICE)
+    assert_named_output_contains(payload, "emailBody", CREDIT, require_all=False)
+    print(f"OK: emailBody drafted, cites invoice {INVOICE} and the approved credit")
+
+    # Slack outcome — verified against the executed send's own response.
+    assert_slack_message_posted(
+        payload,
+        "slackMessageId",
+        expected_channel=SLACK_CHANNEL,
+        must_contain=[case["inputs"]["correlationId"], INVOICE],
+    )
+    print(
+        f"OK: {case['name']} completed — resolution drafted and the Slack alert "
+        "was posted (real message ts) carrying the correlationId + invoice"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/e2e/billing_resolution_slack_notify/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/billing_resolution_slack_notify/seed.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Seed one DevCon billing-resolution case for the Slack-notify outcome eval.
+
+Writes seed.json with a single case: the customer, the disputed invoice, and the
+approved credit the inline agent drafts a resolution for. A fresh correlationId
+per run keeps the posted Slack message and the caseKey assertion isolated across
+runs. The invoice/credit are fixed oracles the grader checks in both the drafted
+emailBody and the posted Slack message. The grader
+(check_billing_resolution_slack_notify.py) runs `flow debug --inputs <inputs>`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+
+def build_seed() -> dict:
+    run_id = uuid4().hex[:12]
+    return {
+        "run_id": run_id,
+        "cases": [
+            {
+                "name": "northwind-resolution-slack-notify",
+                "inputs": {
+                    "customerName": "Northwind Traders",
+                    "invoiceNumber": "MCS-2026-04872",
+                    "creditAmount": 1610,
+                    "correlationId": f"RESO-{run_id}",
+                },
+                "expected": {
+                    "invoiceNumber": "MCS-2026-04872",
+                    "creditAmount": 1610,
+                    "caseKey": f"RESO-{run_id}",
+                },
+            }
+        ],
+    }
+
+
+def main() -> None:
+    path = Path("seed.json")
+    path.write_text(json.dumps(build_seed(), indent=2) + "\n", encoding="utf-8")
+    print(f"seeded {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a DevCon outcome test that grades a **real Slack side effect**, derived from the DevCon `billing_resolution_writer` scenario. Today that task only checks the **drafted email text** (`emailBody`) — a self-contained string, not a delivered outcome. This task keeps the inline-agent draft and adds the demo's real "notify" step: **post the resolution to Slack and verify it actually posted.**

- **New task** `e2e/billing_resolution_slack_notify/` (self-contained; does **not** touch the parity-locked `multi_node/billing_resolution_writer` campaign task).
- **Prompt:** inline `uipath.agent.autonomous` drafts `subject`/`body` citing the invoice + approved credit → Slack "Send Message to channel" posts the resolution to `coding-agent-testing` (`is-sandboxes` connection, send-as `user`, includes correlationId + invoice + credit) → End maps `emailSubject`, `emailBody`, `caseKey=correlationId`, `slackMessageId`.
- **Graded on delivered outcomes:** agent node present (anti-hardcode) + `emailBody` cites invoice & credit (kept from the original) + **`assert_slack_message_posted`** — a real message `ts` from the executed Slack send, in the right channel, carrying the correlationId + invoice.
- Seeded per-run `correlationId` isolates the posted message across runs; `run_debug` uses its default transient-retry (survives the backend `504`s seen on the sibling Slack task).

## Why a new task, not an edit of `billing_resolution_writer`
`billing_resolution_writer` is an arm of Tao's same-ground A/B campaign (contract 2026-08-10). Adding a Slack step to its pinned prompt would change what both arms build and break continuity with the recorded baseline. A self-contained derived task delivers the outcome coverage without perturbing the campaign.

## Success criteria
1. `command_executed` (1.5) — agent validated the flow
2. `run_command` (3.0) — `flow validate` passes (shared `validate_flow.py` helper)
3. `run_command` (5.0) — outcome checker: inline agent + drafted body cites invoice/credit + **real Slack post** verified

## Validation
Dispatching `run-coder-eval.yml` from this branch. (Note: this scenario builds an inline agent + a connector, so expect the same live-tenant flakiness as the sibling Slack task — may need a re-run for a clean provisioning cycle.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Evidence of passing run:** Ran `skill-flow-e2e-billing-resolution-slack-notify` on `run-coder-eval.yml` (claude, nightly) — **passed 3/3, weighted score 1.000** (run 33209555200, ~632s): inline agent drafted the resolution citing invoice MCS-2026-04872 + credit, and a real Slack message posted to coding-agent-testing was verified via its `ts`. Passed on the first attempt.
