### PR TITLE
chore: refresh uip CLI catalog (1.202.0-dev.8414)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-29T04:13:28Z",
+  "generated_at": "2026-08-30T04:11:50Z",
   "cli_version": "1.202.0-dev.8414",
   "verbs": [
     "admin",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.202.0-dev.8414`. The catalog has 1555 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.