### PR TITLE
test(maestro-bpmn): accept message summary events

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/patterns/high_volume_batch/check_greenfield.py
+++ b/tests/tasks/uipath-maestro-bpmn/patterns/high_volume_batch/check_greenfield.py
@@ -44,8 +44,19 @@ def main() -> None:
         fail(f"no gateway is reachable from {sub_id} — the block never reaches a verdict")
 
     verdict = verdicts[0]
+    # A BPMN message throw is the native way to send a summary. Count it as
+    # work on the path alongside task-shaped activities; requiring a sendTask
+    # would grade an implementation detail rather than the requested behavior.
+    message_throws = [
+        event
+        for event in elements(root, "intermediateThrowEvent")
+        if event.find(f"./{{{BPMN_NS}}}messageEventDefinition") is not None
+    ]
     work_ids = ids(
-        elements(root, "serviceTask") + elements(root, "scriptTask") + elements(root, "sendTask")
+        elements(root, "serviceTask")
+        + elements(root, "scriptTask")
+        + elements(root, "sendTask")
+        + message_throws
     )
     on_path = {
         n for n in downstream & work_ids


### PR DESCRIPTION
## Summary

- Treat a BPMN intermediate message throw as valid summary-sending work in the high-volume batch checker.
- Keep the existing requirement for two distinct post-batch operations before the policy verdict.

## RCA

The preview artifact correctly emitted `aggregate -> Send summary to finance (message throw) -> policy gateway`. The checker counted only service, script, and send tasks, so it reported only one activity and rejected the native BPMN message-event representation.

## Verification

- Replayed the checker against the failed v2 artifact: PASS
- `python3 -m py_compile tests/tasks/uipath-maestro-bpmn/patterns/high_volume_batch/check_greenfield.py`
- `git diff --check`

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)