### PR TITLE
Make remaining Flow checks arm-neutral

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -9,8 +9,10 @@ description: >
   operation with a `displayName = "active"` filter, following the canonical
   shape documented in the Filter Trees (CEQL) section of the
   uipath-platform skill. The flow must reference the registered connector
-  key (`uipath-microsoft-azureactivedirectory`), use Decision + Terminate
-  for routing, and pass `uip maestro flow validate`.
+  key (`uipath-microsoft-azureactivedirectory`) and use Decision + Terminate
+  for routing. This is an offline structure test: product validation is not
+  graded because the two authoring loops persist an unconfigured connector
+  differently.
 tags: [uipath-maestro-flow, integration, connector, ceql, filter, uipath-microsoft-azureactivedirectory, ipe, mode:build]
 
 run_limits:
@@ -30,7 +32,9 @@ initial_prompt: |
 
   Branch on the result: if the call fails, stop the flow immediately;
   if it succeeds, log "CeqlWhere test passed".
-  Validate the final flow file.
+  Compile the final flow file. Do not fabricate a tenant connection merely to
+  make product validation pass; the generated structure and the separately
+  reviewable filter are the deliverables in this offline task.
 
 success_criteria:
   - type: run_command
@@ -39,12 +43,4 @@ success_criteria:
     timeout: 60
     expected_exit_code: 0
     weight: 8.0
-    pass_threshold: 1.0
-
-  - type: run_command
-    description: "The completed flow validates"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
-    timeout: 30
-    expected_exit_code: 0
-    weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
@@ -19,10 +19,11 @@ initial_prompt: |
   Build a flow that retrieves WooCommerce product reviews and lets the caller 
   choose whether they come back oldest-first or newest-first, picking from friendly 
   labels rather than raw codes. Discover the get-product-reviews operation and set 
-  its sort-order field. Validate the final flow file.
+  its sort-order field. Compile the final flow file.
   If the WooCommerce operation exists in the registry but the tenant has no
-  live connection, keep the real WooCommerce operation node with its inputs left unset, 
-  confirm that shape validates, and stop there.
+  live connection, keep the real WooCommerce operation node with its inputs left unset
+  and stop there. Do not fabricate a tenant connection merely to make product
+  validation pass; the connector shape is the deliverable in this offline task.
 
 success_criteria:
   - type: run_command
@@ -39,12 +40,4 @@ success_criteria:
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
-    pass_threshold: 1.0
-
-  - type: run_command
-    description: "The completed flow validates"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
-    timeout: 30
-    expected_exit_code: 0
-    weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/check_webhook_waitfor_parallel.py
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/check_webhook_waitfor_parallel.py
@@ -5,7 +5,8 @@ The flow must be:
 
   manual start trigger
     ├─ branch 1: Wait-for-event node (HTTP Webhook, uipath-http-webhook) -> End
