### PR TITLE
test(maestro-flow): add real Slack outcome to billing_resolution_writer (in-place, cf #2890)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_resolution_writer.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_resolution_writer.py
@@ -167,18 +167,30 @@ def main():
 
     # Exactly one Slack SEND node (native connector node or connector-mode HTTP
     # proxy to the send op) — a read/search activity is not a delivery.
+    def _bound(v):
+        return v is not None and (not isinstance(v, str) or v.strip() != "")
+
     def is_slack_send(n: dict) -> bool:
         t = str(n.get("type", ""))
         if SLACK_KEY in t and SLACK_OP in t:
             return True
         detail = (n.get("inputs") or {}).get("detail") or {}
-        body = detail.get("bodyParameters") or {} if isinstance(detail, dict) else {}
+        if not isinstance(detail, dict):
+            return False
+        body = detail.get("bodyParameters") or {}
+        body = body if isinstance(body, dict) else {}
         target = str((body.get("targetConnector") or body.get("connectorKey") or "")).lower()
         auth = str(body.get("authentication") or "").lower()
+        # Mirror the live gate (_connector_node_ids): a connector-mode HTTP proxy
+        # counts only with a real bound connection. Without connectionId +
+        # connectionFolderKey it would pass here but fail assert_slack_message_posted
+        # with "no connected send node found".
         return (
             t.lower().startswith("core.action.http")
             and target == SLACK_KEY
             and auth == "connector"
+            and _bound(detail.get("connectionId"))
+            and _bound(detail.get("connectionFolderKey"))
             and SLACK_OP.replace("-", "") in json.dumps(detail).lower().replace("-", "").replace("_", "")
         )
 

--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_resolution_writer.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_resolution_writer.py
@@ -35,6 +35,8 @@ can see:
 Usage: advisory_billing_resolution_writer.py [<FlowName>.flow]
 """
 
+import json
+
 from advisory_flow_utils import (
     agent_prompt_text,
     carries_literal,

--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_resolution_writer.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_resolution_writer.py
@@ -26,6 +26,11 @@ can see:
    script that ignores the agent.
 5. **The draft is not written in.** No literal invoice number, credit amount, or
    canned email body anywhere in the flow.
+6. **The drafted resolution is POSTED to Slack.** `correlationId` is a declared
+   input; `caseKey`/`slackMessageId` are declared routed outputs; exactly one Slack
+   `send-message-to-channel` node sends as `user`; the message depends on the agent
+   step (so a canned template over the trigger inputs is refused offline); `caseKey`
+   routes the correlationId and `slackMessageId` comes from the executed send.
 
 Usage: advisory_billing_resolution_writer.py [<FlowName>.flow]
 """
@@ -46,6 +51,14 @@ from advisory_flow_utils import (
 INLINE = "uipath.agent.autonomous"
 IN_CONTRACT = ["customerName", "invoiceNumber", "creditAmount"]
 OUT_CONTRACT = {"emailSubject": "string", "emailBody": "string"}
+# correlationId is a flow INPUT but not drafting material, so it is not in
+# IN_CONTRACT (which gates what the agent must be fed); it is required as a
+# declared in-global only. caseKey/slackMessageId are routed outputs, not
+# agent-drafted, so they are not in OUT_CONTRACT (which gates agent-dependency).
+ROUTED_IN = "correlationId"
+ROUTED_OUT = {"caseKey": "string", "slackMessageId": "string"}
+SLACK_KEY = "uipath-salesforce-slack"
+SLACK_OP = "send-message-to-channel"
 # The values the live rung asserts. None may be a literal in the flow.
 FORBIDDEN = ["MCS-2026-04872", "Northwind Traders"]
 FORBIDDEN_NUMBERS = ["1610", "1,610"]
@@ -138,6 +151,69 @@ def main():
     for bad in FORBIDDEN_NUMBERS:
         if carries_literal(f, bad):
             fail(f"the flow carries the credit amount {bad!r} as a literal; it arrives as a flow INPUT")
+
+    # ── 6. the drafted resolution is POSTED to Slack ──────────────────────────
+    # correlationId is a declared flow input; caseKey + slackMessageId are declared
+    # routed outputs.
+    if ROUTED_IN not in ins_g:
+        fail(f"the flow declares in-globals {sorted(ins_g)}; the contract asks for {ROUTED_IN}")
+    for name, want in ROUTED_OUT.items():
+        if name not in outs_g:
+            fail(f"the flow declares out-globals {sorted(outs_g)}; the contract asks for {name}")
+        if outs_g[name].get("type") != want:
+            fail(f"output {name} is declared {outs_g[name].get('type')!r}; the contract asks for {want}")
+
+    # Exactly one Slack SEND node (native connector node or connector-mode HTTP
+    # proxy to the send op) — a read/search activity is not a delivery.
+    def is_slack_send(n: dict) -> bool:
+        t = str(n.get("type", ""))
+        if SLACK_KEY in t and SLACK_OP in t:
+            return True
+        detail = (n.get("inputs") or {}).get("detail") or {}
+        body = detail.get("bodyParameters") or {} if isinstance(detail, dict) else {}
+        target = str((body.get("targetConnector") or body.get("connectorKey") or "")).lower()
+        auth = str(body.get("authentication") or "").lower()
+        return (
+            t.lower().startswith("core.action.http")
+            and target == SLACK_KEY
+            and auth == "connector"
+            and SLACK_OP.replace("-", "") in json.dumps(detail).lower().replace("-", "").replace("_", "")
+        )
+
+    slack_nodes = [n for n in nodes if is_slack_send(n)]
+    if len(slack_nodes) != 1:
+        fail(f"expected exactly ONE Slack {SLACK_OP} node, found {len(slack_nodes)}; node types: {types_seen}")
+    slack = slack_nodes[0]
+
+    # Send as `user`, not the default bot.
+    send_as = str(((slack.get("inputs") or {}).get("detail") or {}).get("queryParameters", {}).get("send_as", "")).strip().lower()
+    if send_as != "user":
+        fail(f"the Slack send node sets send_as={send_as!r}; the prompt requires sending as 'user'")
+
+    # The posted message must depend on the agent's draft — a canned template over
+    # trigger inputs (correlationId, invoice, credit) would satisfy an ids-only gate
+    # without ever posting the resolution. This is the structural, offline-catchable
+    # form of the live checker's body[:80] assertion.
+    if not source_depends_on(slack.get("inputs") or {}, a["id"], dependencies):
+        fail(
+            f"the Slack node's inputs do not depend on $vars.{a['id']}.output — the message "
+            "must carry the agent's drafted resolution, not only the trigger inputs"
+        )
+
+    # caseKey routes the correlationId; slackMessageId comes from the Slack send.
+    case_bindings = end_bindings(nodes, success_ends, "caseKey")
+    if not case_bindings:
+        fail("no successful End node binds an output named 'caseKey'")
+    if not any(references_field(v, ROUTED_IN) for v in case_bindings):
+        fail(f"caseKey has bindings {[str(unwrap(v)) for v in case_bindings]!r}; it must route the {ROUTED_IN}")
+    ts_bindings = end_bindings(nodes, success_ends, "slackMessageId")
+    if not ts_bindings:
+        fail("no successful End node binds an output named 'slackMessageId'")
+    if not any(source_depends_on(v, slack["id"], dependencies) for v in ts_bindings):
+        fail(
+            f"slackMessageId has bindings {[str(unwrap(v)) for v in ts_bindings]!r}, none depending on "
+            f"$vars.{slack['id']}.output — the posted message's ts must come FROM the executed send"
+        )
 
     print(
         f"{len(nodes)} nodes; one {INLINE} ({a['id']}) fed {declared or 'via prompt refs'}, "

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
@@ -250,3 +250,63 @@ def test_reachability_excludes_the_loop_break_edge() -> None:
     ]
 
     assert successful_end_ids(nodes, edges, "body") == set()
+
+
+def test_resolution_writer_advisory_accepts_connector_mode_http_proxy(tmp_path: Path) -> None:
+    """The Slack contract also accepts a connector-mode HTTP proxy send node, not
+    only the native connector node. Exercises the previously-unexercised proxy
+    branch of ``is_slack_send`` — where an unimported ``json`` once hid — because
+    the parametrized reference case feeds only the native-node flow."""
+    source = FLOW_TASKS / REFERENCE_CASES["advisory_billing_resolution_writer.py"]
+    flow = json.loads(source.read_text())
+    slack = next(n for n in flow["nodes"] if n["id"] == "postResolution")
+    slack["type"] = "core.action.http.v2"
+    slack["inputs"] = {
+        "detail": {
+            "connectionId": "849e85d8-1aa9-4d52-8bbd-20041c8f05d8",
+            "connectionFolderKey": "5da18ec0-7de1-4e57-aaf1-ddc8a369c199",
+            "method": "POST",
+            "endpoint": "/send_message_to_channel_v2",
+            "queryParameters": {"send_as": "user"},
+            "bodyParameters": {
+                "authentication": "connector",
+                "targetConnector": "uipath-salesforce-slack",
+                "channel": "C0B2FDZD1M3",
+                "messageToSend": "=js:`${$vars.start.output.correlationId}: ${$vars.resolutionWriter.output.body}`",
+            },
+        }
+    }
+    target = tmp_path / "BillingResolutionWriter.flow"
+    target.write_text(json.dumps(flow))
+
+    result = run_script("advisory_billing_resolution_writer.py", target)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_resolution_writer_advisory_rejects_proxy_send_without_bound_connection(tmp_path: Path) -> None:
+    """A connector-mode HTTP proxy with no bound connection must be refused — it
+    passes an ids-only shape check but the live rung's assert_slack_message_posted
+    rejects it ("no connected send node found")."""
+    source = FLOW_TASKS / REFERENCE_CASES["advisory_billing_resolution_writer.py"]
+    flow = json.loads(source.read_text())
+    slack = next(n for n in flow["nodes"] if n["id"] == "postResolution")
+    slack["type"] = "core.action.http.v2"
+    slack["inputs"] = {
+        "detail": {
+            "method": "POST",
+            "endpoint": "/send_message_to_channel_v2",
+            "queryParameters": {"send_as": "user"},
+            "bodyParameters": {
+                "authentication": "connector",
+                "targetConnector": "uipath-salesforce-slack",
+                "channel": "C0B2FDZD1M3",
+                "messageToSend": "=js:`${$vars.start.output.correlationId}: ${$vars.resolutionWriter.output.body}`",
+            },
+        }
+    }
+    target = tmp_path / "BillingResolutionWriter.flow"
+    target.write_text(json.dumps(flow))
+
+    result = run_script("advisory_billing_resolution_writer.py", target)
+    assert result.returncode != 0
+    assert "Slack" in (result.stdout + result.stderr)

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/BillingResolutionWriter.reference.flow
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/BillingResolutionWriter.reference.flow
@@ -120,22 +120,28 @@
       "type": "uipath.connector.uipath-salesforce-slack.send-message-to-channel",
       "typeVersion": "1.0.0",
       "display": {
-        "label": "Post Resolution to Slack"
+        "label": "Send Message to Channel"
       },
       "inputs": {
         "detail": {
           "connector": "uipath-salesforce-slack",
-          "connectionId": "fb06f30e-cde8-4e4a-a534-29cb485971d4",
-          "connectionFolderKey": "692bbf4e-5754-4bdc-8ec6-d8e3a986dea2",
+          "connectionId": "849e85d8-1aa9-4d52-8bbd-20041c8f05d8",
+          "connectionResourceId": "849e85d8-1aa9-4d52-8bbd-20041c8f05d8",
+          "connectionFolderKey": "5da18ec0-7de1-4e57-aaf1-ddc8a369c199",
+          "method": "POST",
+          "endpoint": "/send_message_to_channel_v2",
+          "bodyParameters": {
+            "channel": "C0B2FDZD1M3",
+            "messageToSend": "=js:`${$vars.start.output.correlationId}: ${$vars.resolutionWriter.output.body}`"
+          },
           "queryParameters": {
             "send_as": "user"
           },
-          "channel": "coding-agent-testing",
-          "messageToSend": {
-            "type": "jsExpression",
-            "expression": "`${$vars.start.output.correlationId}\n${$vars.resolutionWriter.output.body}`",
-            "fieldType": "string"
-          }
+          "uiPathActivityTypeId": "37a305b2-89b1-315d-b73f-1778839a6c47",
+          "errorState": {
+            "issues": []
+          },
+          "configuration": "=jsonString:{\"essentialConfiguration\":{\"instanceParameters\":{\"connectorKey\":\"uipath-salesforce-slack\",\"objectName\":\"send_message_to_channel_v2\",\"httpMethod\":\"POST\",\"activityType\":\"Curated\",\"version\":\"1.0.0\"},\"objectName\":\"send_message_to_channel_v2\",\"operation\":\"create\",\"packageVersion\":\"1.0.0\",\"httpMethod\":\"POST\",\"path\":\"/send_message_to_channel_v2\",\"unifiedTypesCompatible\":true}}"
         }
       }
     },

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/BillingResolutionWriter.reference.flow
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/BillingResolutionWriter.reference.flow
@@ -116,6 +116,30 @@
       }
     },
     {
+      "id": "postResolution",
+      "type": "uipath.connector.uipath-salesforce-slack.send-message-to-channel",
+      "typeVersion": "1.0.0",
+      "display": {
+        "label": "Post Resolution to Slack"
+      },
+      "inputs": {
+        "detail": {
+          "connector": "uipath-salesforce-slack",
+          "connectionId": "fb06f30e-cde8-4e4a-a534-29cb485971d4",
+          "connectionFolderKey": "692bbf4e-5754-4bdc-8ec6-d8e3a986dea2",
+          "queryParameters": {
+            "send_as": "user"
+          },
+          "channel": "coding-agent-testing",
+          "messageToSend": {
+            "type": "jsExpression",
+            "expression": "`${$vars.start.output.correlationId}\n${$vars.resolutionWriter.output.body}`",
+            "fieldType": "string"
+          }
+        }
+      }
+    },
+    {
       "id": "doneSuccess",
       "type": "core.control.end",
       "typeVersion": "1.0",
@@ -137,6 +161,20 @@
             "expression": "$vars.resolutionWriter.output.body",
             "fieldType": "string"
           }
