### PR TITLE
fix(maestro-bpmn): accept registry-native agent jobs

### DIFF
--- a/.github/workflows/test-helpers.yml
+++ b/.github/workflows/test-helpers.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'tests/tasks/uipath-maestro-flow/**'
       - 'tests/tasks/uipath-maestro-case/**'
+      - 'tests/tasks/uipath-maestro-bpmn/**'
       - 'tests/tasks/uipath-planner/**'
       - 'tests/tasks/uipath-agents/**'
       - 'tests/tasks/uipath-admin/**'
@@ -15,6 +16,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  pytest-bpmn-check:
+    runs-on: uipath-ubuntu-latest
+    name: maestro-bpmn checker unit tests
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.13'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run pytest
+        run: pytest tests/tasks/uipath-maestro-bpmn/ -v
+
   pytest-flow-check:
     runs-on: uipath-ubuntu-latest
     name: maestro-flow checker unit tests

--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -285,10 +285,14 @@ and honestly surfaced to the user as gaps when asked.
    and the process structure with the user (AskUserQuestion).
 5. **The diagram is mandatory.** Import is diagram-driven — every node needs a
    `BPMNShape`, every flow a `BPMNEdge`, or it will not appear on the canvas.
-6. **Node type is a child element, never an attribute.** Every `uipath:activity`
-   / `uipath:event` / `uipath:mapping` declares its type as
-   `<uipath:type value="<Type>" version="v1" />` inside the wrapper. Never write
-   `<uipath:activity type="…">` — the canvas will not recognize the node.
+6. **Preserve the registry's node-type shape.** Most `uipath:activity` /
+   `uipath:event` / `uipath:mapping` templates declare their type as a nested
+   `<uipath:type value="<Type>" version="v1" />`. Some runtime-authored
+   templates use the payload's `type` attribute instead; notably,
+   `Orchestrator.StartAgentJob` is a direct child of `bpmn:serviceTask` with
+   `<uipath:activity type="Orchestrator.StartAgentJob" version="v1">`. Both
+   declarations are supported. Paste the selected registry template literally
+   and do not normalize one form into the other.
    Event extension types (`Intsvc.WaitForEvent`, `Intsvc.EventTrigger`,
    `Maestro.ReceiveMessageEvent`, `Maestro.SendMessageEvent`) must use
    `<uipath:event>`, including when the BPMN host is task-like such as

--- a/skills/uipath-maestro-bpmn/validator/bpmn-spec.json
+++ b/skills/uipath-maestro-bpmn/validator/bpmn-spec.json
@@ -165,46 +165,33 @@
       "extensionTag": "uipath:activity",
       "contextFields": [
         {
-          "name": "releaseKey",
-          "displayName": "Process",
+          "name": "name",
+          "displayName": "Agent",
           "type": "string",
-          "required": false,
+          "required": true,
           "hidden": true,
           "isPrimaryKey": false,
-          "binding": false,
+          "binding": true,
           "defaultValue": null,
           "bindingInfo": {
             "resource": "process",
             "resourceKeyPattern": "${metadata.key}",
-            "propertyAttribute": "Key"
+            "propertyAttribute": "name"
           }
-        },
-        {
-          "name": "folderId",
-          "type": "string",
-          "required": false,
-          "hidden": true,
-          "isPrimaryKey": false,
-          "binding": false,
-          "defaultValue": null
         },
         {
           "name": "folderPath",
           "type": "string",
-          "required": false,
+          "required": true,
           "hidden": true,
           "isPrimaryKey": false,
-          "binding": false,
-          "defaultValue": null
-        },
-        {
-          "name": "name",
-          "type": "string",
-          "required": false,
-          "hidden": true,
-          "isPrimaryKey": false,
-          "binding": false,
-          "defaultValue": null
+          "binding": true,
+          "defaultValue": null,
+          "bindingInfo": {
+            "resource": "process",
+            "resourceKeyPattern": "${metadata.key}",
+            "propertyAttribute": "folderPath"
+          }
         }
       ],
       "inputPattern": "mergedBody",
