### PR TITLE
Accept the SDK default for optional Case tasks

### DIFF
--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/check_task_dependency_chain.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/check_task_dependency_chain.py
@@ -61,6 +61,12 @@ def _task_entry_rule(task: dict) -> str | None:
     return None
 
 
+def _task_is_non_required(task: dict) -> bool:
+    # The Case SDK omits isRequired for the default non-required state.
+    value = task.get("isRequired")
+    return value is None or value is False
+
+
 def main():
     plan = read_caseplan()
 
@@ -158,7 +164,7 @@ def main():
         (first_rule_of_condition(condition) or {}).get("rule")
         for condition in (optional_audit.get("entryConditions") or [])
     ]
-    if adhoc_rules != ["adhoc"] or optional_audit.get("isRequired") is not False:
+    if adhoc_rules != ["adhoc"] or not _task_is_non_required(optional_audit):
         sys.exit(
             "FAIL: Optional Audit must be an adhoc-only, non-required task; "
             f"rules={adhoc_rules!r}, isRequired={optional_audit.get('isRequired')!r}"

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/test_check_task_dependency_chain.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/test_check_task_dependency_chain.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from check_task_dependency_chain import _task_is_non_required  # noqa: E402
+
+
+def test_non_required_accepts_the_sdk_default_or_explicit_false():
+    assert _task_is_non_required({})
+    assert _task_is_non_required({"isRequired": False})
+
+
+def test_non_required_rejects_required_or_invalid_values():
+    assert not _task_is_non_required({"isRequired": True})
+    assert not _task_is_non_required({"isRequired": "false"})


### PR DESCRIPTION
## Summary
- accept the Case SDK's omitted `isRequired` field as the default non-required state
- continue rejecting explicitly required and malformed values
- add focused regression coverage for both accepted serializations

## Root cause
The task checker required `isRequired: false`, but the Case SDK intentionally omits the field unless `.required(...)` is called. Its serialization tests define omission as the normal optional-task representation, so the evaluator was grading a redundant spelling rather than the runtime semantics.

## Verification
- `uv run --with pytest pytest -q tests/tasks/uipath-maestro-case/` (118 passed, 14 skipped)
- `git diff --check`

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)
