### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@e2ab916

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 48e87bc. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ e2ab916. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 
@@ -42,7 +42,7 @@ need, then let TypeScript and `bpmn check` provide the detailed contract.
 | Connectors and external work | `connector`, `externalAgent`, `externalWorkflow` | [Connections](references/bpmn-runtime.md#connectors-and-bindings) | `examples/NotifyChannel.bpmn.ts` |
 | Generic registry activity | `activity` | [ActivityNodeOpts](references/api.md#activitynodeopts-interface) | `examples/NotifyChannel.bpmn.ts` |
 | Existing BPMN | `bpmn decompile`, `compile`, `merge` | [Brownfield](references/bpmn-runtime.md#brownfield-editing) | `examples/NotifyChannel.bpmn.ts` |
-| Project package and layout | project metadata, `bpmn format` | [Packaging](references/bpmn-runtime.md#packaging-and-layout) | `examples/NotifyChannel.bpmn.ts` |
+| Process metadata, package, and layout | `metadata`, project metadata, `bpmn format` | [Contract metadata](references/bpmn-runtime.md#contract-metadata) | `examples/NotifyChannel.bpmn.ts` |
 
 ## Minimal shape
 

--- a/preview/uipath-maestro-bpmn/references/bpmn-runtime.md
+++ b/preview/uipath-maestro-bpmn/references/bpmn-runtime.md
@@ -50,6 +50,16 @@ make from syntax alone. Exact signatures remain in [the generated API](api.md).
 - Format after adding elements that need diagram shapes. Avoid formatting a
   metadata-only edit because it replaces preserved geometry.
 
+## Contract metadata
+
+<!-- RULE:bpmn.metadata.case-management -->
+- A process-level `uipath:caseManagement` marker is distinct from a typed
+  `Orchestrator.StartCaseMgmtProcess` or `Orchestrator.StartCaseMgmtProcessAsync`
+  call activity. When a contract or fixture explicitly requires that marker,
+  author it with synthetic content through
+  `.metadata({ caseManagement: { version: 'v1', value: '{"mode":"preserve-only"}' } })`.
+  A case-process call does not emit or replace the marker.
+
 ## Packaging and layout
 
 <!-- RULE:bpmn.package.derived -->

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 48e87bc. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ e2ab916. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,
@@ -30,7 +30,8 @@ need, then let TypeScript and `case check` provide the detailed contract.
 4. Run `uip maestro case check <Name>.case.ts --source` after each structural change.
 5. Compile into the scaffolded Case project, then run `uip maestro case validate`.
    Compile keeps existing `entry-points.json` and `bindings_v2.json` sidecars in
-   sync. When resource bindings changed, refresh the solution resources too.
+   sync. Refresh added bindings; after removing/repointing a bound task, list
+   solution resources and remove each orphan by key before refreshing.
 6. Run live debug only when the task requires runtime evidence and provides tenant resources.
 
 ## Capability router
@@ -84,7 +85,7 @@ export default casePlan('loan-approval')
 uip maestro case check <Name>.case.ts --source
 uip maestro case compile <Name>.case.ts -o <project>/caseplan.json
 uip maestro case validate <project>/caseplan.json --output json
-# After adding, removing, or repointing a resource-bound task or connector:
+uip solution resources remove <orphan-key> --solution-folder <solution> --output json
 uip solution resources refresh --solution-folder <solution> --output json
 ```
 

--- a/preview/uipath-maestro-case/references/case-runtime.md
+++ b/preview/uipath-maestro-case/references/case-runtime.md
@@ -9,9 +9,12 @@ make from syntax alone. Exact signatures remain in [the generated API](api.md).
 - A connector event without a subscription is a placeholder. A resolved event
   needs a generated descriptor or connector key/event plus symbolic connection
   and folder bindings. For an unresolved placeholder, preserve the requested
-  source system and object in the trigger description; the service-type-only
-  runtime bag cannot carry that intent. Only a live subscription proves the
-  payload shape.
+  source system, object, and event verbatim in the trigger name or description;
+  the service-type-only runtime bag cannot carry that intent. Do not fabricate
+  a connector descriptor or node type. For example,
+  `eventTrigger({ name: 'aged_invoice_cases record created' })` preserves the
+  unresolved source while remaining a valid placeholder. Only a live
+  subscription proves the payload shape.
 
 ## Human and on-demand work
 
@@ -61,7 +64,10 @@ make from syntax alone. Exact signatures remain in [the generated API](api.md).
   metadata and bindings that the typed surface does not own. Strict decompile
   fails closed on unresolved references. For an explicitly broken input, rerun
   with `--best-effort`, inspect every reported diagnostic, and replace every
-  `__UNRESOLVED_*` marker before checking or compiling the repair.
+  `__UNRESOLVED_*` marker before checking or compiling the repair. Removing or
+  repointing a bound task also requires the orphan cleanup under
+  [Connections and external work](#connections-and-external-work); compilation
+  and resource refresh do not remove solution declarations.
 
 ## Product boundary
 

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 48e87bc. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ e2ab916. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `48e87bc` to current `UiPath/flow-builder-sdk@main` (`e2ab916`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)