@@ -218,12 +205,12 @@
       "bindingInfo": {
         "resource": "process",
         "resourceKeyPattern": "${metadata.key}",
-        "propertyAttribute": "Key",
-        "contextField": "releaseKey"
+        "propertyAttribute": "name",
+        "contextField": "name"
       },
       "requiresDiscovery": true,
       "isDynamic": true,
-      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Orchestrator.StartAgentJob\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"releaseKey\" value=\"{releaseKey}\" />\n        <uipath:input name=\"folderId\" value=\"{folderId}\" />\n        <uipath:input name=\"folderPath\" value=\"{folderPath}\" />\n        <uipath:input name=\"name\" value=\"{name}\" />\n      </uipath:context>\n      <uipath:input name=\"JobArguments\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"Process response\" type=\"Orchestrator.RunJob\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <uipath:activity type=\"Orchestrator.StartAgentJob\" version=\"v1\">\n    <uipath:context>\n      <uipath:input name=\"name\" value=\"=bindings.{nameBindingId}\" />\n      <uipath:input name=\"folderPath\" value=\"=bindings.{folderPathBindingId}\" />\n    </uipath:context>\n    <uipath:input name=\"JobArguments\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n    <uipath:output name=\"Process response\" type=\"Orchestrator.RunJob\" var=\"{varId}\" />\n  </uipath:activity>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
       "discoveryNotes": "Uses getSupportedOrchestratorTasks('agent', search) to list available agents"
     },
     "Orchestrator.BusinessRules": {

--- a/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_check.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_check.py
@@ -71,7 +71,33 @@ def text_content(element: ET.Element) -> str:
 
 def has_uipath_extension(element: ET.Element, token: str) -> bool:
     ext = element.find("bpmn:extensionElements", NS)
-    return ext is not None and token in ET.tostring(ext, encoding="unicode")
+    if ext is not None and token in ET.tostring(ext, encoding="unicode"):
+        return True
+    return any(
+        token in ET.tostring(child, encoding="unicode")
+        for child in element
+        if child.tag.startswith(f"{{{NS['uipath']}}}")
+    )
+
+
+def has_typed_uipath_extension(
+    element: ET.Element, extension_name: str, type_value: str
+) -> bool:
+    """Match both registry-supported UiPath payload type declarations."""
+    payloads = list(element.findall(f"uipath:{extension_name}", NS))
+    ext = element.find("bpmn:extensionElements", NS)
+    if ext is not None:
+        payloads.extend(ext.findall(f"uipath:{extension_name}", NS))
+
+    for payload in payloads:
+        if payload.attrib.get("type") == type_value:
+            return True
+        if any(
+            type_elem.attrib.get("value") == type_value
+            for type_elem in payload.findall("uipath:type", NS)
+        ):
+            return True
+    return False
 
 
 def require_di_for_visible_elements(root: ET.Element) -> None:

--- a/tests/tasks/uipath-maestro-bpmn/_shared/test_bpmn_check.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/test_bpmn_check.py
@@ -1,0 +1,75 @@
+"""Unit tests for shared Maestro BPMN checker contracts."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from bpmn_check import (  # noqa: E402
+    NS,
+    has_typed_uipath_extension,
+    has_uipath_extension,
+)
+
+
+def _service_task(payload: str) -> ET.Element:
+    return ET.fromstring(
+        f'<bpmn:serviceTask xmlns:bpmn="{NS["bpmn"]}" '
+        f'xmlns:uipath="{NS["uipath"]}" id="Task_1">{payload}</bpmn:serviceTask>'
+    )
+
+
+def test_typed_extension_accepts_nested_type_child() -> None:
+    task = _service_task(
+        """
+        <bpmn:extensionElements>
+          <uipath:activity version="v1">
+            <uipath:type value="Orchestrator.StartJob" version="v1" />
+          </uipath:activity>
+        </bpmn:extensionElements>
+        """
+    )
+
+    assert has_typed_uipath_extension(task, "activity", "Orchestrator.StartJob")
+    assert has_uipath_extension(task, "Orchestrator.StartJob")
+
+
+def test_typed_extension_accepts_registry_direct_type_attribute() -> None:
+    task = _service_task(
+        '<uipath:activity type="Orchestrator.StartAgentJob" version="v1" />'
+    )
+
+    assert has_typed_uipath_extension(task, "activity", "Orchestrator.StartAgentJob")
+    assert has_uipath_extension(task, "Orchestrator.StartAgentJob")
+
+
+def test_typed_extension_rejects_wrong_wrapper_or_type() -> None:
+    task = _service_task(
+        '<uipath:event type="Orchestrator.StartAgentJob" version="v1" />'
+    )
+
+    assert not has_typed_uipath_extension(task, "activity", "Orchestrator.StartAgentJob")
+    assert not has_typed_uipath_extension(task, "event", "Orchestrator.StartJob")
+
+
+def test_bundled_start_agent_contract_matches_runtime_registry() -> None:
+    repo_root = Path(__file__).parents[4]
+    spec_path = repo_root / "skills/uipath-maestro-bpmn/validator/bpmn-spec.json"
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    start_agent = spec["extensionTypes"]["Orchestrator.StartAgentJob"]
+
+    assert [field["name"] for field in start_agent["contextFields"]] == [
+        "name",
+        "folderPath",
+    ]
+    assert start_agent["bindingInfo"]["contextField"] == "name"
+    assert '<uipath:activity type="Orchestrator.StartAgentJob"' in start_agent[
+        "xmlTemplate"
+    ]
+    assert "<bpmn:extensionElements>" not in start_agent["xmlTemplate"]
+    assert "releaseKey" not in start_agent["xmlTemplate"]

--- a/tests/tasks/uipath-maestro-bpmn/nodes/check_contract_variant_wrappers.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/check_contract_variant_wrappers.py
@@ -9,6 +9,7 @@ from _shared.bpmn_check import (  # noqa: E402
     NS,
     elements,
     fail,
+    has_typed_uipath_extension,
     parse_bpmn,
     require_di_for_visible_elements,
     require_no_private_connector_values,
@@ -16,22 +17,11 @@ from _shared.bpmn_check import (  # noqa: E402
 )
 
 
-def has_typed_extension(element: ET.Element, extension_name: str, type_value: str) -> bool:
-    ext = element.find("bpmn:extensionElements", NS)
-    if ext is None:
-        return False
-    for payload in ext.findall(f"uipath:{extension_name}", NS):
-        type_elem = payload.find("uipath:type", NS)
-        if type_elem is not None and type_elem.attrib.get("value") == type_value:
-            return True
-    return False
-
-
 def require_wrapper(root: ET.Element, wrapper: str, extension_name: str, type_value: str) -> None:
     matches = [
         elem
         for elem in elements(root, wrapper)
-        if has_typed_extension(elem, extension_name, type_value)
+        if has_typed_uipath_extension(elem, extension_name, type_value)
     ]
     if not matches:
         fail(f"missing bpmn:{wrapper} with {type_value} uipath:{extension_name} shell")


### PR DESCRIPTION
## Summary

- accept both supported UiPath BPMN type declarations in shared checker helpers
- align the live BPMN skill and bundled registry fallback with the CLI registry’s runtime-authored `Orchestrator.StartAgentJob` contract
- add a path-filtered BPMN checker unit-test gate

## RCA

The contract-variant task failed repeatedly even though the agent pasted the current CLI registry template. The checker only searched nested `bpmn:extensionElements/uipath:type`, while `Orchestrator.StartAgentJob` intentionally uses a direct `uipath:activity type="Orchestrator.StartAgentJob"` payload. The live skill simultaneously instructed agents to preserve registry templates and prohibited the direct form.

CLI manifest commit `27551befe` and its validator/packager tests establish the direct form as supported. This change fixes that enabling contract rather than rewriting a valid generated artifact.

## Verification

- `uv run --with pytest pytest tests/tasks/uipath-maestro-bpmn/ -v` (4 passed)
- current CLI and bundled `Orchestrator.StartAgentJob` registry entries compare byte-for-byte after canonical JSON sorting
- the unchanged R2 live artifact now passes `check_contract_variant_wrappers.py`
- `git diff --check`

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)