### PR TITLE
Accept SDK-authored generic BPMN activities

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/nodes/check_contract_variant_wrappers.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/check_contract_variant_wrappers.py
@@ -32,6 +32,15 @@ def require_uipath_element(root: ET.Element, local_name: str, description: str) 
         fail(f"missing {description}")
 
 
+def has_preserve_only_generic_activity(root: ET.Element) -> bool:
+    if root.findall(".//uipath:Activity", NS):
+        return True
+    return any(
+        has_typed_uipath_extension(task, "activity", "uipath:Activity")
+        for task in elements(root, "serviceTask")
+    )
+
+
 def require_uipath_attr_value(
     root: ET.Element, local_name: str, attr_name: str, expected_value: str, description: str
 ) -> None:
@@ -75,7 +84,8 @@ def main() -> None:
         root, "scriptVersion", "value", "v2", "preserved legacy scriptVersion"
     )
     require_uipath_element(root, "caseManagement", "preserve-only uipath:caseManagement payload")
-    require_uipath_element(root, "Activity", "preserve-only generic uipath:Activity payload")
+    if not has_preserve_only_generic_activity(root):
+        fail("missing preserve-only generic uipath:Activity payload")
 
     require_no_private_connector_values(root)
     require_sequence_integrity(root)

--- a/tests/tasks/uipath-maestro-bpmn/nodes/test_contract_variant_wrappers.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/test_contract_variant_wrappers.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from check_contract_variant_wrappers import NS, has_preserve_only_generic_activity
+
+
+def _root(payload: str) -> ET.Element:
+    return ET.fromstring(
+        f'<bpmn:definitions xmlns:bpmn="{NS["bpmn"]}" '
+        f'xmlns:uipath="{NS["uipath"]}"><bpmn:process>'
+        f'<bpmn:serviceTask id="Task_1"><bpmn:extensionElements>{payload}'
+        "</bpmn:extensionElements></bpmn:serviceTask></bpmn:process></bpmn:definitions>"
+    )
+
+
+def test_accepts_legacy_literal_generic_activity() -> None:
+    root = _root('<uipath:Activity version="v1">synthetic</uipath:Activity>')
+
+    assert has_preserve_only_generic_activity(root)
+
+
+def test_accepts_sdk_authored_generic_activity_type() -> None:
+    root = _root(
+        '<uipath:activity version="v1">'
+        '<uipath:type value="uipath:Activity" version="v1" />'
+        "</uipath:activity>"
+    )
+
+    assert has_preserve_only_generic_activity(root)
+
+
+def test_rejects_unrelated_activity_type() -> None:
+    root = _root(
+        '<uipath:activity version="v1">'
+        '<uipath:type value="Orchestrator.StartJob" version="v1" />'
+        "</uipath:activity>"
+    )
+
+    assert not has_preserve_only_generic_activity(root)


### PR DESCRIPTION
## Summary

- accept the SDK-supported typed `uipath:Activity` representation in the contract-variant checker
- retain compatibility with the legacy literal `<uipath:Activity>` preserve-only payload
- cover both accepted forms and an unrelated-type negative control

## Verification

- `7 passed` across the focused contract and shared BPMN checker tests
- the failed SDK 3.27.5 preview artifact from the final campaign rerun passes the updated checker

Fixes #2904

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)