### PR TITLE
Make BPMN evals author-loop neutral

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/author/check_simple_approval_bpmn.py
+++ b/tests/tasks/uipath-maestro-bpmn/author/check_simple_approval_bpmn.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import xml.etree.ElementTree as ET
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.bpmn_check import (  # noqa: E402
@@ -16,6 +17,15 @@ from _shared.bpmn_check import (  # noqa: E402
     require_no_private_connector_values,
     require_sequence_integrity,
 )
+
+
+def root_variable_identifiers(process: ET.Element) -> set[str]:
+    return {
+        identifier
+        for var in process.findall("bpmn:extensionElements/uipath:variables/*", NS)
+        for identifier in (var.attrib.get("id"), var.attrib.get("name"))
+        if identifier
+    }
 
 
 def main() -> None:
@@ -57,13 +67,9 @@ def main() -> None:
     process = root.find("bpmn:process", NS)
     if process is None:
         fail("missing bpmn:process element")
-    variable_names = {
-        var.attrib.get("name")
-        for var in process.findall("bpmn:extensionElements/uipath:variables/*", NS)
-        if var.attrib.get("name")
-    }
+    variable_identifiers = root_variable_identifiers(process)
     for required in ("expenseId", "amount", "decision"):
-        if required not in variable_names:
+        if required not in variable_identifiers:
             fail(f"missing root variable named {required!r}")
 
     migration_versions = {

--- a/tests/tasks/uipath-maestro-bpmn/author/simple_approval_bpmn.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/simple_approval_bpmn.yaml
@@ -37,15 +37,19 @@ initial_prompt: |
   - Do not upload, publish, deploy, debug, or run the process.
 
 success_criteria:
-  - type: file_exists
+  - type: run_command
     description: "BPMN source was created"
-    path: "ExpenseApprovalBpmn/ExpenseApprovalBpmn.bpmn"
+    command: "python3 -c \"from pathlib import Path; import sys; sys.exit(0 if any(Path('.').rglob('ExpenseApprovalBpmn.bpmn')) else 'ExpenseApprovalBpmn.bpmn missing')\""
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: file_exists
-    description: "Project metadata was created"
-    path: "ExpenseApprovalBpmn/project.uiproj"
+  - type: run_command
+    description: "Editable project source or metadata was created beside the BPMN"
+    command: "python3 -c \"from pathlib import Path; import sys; b=next(Path('.').rglob('ExpenseApprovalBpmn.bpmn'), None); sys.exit(0 if b and ((b.parent / 'project.uiproj').is_file() or b.with_suffix('.bpmn.ts').is_file()) else 'project.uiproj or ExpenseApprovalBpmn.bpmn.ts missing beside BPMN')\""
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-bpmn/author/test_simple_approval_bpmn.py
+++ b/tests/tasks/uipath-maestro-bpmn/author/test_simple_approval_bpmn.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from check_simple_approval_bpmn import NS, root_variable_identifiers  # noqa: E402
+
+
+def _variable_identifiers(payload: str) -> set[str]:
+    root = ET.fromstring(
+        f'<bpmn:process xmlns:bpmn="{NS["bpmn"]}" '
+        f'xmlns:uipath="{NS["uipath"]}">'
+        f"<bpmn:extensionElements><uipath:variables>{payload}"
+        "</uipath:variables></bpmn:extensionElements></bpmn:process>"
+    )
+    return root_variable_identifiers(root)
+
+
+def test_variable_identity_accepts_sdk_ids_with_descriptive_names() -> None:
+    identifiers = _variable_identifiers(
+        '<uipath:input id="expenseId" name="Expense identifier (string)" />'
+        '<uipath:input id="amount" name="Expense amount (number)" />'
+        '<uipath:output id="decision" name="Approval decision (string)" />'
+    )
+
+    assert {"expenseId", "amount", "decision"} <= identifiers
+
+
+def test_variable_identity_retains_legacy_name_compatibility() -> None:
+    identifiers = _variable_identifiers(
+        '<uipath:input name="expenseId" />'
+        '<uipath:input name="amount" />'
+        '<uipath:output name="decision" />'
+    )
+
+    assert {"expenseId", "amount", "decision"} <= identifiers
+
+
+def test_variable_identity_rejects_unrelated_ids_and_names() -> None:
+    identifiers = _variable_identifiers(
+        '<uipath:input id="requestId" name="Request identifier" />'
+        '<uipath:output id="status" name="Request status" />'
+    )
+
+    assert not {"expenseId", "amount", "decision"} <= identifiers

--- a/tests/tasks/uipath-maestro-bpmn/connector/integration_service_boundary.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/connector/integration_service_boundary.yaml
@@ -31,9 +31,11 @@ initial_prompt: |
   - Do not upload, publish, deploy, debug, or run the process.
 
 success_criteria:
-  - type: file_exists
+  - type: run_command
     description: "BPMN source was created"
-    path: "SlackDigestBoundaryBpmn/SlackDigestBoundaryBpmn.bpmn"
+    command: "python3 -c \"from pathlib import Path; import sys; sys.exit(0 if any(Path('.').rglob('SlackDigestBoundaryBpmn.bpmn')) else 'SlackDigestBoundaryBpmn.bpmn missing')\""
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-bpmn/debug/debug_workflow_mocked/debug_workflow_mocked.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/debug/debug_workflow_mocked/debug_workflow_mocked.yaml
@@ -61,13 +61,11 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "Summary reports the runtime variable values only obtainable from the debug session"
-    path: "summary.md"
-    includes:
-      - "1875"
-      - "AutoApproved"
-      - "Tier2"
+    command: "python3 -c \"from pathlib import Path; import sys; texts=[p.read_text(encoding='utf-8') for p in Path('.').rglob('summary.md')]; required=('1875', 'AutoApproved', 'Tier2'); sys.exit(0 if any(all(value in text for value in required) for text in texts) else 'no summary.md contains all runtime values')\""
+    timeout: 30
+    expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -52,7 +52,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "BPMN source file was created"
-    command: "python3 -c \"from pathlib import Path; import sys; paths=[Path('WikiPageviews/WikiPageviews.bpmn'), Path('WikiPageviewsSolution/WikiPageviews/WikiPageviews.bpmn')]; sys.exit(0 if any(p.is_file() for p in paths) else 'WikiPageviews.bpmn missing in direct or solution-wrapper layout')\""
+    command: "python3 -c \"from pathlib import Path; import sys; sys.exit(0 if any(Path('.').rglob('WikiPageviews.bpmn')) else 'WikiPageviews.bpmn missing')\""
     timeout: 30
     expected_exit_code: 0
     weight: 1.5
@@ -60,7 +60,7 @@ success_criteria:
 
   - type: run_command
     description: "Package operate metadata was created"
-    command: "python3 -c \"from pathlib import Path; import sys; paths=[Path('WikiPageviews/operate.json'), Path('WikiPageviewsSolution/WikiPageviews/operate.json')]; sys.exit(0 if any(p.is_file() for p in paths) else 'operate.json missing in direct or solution-wrapper layout')\""
+    command: "python3 -c \"from pathlib import Path; import sys; sys.exit(0 if any(Path('.').rglob('operate.json')) else 'operate.json missing')\""
     timeout: 30
     expected_exit_code: 0
     weight: 1.0
@@ -68,7 +68,7 @@ success_criteria:
 
   - type: run_command
     description: "The invalid-article path returns the fixed error string"
-    command: "python3 -c \"from pathlib import Path; import sys; paths=[Path('WikiPageviews/WikiPageviews.bpmn'), Path('WikiPageviewsSolution/WikiPageviews/WikiPageviews.bpmn')]; texts=[p.read_text(encoding='utf-8') for p in paths if p.is_file()]; sys.exit(0 if any('Article not found' in t for t in texts) else 'Article not found missing from WikiPageviews.bpmn')\""
+    command: "python3 -c \"from pathlib import Path; import sys; texts=[p.read_text(encoding='utf-8') for p in Path('.').rglob('WikiPageviews.bpmn')]; sys.exit(0 if any('Article not found' in t for t in texts) else 'Article not found missing from WikiPageviews.bpmn')\""
     timeout: 30
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/nodes/hitl_rpa_wrappers.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/hitl_rpa_wrappers.yaml
@@ -22,9 +22,11 @@ initial_prompt: |
   - Do not upload, publish, deploy, debug, or run the process.
 
 success_criteria:
-  - type: file_exists
+  - type: run_command
     description: "BPMN source was created"
-    path: "EmployeeAccessBpmn/EmployeeAccessBpmn.bpmn"
+    command: "python3 -c \"from pathlib import Path; import sys; sys.exit(0 if any(Path('.').rglob('EmployeeAccessBpmn.bpmn')) else 'EmployeeAccessBpmn.bpmn missing')\""
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Summary

- discover BPMN artifacts recursively so live nested projects and SDK root outputs are graded identically
- accept either live `project.uiproj` metadata or SDK `.bpmn.ts` source beside Simple Approval BPMN
- recognize canonical variable IDs while retaining legacy display-name compatibility
- cover SDK IDs, legacy names, and an unrelated-variable negative control

## Verification

- `10 passed` across all Maestro BPMN checker unit tests
- `npm run skills:validate`
- replayed the fresh failed SDK 3.27.6 artifacts: HITL/RPA, Simple Approval, and WikiPageviews pass every deterministic criterion after the change
- replayed fresh live Simple Approval artifact: semantic checker still passes
- Integration Service evidence now passes only the layout criterion and still fails its independent semantic blocker check

Fixes #2908

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)