### PR TITLE
Align Case evals across authoring loops

### DIFF
--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -485,7 +485,9 @@ def _get_ci(mapping: Any, *candidate_keys: str, default: Any = None) -> Any:
 def find_project_dir(pattern: str = "**/project.uiproj") -> str:
     """Return the directory holding the Case `project.uiproj`. Filters by
     ``ProjectType`` so a sibling Agent / RPA / Coded project in the same
-    solution does not collide with the Case project we want to debug.
+    solution does not collide with the Case project we want to debug. When a
+    preview author leaves both a substantive project and a generated
+    trigger-only scaffold, select the substantive project.
     """
     candidates = sorted(
         p for p in glob.glob(pattern, recursive=True) if "/.venv/" not in p
@@ -501,6 +503,12 @@ def find_project_dir(pattern: str = "**/project.uiproj") -> str:
             f"\n  - {joined}"
         )
     if len(case_projects) > 1:
+        selected, husks = _split_case_project_husks(case_projects)
+        if selected is not None:
+            print(
+                f"note: ignoring {len(husks)} abandoned Case project scaffold(s)"
+            )
+            return os.path.dirname(selected)
         joined = "\n  - ".join(case_projects)
         _fail(
             f"Multiple Case projects match {pattern!r} — refusing to guess:"
@@ -511,7 +519,9 @@ def find_project_dir(pattern: str = "**/project.uiproj") -> str:
 
 def find_solution_dir(pattern: str = "**/*.uipx") -> str:
     """Return the directory holding the ``*.uipx`` solution manifest.
-    Used as ``--solution-folder`` for ``uip solution resources refresh``.
+    Used as ``--solution-folder`` for ``uip solution resources refresh``. A
+    solution whose Case project is substantive wins over generated solutions
+    that contain only a trigger scaffold.
     """
     matches = sorted(
         p for p in glob.glob(pattern, recursive=True) if "/.venv/" not in p
@@ -519,9 +529,67 @@ def find_solution_dir(pattern: str = "**/*.uipx") -> str:
     if not matches:
         _fail(f"No solution manifest found matching {pattern}")
     if len(matches) > 1:
+        selected, husks = _split_case_solution_husks(matches)
+        if selected is not None:
+            print(
+                f"note: ignoring {len(husks)} abandoned Case solution scaffold(s)"
+            )
+            return os.path.dirname(selected)
         joined = "\n  - ".join(matches)
         _fail(f"Multiple solution manifests match {pattern!r}:\n  - {joined}")
     return os.path.dirname(matches[0])
+
+
+def _split_case_project_husks(
+    project_uiprojs: list[str],
+) -> tuple[str | None, list[str]]:
+    counts = [
+        (path, _caseplan_node_count(os.path.dirname(path)))
+        for path in project_uiprojs
+    ]
+    return _split_case_husks(counts)
+
+
+def _split_case_solution_husks(
+    solution_uipxs: list[str],
+) -> tuple[str | None, list[str]]:
+    counts = [
+        (path, _caseplan_node_count(os.path.dirname(path)))
+        for path in solution_uipxs
+    ]
+    return _split_case_husks(counts)
+
+
+def _split_case_husks(
+    counts: list[tuple[str, int | None]],
+) -> tuple[str | None, list[str]]:
+    substantive = [path for path, count in counts if count is None or count > 1]
+    husks = [path for path, count in counts if count is not None and count <= 1]
+    if len(substantive) != 1:
+        return None, []
+    selected = substantive[0]
+    selected_count = next(count for path, count in counts if path == selected)
+    if selected_count is None:
+        return None, []
+    return selected, husks
+
+
+def _caseplan_node_count(root: str) -> int | None:
+    """Return the node count for one unambiguous Case plan under ``root``."""
+    plans = sorted(
+        path
+        for path in glob.glob(os.path.join(root, "**/caseplan.json"), recursive=True)
+        if "/.venv/" not in path
+    )
+    if len(plans) != 1:
+        return None
+    try:
+        with open(plans[0], encoding="utf-8") as f:
+            plan = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    nodes = plan.get("nodes") if isinstance(plan, dict) else None
+    return len(nodes) if isinstance(nodes, list) else None
 
 
 def run_debug(

--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -75,6 +75,35 @@ def read_caseplan(path: str | None = None) -> dict:
         return json.load(f)
 
 
+def is_non_required(item: dict) -> bool:
+    """Accept the Case SDK's omitted default and the explicit false form."""
+    value = item.get("isRequired")
+    return value is None or value is False
+
+
+def registry_audit_entries(payload: object) -> list[dict]:
+    """Read equivalent flat and enveloped registry-audit representations."""
+    if isinstance(payload, list):
+        entries = payload
+    elif isinstance(payload, dict):
+        entries = next(
+            (
+                payload[key]
+                for key in ("resolutions", "resources")
+                if isinstance(payload.get(key), list)
+            ),
+            None,
+        )
+        if entries is None:
+            _fail("registry-resolved.json has no resolutions/resources list")
+    else:
+        _fail("registry-resolved.json must be a list or object envelope")
+
+    if not all(isinstance(entry, dict) for entry in entries):
+        _fail("registry-resolved.json entries must be objects")
+    return entries
+
+
 def iter_tasks(plan: dict):
     """Yield every task dict from every Stage node (and legacy ExceptionStage).
 

--- a/tests/tasks/uipath-maestro-case/_shared/test_case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_case_check.py
@@ -22,6 +22,8 @@ from case_check import (  # noqa: E402
     _get_ci,
     collect_outputs,
     find_caseplan,
+    find_project_dir,
+    find_solution_dir,
     is_non_required,
     partition_return_to_origin_conditions,
     registry_audit_entries,
@@ -33,6 +35,16 @@ import case_check  # noqa: E402
 def _write_caseplan(path, nodes):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps({"nodes": nodes}), encoding="utf-8")
+
+
+def _write_case_project(root, solution, project, nodes):
+    project_dir = root / solution / project
+    _write_caseplan(project_dir / "caseplan.json", nodes)
+    (project_dir / "project.uiproj").write_text(
+        json.dumps({"ProjectType": "CaseManagement"}), encoding="utf-8"
+    )
+    (root / solution / f"{solution}.uipx").write_text("{}", encoding="utf-8")
+    return project_dir
 
 
 def test_find_caseplan_prefers_one_substantive_plan_over_scaffold_husk(tmp_path, monkeypatch):
@@ -63,6 +75,53 @@ def test_find_caseplan_rejects_distinct_substantive_plans(tmp_path, monkeypatch)
 
     with pytest.raises(SystemExit, match="Multiple distinct caseplan.json"):
         find_caseplan()
+
+
+def test_project_and_solution_discovery_prefer_substantive_case_over_husk(
+    tmp_path, monkeypatch, capsys
+):
+    substantive = _write_case_project(
+        tmp_path,
+        "Case",
+        "Case",
+        [{"id": "trigger"}, {"id": "stage"}],
+    )
+    _write_case_project(
+        tmp_path,
+        "CaseSolution",
+        "Case",
+        [{"id": "trigger"}],
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert find_project_dir() == os.path.relpath(substantive, tmp_path)
+    assert find_solution_dir() == "Case"
+    notes = capsys.readouterr().out
+    assert "ignoring 1 abandoned Case project scaffold(s)" in notes
+    assert "ignoring 1 abandoned Case solution scaffold(s)" in notes
+
+
+def test_project_discovery_still_refuses_distinct_substantive_cases(
+    tmp_path, monkeypatch
+):
+    _write_case_project(
+        tmp_path,
+        "FirstSolution",
+        "First",
+        [{"id": "trigger"}, {"id": "first"}],
+    )
+    _write_case_project(
+        tmp_path,
+        "SecondSolution",
+        "Second",
+        [{"id": "trigger"}, {"id": "second"}],
+    )
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit, match="Multiple Case projects match"):
+        find_project_dir()
+    with pytest.raises(SystemExit, match="Multiple solution manifests match"):
+        find_solution_dir()
 
 
 def test_non_required_accepts_omitted_or_explicit_false():

--- a/tests/tasks/uipath-maestro-case/_shared/test_case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_case_check.py
@@ -22,7 +22,9 @@ from case_check import (  # noqa: E402
     _get_ci,
     collect_outputs,
     find_caseplan,
+    is_non_required,
     partition_return_to_origin_conditions,
+    registry_audit_entries,
     run_debug,
 )
 import case_check  # noqa: E402
@@ -61,6 +63,31 @@ def test_find_caseplan_rejects_distinct_substantive_plans(tmp_path, monkeypatch)
 
     with pytest.raises(SystemExit, match="Multiple distinct caseplan.json"):
         find_caseplan()
+
+
+def test_non_required_accepts_omitted_or_explicit_false():
+    assert is_non_required({})
+    assert is_non_required({"isRequired": False})
+
+
+def test_non_required_rejects_required_or_invalid_values():
+    assert not is_non_required({"isRequired": True})
+    assert not is_non_required({"isRequired": "false"})
+
+
+def test_registry_audit_entries_accepts_flat_and_named_envelopes():
+    entries = [{"task": "Post Invoice"}]
+
+    assert registry_audit_entries(entries) == entries
+    assert registry_audit_entries({"resolutions": entries}) == entries
+    assert registry_audit_entries({"resources": entries}) == entries
+
+
+def test_registry_audit_entries_rejects_missing_or_non_object_entries():
+    with pytest.raises(SystemExit, match="no resolutions/resources list"):
+        registry_audit_entries({"status": "resolved"})
+    with pytest.raises(SystemExit, match="entries must be objects"):
+        registry_audit_entries({"resources": ["Post Invoice"]})
 
 
 def test_get_ci_reads_camelcase_and_pascalcase():

--- a/tests/tasks/uipath-maestro-case/connector_features/connector_wait/check_connector_wait.py
+++ b/tests/tasks/uipath-maestro-case/connector_features/connector_wait/check_connector_wait.py
@@ -18,6 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from _shared.case_check import (  # noqa: E402
     assert_task_type_present,
     first_rule_of_condition,
+    is_non_required,
     iter_tasks,
     read_caseplan,
     task_is_skeleton,
@@ -94,7 +95,7 @@ def main():
                     f"FAIL: entry rule {slot}[{entry.get('name')!r}].elementId "
                     f"must be {expected_element_id!r}; got {entry.get('elementId')!r}"
                 )
-    if event_task.get("isRequired") is not False:
+    if not is_non_required(event_task):
         sys.exit(
             "FAIL: event-triggered placeholder process should stay non-required; "
             f"got isRequired={event_task.get('isRequired')!r}"

--- a/tests/tasks/uipath-maestro-case/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_02_result_downstream.yaml
@@ -205,11 +205,11 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "tasks.md records the action output binding for approved"
-    path: "tasks/tasks.md"
-    includes:
-      - "approved"
+    command: "python3 -c \"from pathlib import Path; import sys; texts=[p.read_text(encoding='utf-8') for p in Path('.').rglob('tasks.md')]; sys.exit(0 if any('approved' in text for text in texts) else 'no tasks.md records approved')\""
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-case/logging/logging_issue_log.yaml
+++ b/tests/tasks/uipath-maestro-case/logging/logging_issue_log.yaml
@@ -131,8 +131,9 @@ initial_prompt: |
   Run `uip maestro case validate TimerLogCase/TimerLogCase/caseplan.json
   --output json`. Validation is expected to fail due to the invalid exitType;
   that is not a reason to stop. The task is NOT complete until validate has run
-  and the build's issue log is on disk. Follow the skill's own logging contract
-  for when and how that log is written.
+  and `tasks/build-issues.md` is on disk. Keep that file as an append-only build
+  journal: include a heading naming TimerLogCase, a `## Journal` table with the
+  validation failure, and a completed summary of the recorded issue.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/check_case_exit_full.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/check_case_exit_full.py
@@ -13,6 +13,7 @@ from _shared.case_check import (  # noqa: E402
     find_stages,
     first_rule_of_condition,
     get_case_exit_conditions,
+    is_non_required,
     iter_stage_entry_conditions,
     iter_stage_exit_conditions,
     read_caseplan,
@@ -47,7 +48,8 @@ def main():
     }
     for name, (stage, want) in expected_required.items():
         got = _is_required(stage)
-        if got is not want:
+        matches = got is True if want else is_non_required(stage.get("data") or {})
+        if not matches:
             sys.exit(
                 f"FAIL: stage {name!r} isRequired should be {want}; got {got!r}"
             )

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/check_linear_three_stages.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/check_linear_three_stages.py
@@ -16,6 +16,7 @@ from _shared.case_check import (  # noqa: E402
     get_variables,
     iter_stage_entry_conditions,
     iter_tasks,
+    is_non_required,
     read_caseplan,
     start_debug,
 )
@@ -110,7 +111,7 @@ def main():
             f"FAIL: 'Hold For 1 Hour' skipCondition should reference skipReview; "
             f"got {skip!r}"
         )
-    if notify.get("isRequired") is not False:
+    if not is_non_required(notify):
         sys.exit(
             f"FAIL: 'Notify Reviewer' should have isRequired=false (task-level "
             f"flag explicitly set); got {notify.get('isRequired')!r}"

--- a/tests/tasks/uipath-maestro-case/registry_handoff_sdd_only/check_registry_handoff.py
+++ b/tests/tasks/uipath-maestro-case/registry_handoff_sdd_only/check_registry_handoff.py
@@ -1,5 +1,10 @@
 import json
+import os
+import sys
 from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.case_check import registry_audit_entries  # noqa: E402
 
 
 EXPECTED = {
@@ -15,16 +20,6 @@ EXPECTED = {
     },
 }
 STAGE = "Resolve Resources"
-REQUIRED_KEYS = {
-    "stage",
-    "task",
-    "taskType",
-    "cacheFile",
-    "searchQuery",
-    "matches",
-    "selected",
-    "rationale",
-}
 
 
 def load_json(path: Path):
@@ -34,7 +29,7 @@ def load_json(path: Path):
 
 registry_path = Path("tasks/registry-resolved.json")
 entries = load_json(registry_path)
-assert isinstance(entries, list), "registry-resolved.json must be a list"
+entries = registry_audit_entries(entries)
 assert len(entries) == len(EXPECTED), (
     f"expected one fresh audit entry per SDD task, got {len(entries)}"
 )
@@ -46,34 +41,36 @@ for name, expected in EXPECTED.items():
     matching_entries = [
         entry
         for entry in entries
-        if str(entry.get("searchQuery", "")).strip() == name
+        if str(entry.get("searchQuery") or entry.get("resolvedResource") or "").strip()
+        == name
     ]
     assert len(matching_entries) == 1, (
         f"expected one registry audit entry for {name}, got {len(matching_entries)}"
     )
     entry = matching_entries[0]
-    assert REQUIRED_KEYS <= entry.keys(), (
-        f"{name} audit entry is missing {sorted(REQUIRED_KEYS - entry.keys())}"
-    )
-    assert str(entry.get("rationale", "")).strip(), (
-        f"{name} audit entry has no selection rationale"
-    )
-    assert entry.get("stage") == STAGE, (
-        f"{name} audit entry is associated with stage {entry.get('stage')!r}"
-    )
-    assert entry.get("task") == expected["task"], (
-        f"{name} audit entry is associated with task {entry.get('task')!r}"
+    if "stage" in entry:
+        assert entry["stage"] == STAGE, (
+            f"{name} audit entry is associated with stage {entry['stage']!r}"
+        )
+    task_name = entry.get("task") or entry.get("taskName")
+    assert task_name == expected["task"], (
+        f"{name} audit entry is associated with task {task_name!r}"
     )
     assert entry.get("taskType") == expected["task_type"], (
         f"{name} used taskType {entry.get('taskType')!r}"
     )
-    assert entry.get("cacheFile") == expected["cache_file"], (
-        f"{name} did not record cacheFile {expected['cache_file']}"
-    )
+    if "cacheFile" in entry:
+        assert entry["cacheFile"] == expected["cache_file"], (
+            f"{name} did not record cacheFile {expected['cache_file']}"
+        )
+    assert str(entry.get("rationale") or "").strip() or isinstance(
+        entry.get("resolution"), dict
+    ), f"{name} audit entry has no resolution evidence"
 
-    selected = entry.get("selected")
+    selected = entry.get("selected") or entry.get("resourceIdentity")
     assert isinstance(selected, dict), f"missing selected result for {name}"
-    assert selected.get("name") == name, f"selected the wrong resource for {name}"
+    selected_name = selected.get("name") or entry.get("resolvedResource")
+    assert selected_name == name, f"selected the wrong resource for {name}"
 
     cached_resources = load_json(cache_root / expected["cache_file"])
     exact_matches = [
@@ -90,18 +87,18 @@ for name, expected in EXPECTED.items():
     # Also tolerant of ephemeral debug-deploy churn: we require the SELECTED entry to be a
     # live exact-name match and every recorded candidate to be exact-name, not a byte-for-
     # byte copy of the whole cache set.
-    recorded = entry.get("matches") or []
-    assert recorded, f"{name} audit recorded no matches"
-    # The skill's discovery search is substring-based, so `matches` may carry near-name
-    # candidates (e.g. a `<name>V2` sibling) alongside the exact hit. Correctness is proven
-    # by `selected` below (exact-name + live entityKey); here we only require the exact-name
-    # match to be PRESENT among the recorded candidates, not that every candidate is exact.
-    assert any(
-        str(m.get("name", "")).strip().casefold() == name.casefold() for m in recorded
-    ), f"{name} audit recorded no exact-name match"
-    assert isinstance(selected, dict), f"missing selected result for {name}"
+    recorded = entry.get("matches")
+    if recorded is not None:
+        assert recorded, f"{name} audit recorded no matches"
+        # The skill's discovery search is substring-based, so `matches` may carry
+        # near-name candidates alongside the exact hit. Correctness is proven by
+        # `selected`; here we only require the exact-name match to be present.
+        assert any(
+            str(m.get("name", "")).strip().casefold() == name.casefold()
+            for m in recorded
+        ), f"{name} audit recorded no exact-name match"
     assert (
-        str(selected.get("name", "")).strip().casefold() == name.casefold()
+        str(selected_name).strip().casefold() == name.casefold()
         and str(selected.get("entityKey")) in cache_keys
     ), f"selected result for {name} is not a live exact-name cache entry"
 
@@ -111,10 +108,15 @@ for name, expected in EXPECTED.items():
     # flat (folder/folderType) or nested (folders[0].fullyQualifiedName/.type).
     fol = selected.get("folders") or []
     sel_folder = str(
-        selected.get("folder") or (fol[0].get("fullyQualifiedName") if fol else "")
+        selected.get("folder")
+        or selected.get("folderPath")
+        or entry.get("folderPath")
+        or (fol[0].get("fullyQualifiedName") if fol else "")
     ).casefold()
     sel_ftype = str(
-        selected.get("folderType") or (fol[0].get("type") if fol else "")
+        selected.get("folderType")
+        or selected.get("organizationUnitType")
+        or (fol[0].get("type") if fol else "")
     ).casefold()
     assert sel_ftype != "debugsolution" and "debug_" not in sel_folder, (
         f"{name} resolved to an ephemeral debug-solution deploy "

--- a/tests/tasks/uipath-maestro-case/sla_response/at_risk_enter_stage/check_at_risk_enter_stage.py
+++ b/tests/tasks/uipath-maestro-case/sla_response/at_risk_enter_stage/check_at_risk_enter_stage.py
@@ -13,6 +13,7 @@ from _shared.sla_response_check import (  # noqa: E402
     assert_stage_count,
     fail,
     iter_sla_status_change,
+    is_non_required,
     label_of,
     read_plan,
     secondary_stages,
@@ -33,7 +34,7 @@ def main() -> None:
     lane = lanes[0]
     lane_data = lane["data"]
 
-    if lane_data.get("isRequired") is not False:
+    if not is_non_required(lane_data):
         fail(
             f"lane {label_of(lane)!r} has isRequired={lane_data.get('isRequired')!r}; an SLA lane "
             "must stay out of the happy-path required-stages-completed set"

--- a/tests/tasks/uipath-maestro-case/sla_response/case_breach_oversight/check_case_breach_oversight.py
+++ b/tests/tasks/uipath-maestro-case/sla_response/case_breach_oversight/check_case_breach_oversight.py
@@ -19,6 +19,7 @@ from _shared.sla_response_check import (  # noqa: E402
     fail,
     is_secondary,
     iter_sla_status_change,
+    is_non_required,
     label_of,
     read_plan,
 )
@@ -46,7 +47,7 @@ def main() -> None:
             "non-interrupting SLA oversight lane still stays `secondary` — promoting it to a "
             "regular stage would make it required for case completion"
         )
-    if lane["data"].get("isRequired") is not False:
+    if not is_non_required(lane["data"]):
         fail(
             f"lane {label_of(lane)!r} has isRequired={lane['data'].get('isRequired')!r}; an "
             "oversight lane must stay out of the required-stages-completed set"

--- a/tests/tasks/uipath-maestro-case/sla_response/case_breach_takeover/check_case_breach_takeover.py
+++ b/tests/tasks/uipath-maestro-case/sla_response/case_breach_takeover/check_case_breach_takeover.py
@@ -13,6 +13,7 @@ from _shared.sla_response_check import (  # noqa: E402
     assert_stage_count,
     fail,
     iter_sla_status_change,
+    is_non_required,
     label_of,
     read_plan,
     secondary_stages,
@@ -31,7 +32,7 @@ def main() -> None:
             f"{[label_of(n) for n in lanes]}"
         )
     lane = lanes[0]
-    if lane["data"].get("isRequired") is not False:
+    if not is_non_required(lane["data"]):
         fail(f"lane {label_of(lane)!r} must be isRequired False")
 
     hits = [(n, c, r) for n, c, r in iter_sla_status_change(plan) if n is lane]


### PR DESCRIPTION
## Summary

- treat omitted and explicit-false `isRequired` as the same non-required Case state across affected graders
- accept root or nested `tasks.md` placement for HITL output-binding evidence
- validate equivalent flat, `resolutions`, and `resources` registry-audit representations against live resource identities
- state the issue-journal deliverable explicitly in the logging task prompt so both authoring arms receive the same contract
- ignore generated trigger-only Case project/solution scaffolds when one substantive Case build exists, while retaining refusal for distinct substantive builds

## Verification

- `138 passed` across the complete Maestro Case checker suite
- `npm run skills:validate`
- replayed the original SDK 3.27.6 connector-wait artifact successfully
- replayed the original and fresh registry-handoff artifacts successfully
- replayed the original SDK root-level HITL `tasks.md` criterion successfully
- replayed fresh SDK dependency-chain discovery and selected the substantive project/solution over its one-node scaffold

Fixes #2910

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)