### PR TITLE
fix(maestro-flow): make artifact discovery author-loop neutral

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -1429,17 +1429,46 @@ def find_flow_files(
 ) -> list[str]:
     """Return flow artifacts from the selected solution, or one root emit.
 
-    A Flow solution project wins whenever one exists. This keeps a root-level
-    SDK scratch file from competing with the linked solution copy.
-    When no project exists, validate and source-structure checks may consume a
-    root-level SDK emit. Multiple genuinely distinct root emits are ambiguous
-    and fail with their paths rather than selecting one by glob order.
+    A substantive Flow solution project wins whenever one exists. This keeps a
+    root-level SDK scratch file from competing with the linked solution copy.
+    When no project exists, or every project is only an abandoned scaffold,
+    validate and source-structure checks may consume a substantive root-level
+    SDK emit. Multiple genuinely distinct root emits are ambiguous and fail
+    with their paths rather than selecting one by glob order.
 
     Debug callers intentionally do not use this helper: ``uip maestro flow
     debug`` is project-scoped and must continue through :func:`find_project_dir`.
     """
     project_candidates = sorted(glob.glob(project_pattern, recursive=True))
-    if any(_is_flow_project(path) for path in project_candidates):
+    flow_projects = [path for path in project_candidates if _is_flow_project(path)]
+    root_matches = _dedupe_flow_candidates(
+        sorted(glob.glob(os.path.basename(flow_glob)))
+    )
+
+    # A preview author may compile a complete root-level SDK source before a
+    # later CLI command leaves an untouched trigger-only project scaffold. For
+    # file-scoped checks the substantive artifact is the build; the scaffold is
+    # not allowed to shadow it merely because it carries project.uiproj.
+    if flow_projects and len(root_matches) == 1:
+        project_counts = [
+            _flow_node_count(os.path.dirname(path)) for path in flow_projects
+        ]
+        root_count = _flow_file_node_count(root_matches[0])
+        if (
+            root_count is not None
+            and root_count > _HUSK_MAX_NODES
+            and all(
+                count is not None and count <= _HUSK_MAX_NODES
+                for count in project_counts
+            )
+        ):
+            print(
+                "note: ignoring abandoned project scaffold(s) in favor of "
+                f"substantive root Flow emit: {root_matches[0]}"
+            )
+            return root_matches
+
+    if flow_projects:
         project_dir = _find_project(project_pattern)
         matches = sorted(
             glob.glob(
@@ -1454,9 +1483,6 @@ def find_flow_files(
             )
         return matches
 
-    root_matches = _dedupe_flow_candidates(
-        sorted(glob.glob(os.path.basename(flow_glob)))
-    )
     if not root_matches:
         _fail(
             f"No Flow project found matching {project_pattern!r}, and no "
@@ -1582,8 +1608,9 @@ def _find_project(pattern: str) -> str:
     Filtering by manifest avoids a 1-of-N glob collision the symptom of
     MST-9734.
 
-    Two Flow projects can also mean one build plus one abandoned scaffold —
-    see :func:`_split_off_scaffold_husks`. Anything else stays a refusal.
+    Two Flow projects can also mean byte-identical copies, or one build plus one
+    abandoned scaffold — see :func:`_dedupe_flow_projects` and
+    :func:`_split_off_scaffold_husks`. Anything else stays a refusal.
     """
     candidates = sorted(glob.glob(pattern, recursive=True))
     if not candidates:
@@ -1596,6 +1623,15 @@ def _find_project(pattern: str) -> str:
             f'candidates exist but none declare ProjectType="Flow":\n  - {joined}'
         )
     if len(flow_projects) > 1:
+        original_count = len(flow_projects)
+        flow_projects = _dedupe_flow_projects(flow_projects)
+        if len(flow_projects) == 1:
+            print(
+                "note: ignoring "
+                f"{original_count - 1} byte-identical Flow project duplicate(s)"
+            )
+            return os.path.dirname(flow_projects[0])
+
         counts = [(p, _flow_node_count(os.path.dirname(p))) for p in flow_projects]
         selected, husks = _split_off_scaffold_husks(counts)
         if selected is not None:
@@ -1642,16 +1678,52 @@ def _flow_node_count(project_dir: str) -> int | None:
         return None
     total = 0
     for path in flows:
-        try:
-            with open(path, encoding="utf-8") as f:
-                flow = json.load(f)
-        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        count = _flow_file_node_count(path)
+        if count is None:
             return None
-        nodes = flow.get("nodes") if isinstance(flow, dict) else None
-        if not isinstance(nodes, list):
-            return None
-        total += len(nodes)
+        total += count
     return total
+
+
+def _flow_file_node_count(path: str) -> int | None:
+    """Return one Flow file's node count, or ``None`` when unreadable."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            flow = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    nodes = flow.get("nodes") if isinstance(flow, dict) else None
+    return len(nodes) if isinstance(nodes, list) else None
+
+
+def _dedupe_flow_projects(project_uiprojs: list[str]) -> list[str]:
+    """Collapse projects whose relative Flow files are byte-for-byte equal.
+
+    Missing or unreadable Flow files stay distinct so project-scoped debug never
+    guesses across candidates whose equivalence cannot be proved.
+    """
+    by_content: dict[tuple[tuple[str, str], ...] | tuple[str, str], str] = {}
+    for project_uiproj in project_uiprojs:
+        project_dir = os.path.dirname(project_uiproj)
+        flows = sorted(
+            glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True)
+        )
+        fingerprints: list[tuple[str, str]] = []
+        try:
+            for path in flows:
+                with open(path, "rb") as f:
+                    digest = hashlib.sha256(f.read()).hexdigest()
+                fingerprints.append((os.path.relpath(path, project_dir), digest))
+        except OSError:
+            fingerprints = []
+
+        key: tuple[tuple[str, str], ...] | tuple[str, str]
+        if fingerprints:
+            key = tuple(fingerprints)
+        else:
+            key = ("unknown", project_uiproj)
+        by_content.setdefault(key, project_uiproj)
+    return sorted(by_content.values())
 
 
 def _describe_candidate(project_uiproj: str, node_count: int | None) -> str:

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check_discovery.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check_discovery.py
@@ -92,6 +92,25 @@ def test_refuses_when_two_candidates_are_substantive(tmp_path, monkeypatch):
         _find_project(PATTERN)
 
 
+def test_collapses_byte_identical_substantive_projects(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.chdir(tmp_path)
+    body = json.dumps(
+        {"nodes": [{"id": f"n{i}", "type": "core.action.script"} for i in range(3)]}
+    )
+    first = _make_flow_project(
+        tmp_path, "SolutionA", "Build", 3, flow_body=body
+    )
+    _make_flow_project(tmp_path, "SolutionB", "Build", 3, flow_body=body)
+
+    assert _find_project(PATTERN) == os.path.relpath(first, tmp_path)
+    assert (
+        "ignoring 1 byte-identical Flow project duplicate(s)"
+        in capsys.readouterr().out
+    )
+
+
 def test_refuses_when_a_candidate_flow_is_unreadable(tmp_path, monkeypatch):
     """Unknown node count is not a husk — stay conservative and refuse."""
     monkeypatch.chdir(tmp_path)
@@ -176,6 +195,34 @@ def test_solution_flow_beats_root_scratch_emit(tmp_path, monkeypatch):
     (tmp_path / "Build.flow").write_text(json.dumps({"nodes": [{"id": "scratch"}]}))
 
     assert find_flow_files() == [os.path.join("Solution", "Build", "Build.flow")]
+    assert find_flow_file() == os.path.join("Solution", "Build", "Build.flow")
+    assert project.name == "Build"
+
+
+def test_substantive_root_emit_beats_abandoned_project_scaffold(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.chdir(tmp_path)
+    _make_flow_project(tmp_path, "GeneratedSolution", "Build", 1)
+    root = tmp_path / "Build.flow"
+    root.write_text(
+        json.dumps(
+            {"nodes": [{"id": f"n{i}", "type": "core.action.script"} for i in range(4)]}
+        )
+    )
+
+    assert find_flow_files() == ["Build.flow"]
+    assert find_flow_file() == "Build.flow"
+    assert "ignoring abandoned project scaffold(s)" in capsys.readouterr().out
+
+
+def test_root_husk_does_not_override_project_husk(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    project = _make_flow_project(tmp_path, "Solution", "Build", 1)
+    (tmp_path / "Build.flow").write_text(
+        json.dumps({"nodes": [{"id": "start", "type": "core.trigger.manual"}]})
+    )
+
     assert find_flow_file() == os.path.join("Solution", "Build", "Build.flow")
     assert project.name == "Build"
 


### PR DESCRIPTION
## Why

The matched v1/v2 RCA exposed two false negatives in shared Flow discovery. A valid SDK root emit was shadowed by a one-node generated scaffold, while two byte-identical solution copies were rejected as ambiguous. Neither condition changes the authored Flow semantics.

## What changed

- prefer one substantive root `.flow` over project candidates that are all known trigger-only husks for file-scoped validation and structure checks
- collapse project candidates only when their relative `.flow` files are byte-identical
- retain conservative refusal for distinct substantive projects, missing flows, and unreadable flows
- add positive and negative-control discovery tests

## Evidence

- `pytest tests/tasks/uipath-maestro-flow -q`: 315 passed
- the original SDK webhook artifact now passes all structural checks by selecting its substantive root emit over the one-node scaffold
- the original SDK Slack escalation artifact now resolves its two byte-identical solution copies deterministically
- distinct substantive-project and unreadable-project refusal tests remain green

Closes #2912

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)