+        },
+        "caseKey": {
+          "source": {
+            "type": "jsExpression",
+            "expression": "$vars.start.output.correlationId",
+            "fieldType": "string"
+          }
+        },
+        "slackMessageId": {
+          "source": {
+            "type": "jsExpression",
+            "expression": "$vars.postResolution.output.ts",
+            "fieldType": "string"
+          }
         }
       }
     }
@@ -152,6 +190,13 @@
     {
       "id": "e2",
       "sourceNodeId": "resolutionWriter",
+      "sourcePort": "success",
+      "targetNodeId": "postResolution",
+      "targetPort": "input"
+    },
+    {
+      "id": "e3",
+      "sourceNodeId": "postResolution",
       "sourcePort": "success",
       "targetNodeId": "doneSuccess",
       "targetPort": "input"
@@ -939,12 +984,30 @@
         "triggerNodeId": "start"
       },
       {
+        "id": "correlationId",
+        "direction": "in",
+        "type": "string",
+        "defaultValue": "",
+        "description": "Per-run correlation id (routing key)",
+        "triggerNodeId": "start"
+      },
+      {
         "id": "emailSubject",
         "direction": "out",
         "type": "string"
       },
       {
         "id": "emailBody",
+        "direction": "out",
+        "type": "string"
+      },
+      {
+        "id": "caseKey",
+        "direction": "out",
+        "type": "string"
+      },
+      {
+        "id": "slackMessageId",
         "direction": "out",
         "type": "string"
       }

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml
@@ -3,7 +3,7 @@
 # paired limit envelope. Cross-arm parity is enforced by the sync gate.
 task_id: skill-flow-devcon-billing-resolution-writer
 description: |