-    └─ branch 2: Managed HTTP Request (core.action.http.v2, manual GET to the
+    └─ branch 2: Managed HTTP Request (core.action.http or
+                 core.action.http.v2, manual GET to the
                  HTTP Webhook connection's webhook URL, no headers / no query) -> End
 
 Branch 2's GET hits the webhook URL, which delivers the event that completes
@@ -17,8 +18,9 @@ Static assertions (read from the `.flow` source):
      branches (the event wait and the HTTP request).
   2. A Wait-for-event node of the HTTP Webhook connector event exists
      (`uipath.connector.event.uipath-http-webhook.http-webhook`).
-  3. A `core.action.http.v2` node is a MANUAL `GET` whose `url` is the webhook
-     URL, with NOTHING in headers or query (per the prompt).
+  3. A `core.action.http` or `core.action.http.v2` node is a MANUAL `GET` whose
+     `url` is the webhook URL, with NOTHING in headers or query (per the
+     prompt).
   4. Both branch tails reach an End node (`core.control.end`).
 """
 
@@ -33,7 +35,7 @@ from _shared.flow_check import find_flow_file  # noqa: E402
 
 FLOW_GLOB = "**/WebhookSelfTest*.flow"
 EVENT_MARKERS = ("uipath.connector.event", "uipath-http-webhook")
-HTTP_TYPE = "core.action.http.v2"
+HTTP_TYPES = ("core.action.http", "core.action.http.v2")
 END_TYPE = "core.control.end"
 TRIGGER_PREFIX = "core.trigger."
 
@@ -96,20 +98,33 @@ def main() -> None:
     print("OK: HTTP Webhook wait-for-event node present")
 
     # 3. Manual GET HTTP node to the webhook URL, no headers / no query.
-    http_nodes = [n for n in nodes if str(n.get("type", "")) == HTTP_TYPE]
+    http_nodes = [n for n in nodes if str(n.get("type", "")) in HTTP_TYPES]
     if not http_nodes:
-        _fail(f"no {HTTP_TYPE} node. Types seen: {types_seen}")
+        _fail(
+            f"no managed HTTP node ({' or '.join(HTTP_TYPES)}). "
+            f"Types seen: {types_seen}"
+        )
 
     good_http = None
     for n in http_nodes:
-        body = ((n.get("inputs") or {}).get("detail") or {}).get("bodyParameters") or {}
+        inputs = n.get("inputs") or {}
+        body = ((inputs.get("detail") or {}).get("bodyParameters") or inputs)
         if not isinstance(body, dict):
             continue
-        auth = str(body.get("authentication", "")).lower()
+        auth = str(
+            body.get("authentication")
+            or body.get("authenticationType")
+            or body.get("mode")
+            or ""
+        ).lower()
         method = str(body.get("method", "")).lower()
         url = str(body.get("url", ""))
         headers = body.get("headers")
-        query = body.get("query") or body.get("queryParameters")
+        query = (
+            body.get("query")
+            or body.get("queryParameters")
+            or body.get("queryParams")
+        )
         if auth != "manual" or method != "get":
             continue
         if "webhook" not in url.lower():
@@ -123,7 +138,7 @@ def main() -> None:
 
     if good_http is None:
         _fail(
-            "no core.action.http.v2 node configured as a manual GET to the "
+            "no managed HTTP node configured as a manual GET to the "
             "webhook URL (authentication=manual, method=GET, url contains 'webhook')"
         )
     print("OK: manual GET HTTP node to webhook URL, no headers / no query")

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/test_check_webhook_waitfor_parallel.py
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/test_check_webhook_waitfor_parallel.py
@@ -1,0 +1,58 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+CHECKER_PATH = Path(__file__).with_name("check_webhook_waitfor_parallel.py")
+SPEC = importlib.util.spec_from_file_location("check_webhook_waitfor_parallel", CHECKER_PATH)
+assert SPEC and SPEC.loader
+CHECKER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECKER)
+
+
+@pytest.mark.parametrize("http_type", ["core.action.http", "core.action.http.v2"])
+def test_accepts_both_managed_http_representations(tmp_path, monkeypatch, http_type):
+    monkeypatch.chdir(tmp_path)
+    if http_type.endswith(".v2"):
+        inputs = {
+            "detail": {
+                "bodyParameters": {
+                    "authentication": "manual",
+                    "method": "GET",
+                    "url": "https://example.test/webhook/events/1",
+                    "headers": {},
+                    "query": {},
+                }
+            }
+        }
+    else:
+        inputs = {
+            "authenticationType": "manual",
+            "method": "GET",
+            "url": "https://example.test/webhook/events/1",
+            "headers": {},
+            "queryParams": {},
+        }
+
+    flow = {
+        "nodes": [
+            {"id": "start", "type": "core.trigger.manual"},
+            {
+                "id": "wait",
+                "type": "uipath.connector.event.uipath-http-webhook.http-webhook",
+            },
+            {"id": "get", "type": http_type, "inputs": inputs},
+            {"id": "end", "type": "core.control.end"},
+        ],
+        "edges": [
+            {"sourceNodeId": "start", "targetNodeId": "wait"},
+            {"sourceNodeId": "start", "targetNodeId": "get"},
+            {"sourceNodeId": "wait", "targetNodeId": "end"},
+            {"sourceNodeId": "get", "targetNodeId": "end"},
+        ],
+    }
+    (tmp_path / "WebhookSelfTest.flow").write_text(json.dumps(flow))
+
+    CHECKER.main()

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/webhook_waitfor_parallel.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/webhook_waitfor_parallel.yaml
@@ -7,9 +7,10 @@ description: >
   E2E self-testing flow: a manual start trigger fans out into two parallel
   branches. Branch 1 is a mid-flow Wait-for-event node bound to the HTTP Webhook
   connector (`uipath.connector.event.uipath-http-webhook.http-webhook`). Branch 2
-  is a Managed HTTP Request (`core.action.http.v2`, manual GET) whose URL is the
-  webhook URL of that same HTTP Webhook connection, with nothing in headers or
-  query. The GET self-delivers the event that completes the wait at runtime.
+  is a Managed HTTP Request (`core.action.http` or `core.action.http.v2`, manual
+  GET) whose URL is the webhook URL of that same HTTP Webhook connection, with
+  nothing in headers or query. The GET self-delivers the event that completes
+  the wait at runtime.
   Exercises the connector-trigger plugin's "Wait for events" variant, parallel
   branch fan-out from the start trigger, manual-mode HTTP, and the CLI
   webhook-URL wiring. Validates the static two-branch shape.

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/escalation_slack_alert.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/escalation_slack_alert.yaml
@@ -73,8 +73,8 @@ success_criteria:
 
   # ── The delivered flow validates ────────────────────────────────────────
   - type: run_command
-    description: "Generated EscalationSlackAlert Flow validates without errors"
-    command: "uip maestro flow validate EscalationSlackAlert/EscalationSlackAlert/EscalationSlackAlert.flow --output json"
+    description: "Generated EscalationSlackAlert Flow validates without errors, independent of solution layout"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 180
     expected_exit_code: 0
     weight: 3.0


### PR DESCRIPTION
## Summary

- validate the Slack escalation flow through arm-agnostic artifact discovery instead of a live-specific solution path
- accept both validated managed HTTP representations (`core.action.http` and `core.action.http.v2`) in the webhook checker
- normalize direct SDK inputs and nested live inputs before enforcing the same manual GET, webhook URL, empty header/query, and branch semantics
- make the offline CEQL and enhanced-enum tasks grade their structural deliverables instead of requiring product validation of differently persisted unconfigured connector nodes

Closes #2914

## Verification

- `/home/tmatup/root/coder-eval/.venv/bin/pytest -q tests/tasks/uipath-maestro-flow` — 317 passed
- `npm run skills:validate` — passed for default and studioweb
- replayed the new webhook checker against the preview artifact — passed all structural checks
- replayed `validate_flow.py` against the preview Slack artifact — validated successfully
- replayed the CEQL and enhanced-enum structural criteria against both arms — both artifacts pass their arm-neutral criteria

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)