-  Build a Maestro Flow whose single work node is an inline low-code agent (uipath.agent.autonomous) that drafts a customer-facing billing-dispute resolution email. Graded by flow validate plus one flow debug run: the inline agent node must be present and the drafted email must cite the disputed invoice number.
+  Build a Maestro Flow whose inline low-code agent (uipath.agent.autonomous) drafts a customer-facing billing-dispute resolution and then posts it to Slack. Graded by flow validate plus one flow debug run: the inline agent node must be present, the drafted email must cite the disputed invoice number, and the Slack Send-Message activity must have ACTUALLY posted (verified via a real message ts).
 tags:
   - uipath-maestro-flow
   - e2e
@@ -11,27 +11,35 @@ tags:
   - lifecycle:execute
   - shape:multi-node
   - node:inline-agent
+  - connector
   - path-to-ga
+  - outcome-graded
 run_limits:
-  max_turns: 120
-  turn_timeout: 1200
-  task_timeout: 3300
+  max_turns: 150
+  turn_timeout: 3000
+  task_timeout: 3600
 post_run:
   - command: python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
     timeout: 90
 initial_prompt: |
   Build a Maestro Flow "BillingResolutionWriter" (in a solution of the same
-  name) whose single work node is an inline low-code agent embedded in the flow
-  project that drafts a customer-facing billing-dispute resolution email.
+  name) whose inline low-code agent drafts a customer-facing billing-dispute
+  resolution and then posts that resolution to Slack.
 
   - Trigger inputs: `customerName` (string), `invoiceNumber` (string),
-    `creditAmount` (number).
-  - The inline agent reads those inputs and returns two strings: the email
+    `creditAmount` (number), `correlationId` (string).
+  - An inline low-code agent embedded in the flow project (not a separate
+    published agent) reads those inputs and returns two strings: the email
     `subject` and the email `body`. The body must state the invoice number and
     the approved credit amount. Map them to flow outputs `emailSubject` and
     `emailBody`.
-  - The agent must be embedded in the flow project (inline), not a separate
-    published agent.
+  - Post the resolution to Slack using the Slack "Send Message to channel"
+    activity: channel "coding-agent-testing", the Slack connection named
+    "is-sandboxes", send as `user`. The message must include the correlationId,
+    the invoice number, and the approved credit amount.
+  - Also map these flow outputs: `caseKey` = the incoming correlationId, and
+    `slackMessageId` = the identifier of the Slack message that was posted (from
+    the Slack Send Message node's output).
 
   Validate the final flow file — the task is not complete until `uip maestro
   flow validate` passes. Grading then runs the flow under debug, so build it to
@@ -48,7 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
   - type: run_command
-    description: 'Check debugs the flow: an inline uipath.agent.autonomous node is present, the flow completes, and the drafted email cites invoice MCS-2026-04872'
+    description: 'Check debugs the flow: an inline uipath.agent.autonomous node is present, the drafted email cites invoice MCS-2026-04872 and the approved credit, and the Slack Send-Message activity actually posted (real message ts carrying the correlationId + invoice)'
     command: python3 $TASK_DIR/check_billing_resolution_writer.py
     timeout: 600
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml
@@ -70,7 +70,7 @@ success_criteria:
     weight: 1.0
     pass_threshold: 0.0
   - type: run_command
-    description: 'Advisory: STRUCTURAL (covering): exactly one INLINE agent (no published agent, no script stand-in), fed all three inputs through bindings or Flow/sidecar prompt references, both fields declared in returns, both outputs read from the agent, and no email literals'
+    description: 'Advisory: STRUCTURAL (covering): exactly one INLINE agent (no published agent, no script stand-in), fed all three inputs through bindings or Flow/sidecar prompt references, both fields declared in returns, both outputs read from the agent, no email literals; plus the Slack contract — correlationId in-global, caseKey/slackMessageId out-globals, exactly one Slack send-message-to-channel node sending as user, the posted message depending on the agent, caseKey routing the correlationId and slackMessageId from the executed send'
     command: python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_resolution_writer.py
     timeout: 30
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml
@@ -15,9 +15,9 @@ tags:
   - path-to-ga
   - outcome-graded
 run_limits:
-  max_turns: 150
-  turn_timeout: 3000
-  task_timeout: 3600
+  max_turns: 120
+  turn_timeout: 1200
+  task_timeout: 3300
 post_run:
   - command: python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
     timeout: 90
@@ -33,10 +33,10 @@ initial_prompt: |
     `subject` and the email `body`. The body must state the invoice number and
     the approved credit amount. Map them to flow outputs `emailSubject` and
     `emailBody`.
-  - Post the resolution to Slack using the Slack "Send Message to channel"
-    activity: channel "coding-agent-testing", the Slack connection named
-    "is-sandboxes", send as `user`. The message must include the correlationId,
-    the invoice number, and the approved credit amount.
+  - Post the drafted resolution to Slack using the Slack "Send Message to
+    channel" activity: channel "coding-agent-testing", the Slack connection named
+    "is-sandboxes", send as `user`. The message text must be the agent's drafted
+    `body` verbatim, prefixed with the correlationId.
   - Also map these flow outputs: `caseKey` = the incoming correlationId, and
     `slackMessageId` = the identifier of the Slack message that was posted (from
     the Slack Send Message node's output).
@@ -56,7 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
   - type: run_command
-    description: 'Check debugs the flow: an inline uipath.agent.autonomous node is present, the drafted email cites invoice MCS-2026-04872 and the approved credit, and the Slack Send-Message activity actually posted (real message ts carrying the correlationId + invoice)'
+    description: 'Check debugs the flow: an inline uipath.agent.autonomous node is present, the drafted email cites invoice MCS-2026-04872 and the approved credit, caseKey echoes the correlationId, and the Slack Send-Message activity actually posted (real message ts carrying the correlationId + invoice + the drafted resolution)'
     command: python3 $TASK_DIR/check_billing_resolution_writer.py
     timeout: 600
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/check_billing_resolution_writer.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/check_billing_resolution_writer.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
-"""Inline-agent writer flow.
+"""Inline-agent writer flow that ALSO posts to Slack.
 
-Tests a Maestro Flow whose single work node is an inline low-code agent
-(`uipath.agent.autonomous`). Two layers:
+Tests a Maestro Flow whose inline low-code agent (`uipath.agent.autonomous`)
+drafts a resolution and then posts it to Slack. Three layers:
   1. Structural: the flow contains an inline autonomous agent node (anti-hardcode
-     — a Script node cannot stand in for the agent).
-  2. Behavior: `flow debug` completes and the drafted email — landed in the
+     — a Script node cannot stand in for the agent) AND a real Slack connector
+     send node.
+  2. Draft behavior: `flow debug` completes and the drafted email — landed in the
      mapped `emailBody` output — cites the invoice and the approved credit.
+  3. Slack outcome: the `Send Message to channel` activity actually posted — the
+     flow surfaces the posted message's ts as `slackMessageId`, verified against
+     the executed send node's own response, and the message carries the
+     correlationId and the invoice number.
 
 The behavior grade scopes to the `emailBody` output global, NOT the whole debug
 payload. Matching the whole payload is a false pass: the trigger echoes the
@@ -16,6 +21,7 @@ result into `emailBody`. Scoping to `emailBody` catches both.
 """
 import os
 import sys
+from uuid import uuid4
 
 # Walk up to the skill's tests root (the dir holding the _shared package).
 _d = os.path.dirname(os.path.abspath(__file__))
@@ -23,19 +29,35 @@ while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared"
     _d = os.path.dirname(_d)
 sys.path.insert(0, _d)
 from _shared.flow_check import (  # noqa: E402
+    assert_connector_send_identity,
     assert_flow_has_node_type,
+    assert_flow_uses_connector_target,
     assert_named_output_contains,
     assert_output_nonempty,
+    assert_slack_message_posted,
     run_debug,
 )
 
 INVOICE = "MCS-2026-04872"
-INPUTS = {"customerName": "Northwind Traders", "invoiceNumber": INVOICE, "creditAmount": 1610}
+SLACK_KEY = "uipath-salesforce-slack"
+SLACK_CHANNEL = "C0B2FDZD1M3"  # coding-agent-testing
+# Fresh correlationId per run isolates this run's Slack message from prior runs.
+CORRELATION_ID = f"RESO-{uuid4().hex[:12]}"
+INPUTS = {
+    "customerName": "Northwind Traders",
+    "invoiceNumber": INVOICE,
+    "creditAmount": 1610,
+    "correlationId": CORRELATION_ID,
+}
 
 
 def main():
     assert_flow_has_node_type(["uipath.agent.autonomous"])
-    print("OK: flow contains an inline uipath.agent.autonomous node")
+    assert_flow_uses_connector_target(SLACK_KEY)
+    assert_connector_send_identity(
+        SLACK_KEY, expected="user", native_op_hint="send-message-to-channel"
+    )
+    print("OK: flow contains an inline uipath.agent.autonomous node + a Slack send node")
 
     payload = run_debug(inputs=INPUTS, timeout=540)
     # Subject must be mapped + non-empty.
@@ -44,6 +66,15 @@ def main():
     assert_named_output_contains(payload, "emailBody", INVOICE)
     assert_named_output_contains(payload, "emailBody", ["1610", "1,610"], require_all=False)
     print(f"OK: emailBody drafted, cites invoice {INVOICE} and the approved credit")
+
+    # Slack outcome — verified against the executed send's own response.
+    assert_slack_message_posted(
+        payload,
+        "slackMessageId",
+        expected_channel=SLACK_CHANNEL,
+        must_contain=[CORRELATION_ID, INVOICE],
+    )
+    print("OK: Slack alert posted (real message ts) carrying the correlationId + invoice")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/check_billing_resolution_writer.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/check_billing_resolution_writer.py
@@ -10,8 +10,11 @@ drafts a resolution and then posts it to Slack. Three layers:
      mapped `emailBody` output — cites the invoice and the approved credit.
   3. Slack outcome: the `Send Message to channel` activity actually posted — the
      flow surfaces the posted message's ts as `slackMessageId`, verified against
-     the executed send node's own response, and the message carries the
-     correlationId and the invoice number.
+     the executed send node's own response, and the message carries the drafted
+     resolution (a slice of `emailBody`), not only the trigger echoes. Requiring
+     the draft in the post closes the same input-echo false pass warned about for
+     `emailBody`: correlationId + invoice are flow inputs, so a canned template
+     over them would satisfy an ids-only Slack gate one layer out.
 
 The behavior grade scopes to the `emailBody` output global, NOT the whole debug
 payload. Matching the whole payload is a false pass: the trigger echoes the
@@ -32,6 +35,7 @@ from _shared.flow_check import (  # noqa: E402
     assert_connector_send_identity,
     assert_flow_has_node_type,
     assert_flow_uses_connector_target,
+    assert_named_equals,
     assert_named_output_contains,
     assert_output_nonempty,
     assert_slack_message_posted,
@@ -41,7 +45,10 @@ from _shared.flow_check import (  # noqa: E402
 INVOICE = "MCS-2026-04872"
 SLACK_KEY = "uipath-salesforce-slack"
 SLACK_CHANNEL = "C0B2FDZD1M3"  # coding-agent-testing
-# Fresh correlationId per run isolates this run's Slack message from prior runs.
+# Fresh correlationId per run is anti-hardcode: a per-run random token cannot be
+# baked into the flow, so a passing Slack post must carry a value the flow read from
+# this run's trigger, not a literal. (assert_slack_message_posted reads the ts +
+# content off the executed send node's own response, so prior runs never interfere.)
 CORRELATION_ID = f"RESO-{uuid4().hex[:12]}"
 INPUTS = {
     "customerName": "Northwind Traders",
@@ -59,22 +66,33 @@ def main():
     )
     print("OK: flow contains an inline uipath.agent.autonomous node + a Slack send node")
 
-    payload = run_debug(inputs=INPUTS, timeout=540)
+    # retries=1: this flow POSTS to the shared Slack channel, so a whole-flow retry
+    # on a transient poll/5xx failure would re-post a duplicate message. One attempt
+    # only; a genuine transient failure fails the run cleanly.
+    payload = run_debug(inputs=INPUTS, timeout=540, retries=1)
     # Subject must be mapped + non-empty.
     assert_output_nonempty(payload, "emailSubject")
     # Body must be mapped, cite the invoice, and state the approved credit.
+    body = assert_output_nonempty(payload, "emailBody")
     assert_named_output_contains(payload, "emailBody", INVOICE)
     assert_named_output_contains(payload, "emailBody", ["1610", "1,610"], require_all=False)
     print(f"OK: emailBody drafted, cites invoice {INVOICE} and the approved credit")
 
-    # Slack outcome — verified against the executed send's own response.
+    # caseKey must echo the incoming correlationId (opaque id — exact case).
+    assert_named_equals(payload, "caseKey", CORRELATION_ID, case_sensitive=True)
+
+    # Slack outcome — verified against the executed send's own response. The posted
+    # message must carry the agent's DRAFT (a slice of emailBody), not only the
+    # trigger echoes: correlationId + invoice are flow inputs, so a canned template
+    # over them would pass on those alone. Requiring body[:80] ties the delivered
+    # side effect to the agent's work product (cf. check_escalation_slack_alert.py:107).
     assert_slack_message_posted(
         payload,
         "slackMessageId",
         expected_channel=SLACK_CHANNEL,
-        must_contain=[CORRELATION_ID, INVOICE],
+        must_contain=[CORRELATION_ID, INVOICE, str(body)[:80]],
     )
-    print("OK: Slack alert posted (real message ts) carrying the correlationId + invoice")
+    print("OK: Slack message posted (real ts) carrying the correlationId + the drafted resolution")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/check_billing_resolution_writer.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/check_billing_resolution_writer.py
@@ -6,15 +6,14 @@ drafts a resolution and then posts it to Slack. Three layers:
   1. Structural: the flow contains an inline autonomous agent node (anti-hardcode
      — a Script node cannot stand in for the agent) AND a real Slack connector
      send node.
-  2. Draft behavior: `flow debug` completes and the drafted email — landed in the
-     mapped `emailBody` output — cites the invoice and the approved credit.
+  2. Draft behavior: `flow debug` completes; the drafted email — landed in the
+     mapped `emailBody` output — cites the invoice and the approved credit, AND
+     `emailBody` is the EXECUTED agent node's own output (not a JS template that
+     fabricates it from the trigger inputs — the node-type check is source-only).
   3. Slack outcome: the `Send Message to channel` activity actually posted — the
      flow surfaces the posted message's ts as `slackMessageId`, verified against
      the executed send node's own response, and the message carries the drafted
-     resolution (a slice of `emailBody`), not only the trigger echoes. Requiring
-     the draft in the post closes the same input-echo false pass warned about for
-     `emailBody`: correlationId + invoice are flow inputs, so a canned template
-     over them would satisfy an ids-only Slack gate one layer out.
+     `emailBody`, not only the trigger echoes.
 
 The behavior grade scopes to the `emailBody` output global, NOT the whole debug
 payload. Matching the whole payload is a false pass: the trigger echoes the
@@ -39,6 +38,8 @@ from _shared.flow_check import (  # noqa: E402
     assert_named_output_contains,
     assert_output_nonempty,
     assert_slack_message_posted,
+    completed_node_ids_of_type,
+    node_output_leaves,
     run_debug,
 )
 
@@ -78,14 +79,20 @@ def main():
     assert_named_output_contains(payload, "emailBody", ["1610", "1,610"], require_all=False)
     print(f"OK: emailBody drafted, cites invoice {INVOICE} and the approved credit")
 
+    # emailBody must come FROM the executed agent, not a JS template that fabricates
+    # it from the trigger inputs. assert_flow_has_node_type is source-only, so without
+    # this an unexecuted agent node plus one template feeding both emailBody and the
+    # Slack text would pass at full weight. Tie the value to the agent's own response.
+    agent_ids = completed_node_ids_of_type(payload, "uipath.agent.autonomous")
+    if str(body).strip() not in node_output_leaves(payload, agent_ids):
+        sys.exit("FAIL: emailBody did not come from the executed uipath.agent.autonomous node")
+    print("OK: emailBody is the executed agent's own output")
+
     # caseKey must echo the incoming correlationId (opaque id — exact case).
     assert_named_equals(payload, "caseKey", CORRELATION_ID, case_sensitive=True)
 
-    # Slack outcome — verified against the executed send's own response. The posted
-    # message must carry the agent's DRAFT (a slice of emailBody), not only the
-    # trigger echoes: correlationId + invoice are flow inputs, so a canned template
-    # over them would pass on those alone. Requiring body[:80] ties the delivered
-    # side effect to the agent's work product (cf. check_escalation_slack_alert.py:107).
+    # Slack outcome — verified against the executed send's own response: the posted
+    # message must carry the mapped emailBody (body[:80]), not only the trigger echoes.
     assert_slack_message_posted(
         payload,
         "slackMessageId",


### PR DESCRIPTION
## What

Adds a real Slack side effect to the existing DevCon `billing_resolution_writer` task, in place. This is the single surviving version of the coverage — the standalone alternative (#2890) is closed.

Changes to `multi_node/billing_resolution_writer/`:
- **Prompt:** adds a `correlationId` input and a Slack "Send Message to channel" step (channel `coding-agent-testing`, `is-sandboxes` connection, send-as `user`). The message text must be the agent's drafted `body` verbatim, prefixed with the correlationId; maps `caseKey` + `slackMessageId` outputs. The inline-agent draft is unchanged.
- **Checker:** keeps the agent-node + `emailBody` cites invoice/credit assertions, grades `caseKey`, and adds a real Slack-outcome check — `assert_flow_uses_connector_target` + `assert_connector_send_identity(user)` + `assert_slack_message_posted`. The Slack `must_contain` includes `body[:80]`, so the delivered message must carry the drafted resolution, not only the trigger echoes (correlationId + invoice). Per-run `correlationId` (uuid) — no seed file.
- **Reference flow + advisory:** `BillingResolutionWriter.reference.flow` is updated to the new correct build (Slack send node bound to the agent draft, correlationId in, caseKey/slackMessageId out), and `advisory_billing_resolution_writer.py` is extended to cover it, so `test_same_ground_advisories` now catches reference drift.
- **Tags:** adds `connector` + `outcome-graded`. **Limits:** unchanged from the pinned envelope (`max_turns` 120 / `turn_timeout` 1200 / `task_timeout` 3300).

## ⚠️ Same-ground campaign — @tmatup please review / re-baseline

`billing_resolution_writer` is an arm of your same-ground A/B campaign (contract 2026-08-10). This PR changes the pinned **prompt** and the **criteria** (the second criterion's grade now requires the drafted resolution in the Slack post, and grades `caseKey`), and moves this task's **`path-to-ga`** bar. The limit envelope is left unchanged. Both arms read this file, so it needs your sign-off and a re-baseline before merge. Note the proposed new baseline rests on **N=1** (one passing run of the now-stricter task, [34619376405](https://github.com/UiPath/skills/actions/runs/34619376405)); say if you want N-rep before re-baselining.

## Consolidation
The standalone-task alternative (#2890) is **closed** — this edit-in-place task is the one we're keeping. Both shared the same grading hole and retry default; the fixes live here.

## Known gap (pre-existing, not introduced here)
Each run leaves a message in the shared `coding-agent-testing` channel; `cleanup_solutions.py` does not touch Slack. This is pre-existing for all three Slack tasks. `retries=1` (this PR) stops a single run from posting duplicates.

## Validation
Fresh run on `run-coder-eval.yml` (claude) from this branch — [run 34619376405](https://github.com/UiPath/skills/actions/runs/34619376405): **passed 4/4, weighted score 1.000**, `duration=576.2s`, first attempt. The Slack `body[:80]` gate is satisfied by the agent's actual draft ("OK: Slack message posted (real ts) carrying the correlationId + the drafted resolution"), and the extended advisory passes on the agent's build. The prior run (33222516771) is retired — it posted a hardcoded template and demonstrated the false pass. All PR checks green on `f1102dfb6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



