### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@3d5a94e

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 86e3d32. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 3d5a94e. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 
@@ -20,12 +20,20 @@ need, then let TypeScript and `bpmn check` provide the detailed contract.
 
 ## Workflow
 
-1. Keep `<Name>.bpmn.ts` beside this `SKILL.md` and the workspace `package.json`.
-2. Import from `@uipath/flow-sdk/bpmn` and default-export a chain ending in `.build()`.
-3. Start from the closest staged `examples/*.bpmn.ts`.
-4. Run `uip maestro bpmn check <Name>.bpmn.ts --source` after structural changes.
-5. Compile, format only when layout is needed, and run product validation.
-6. Use the merge pipeline for targeted edits to an existing process.
+1. Scaffold the project first: `uip maestro bpmn init <Name>`. It writes
+   `<Name>/<Name>.bpmn` plus `project.uiproj`, `operate.json`, `entry-points.json`,
+   `bindings_v2.json`, and `package-descriptor.json` — the layout `bpmn pack` and
+   product tooling require. Run it inside a solution to join that solution; run it
+   outside one and a parent `<Name>Solution` is scaffolded around it.
+2. Keep `<Name>.bpmn.ts` at the workspace root, beside `package.json`.
+3. Import from `@uipath/flow-sdk/bpmn` and default-export a chain ending in `.build()`.
+4. Start from the closest staged `examples/*.bpmn.ts`.
+5. Run `uip maestro bpmn check <Name>.bpmn.ts --source` after structural changes.
+6. Compile **into the scaffolded project**, format only when layout is needed, and run
+   product validation. Exactly one emitted `<Name>.bpmn` may exist, at
+   `<Name>/<Name>.bpmn`; do not leave a second copy at the workspace root, and do not
+   leave the template `init` wrote in place of your compiled output.
+7. Use the merge pipeline for targeted edits to an existing process.
 
 ## Capability router
 
@@ -62,10 +70,11 @@ export default bpmn('notify')
 ## Validation loop
 
 ```bash
+uip maestro bpmn init <Name>                  # once, before authoring
 uip maestro bpmn check <Name>.bpmn.ts --source
-uip maestro bpmn compile <Name>.bpmn.ts -o <Name>.bpmn
-uip maestro bpmn format <Name>.bpmn
-uip maestro bpmn validate <Name>.bpmn --output json
+uip maestro bpmn compile <Name>.bpmn.ts -o <Name>/<Name>.bpmn
+uip maestro bpmn format <Name>/<Name>.bpmn
+uip maestro bpmn validate <Name>/<Name>.bpmn --output json
 ```
 
 `check` owns source and graph invariants. Product validation owns the compiled

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 86e3d32. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 3d5a94e. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,
@@ -21,7 +21,7 @@ Use this as a router: read only the capability reference you need, then let Type
 
 ## Workflow
 
-1. Scaffold with `uip solution init <SolutionName>`, then run `uip maestro case init <CaseName>` inside it.
+1. Scaffold with `uip solution init <SolutionName>`, then run `uip maestro case init <CaseName>` inside it. Scaffold once: exactly one `project.uiproj` declaring `ProjectType: "CaseManagement"` may survive, because `uip solution projects import` copies rather than moves and validators cannot choose between duplicates. If a bare `<CaseName>/` project already exists outside the solution, import it and delete the original rather than leaving both.
 2. Keep `<Name>.case.ts` beside this `SKILL.md` and the workspace `package.json`.
 3. If the request requires `tasks/tasks.md`, write it before code and treat explicit stage/task rules, required flags, routing, and unresolved resources as authoritative and pre-approved.
 4. Import from `@uipath/flow-sdk/case`; default-export a chain ending in `.build()`.
@@ -95,7 +95,7 @@ API workflow, or sub-case; never fabricate a name or folder. A destination's
 
 ## Evidence boundary
 
-Static success proves the source and artifact contracts. It does not prove live
-resource resolution, human outcomes, timers, skipped-task completion behavior,
-or business-calendar semantics. Read [Case runtime decisions](references/case-runtime.md)
-when one of those affects the requested outcome.
+Static success proves the source and artifact contracts. It proves neither live
+behavior (resource resolution, human outcomes, timers, skipped-task completion,
+business calendars) nor the design decisions no schema checks: lane routing,
+non-completing exits, declared optionality, SDD fidelity. Read [Case runtime decisions](references/case-runtime.md) before authoring, not only when a rung fails.

--- a/preview/uipath-maestro-case/references/case-runtime.md
+++ b/preview/uipath-maestro-case/references/case-runtime.md
@@ -22,6 +22,14 @@ make from syntax alone. Exact signatures remain in [the generated API](api.md).
 - `wait-for-user` and select-next-stage behavior depends on a live Case runtime.
   Static validation proves the contract, not the human selection outcome.
 
+<!-- RULE:case.action.both-outcomes -->
+- A boolean decision from an action has TWO outcomes, and downstream routing has
+  to express both. Gating only the affirmative arm (`approved === true`) leaves
+  the rejection path implicit: nothing runs, the stage never completes for that
+  reader, and the plan validates anyway because an unreferenced value is not an
+  error. Write the complementary condition explicitly, even when the negative
+  arm only routes to a close-out.
+
 ## Connections and external work
 
 <!-- RULE:case.connector.bindings -->
@@ -52,9 +60,62 @@ make from syntax alone. Exact signatures remain in [the generated API](api.md).
   `exceptionStage(...)` and call `.required(false)` so the secondary stage does
   not gate `required-stages-completed`.
 
+<!-- RULE:case.sla.escalation-absent -->
+- An ABSENT `escalation` is the persisted representation of Breached — not a
+  missing field. So when a plan carries a dangling escalation reference (a
+  hand-written `"any"` sentinel, or an id no escalation defines), the repair is
+  to drop the reference and leave a plain breach rule on the SLA. Do not invent
+  an escalation to make the reference resolve: that silently converts a breach
+  response into an at-risk one, which fires at a different time. Only an at-risk
+  response needs a concrete escalation, and it must be one declared on that same
+  SLA.
+
+<!-- RULE:case.sla.lane-exit -->
+- A secondary lane's exit type is a routing decision, and the two shapes are not
+  interchangeable. A lane that hands the case BACK to the work it interrupted
+  exits `return-to-origin`, which lets the origin stage's own conditions carry
+  the case onward — no lane needs a duplicated exit rule per possible origin. A
+  lane that ends the case instead exits `exit-only`, and then the case needs a
+  matching `caseExitRules` row, or the case can reach the lane and never leave
+  it. Read the SDD's own words for which: "returns to", "resumes", "rework"
+  means the first; "closed", "terminated", "escalated out" means the second.
+
 <!-- RULE:case.skip.live -->
 - Whether a skipped task satisfies a completion rule is runtime behavior. For a
   critical bypass, use a separate expression-gated exit or prove the path live.
+
+## Completion and optionality
+
+<!-- RULE:case.exit.non-completing -->
+- `marksCaseComplete` distinguishes two different outcomes, and a case usually
+  needs both. At least one `completeWhen(...)` rule must carry `true`, or the
+  case can never close. An outcome that ENDS the case without closing it
+  normally — an escalated close-out, a rejection, a withdrawal — is a separate
+  rule with `marksCaseComplete: false`. It is added ALONGSIDE the positive rule
+  and never replaces it: folding both readings into one `true` rule ("Case
+  resolved or escalated") loses the distinction the plan was asked to make.
+
+<!-- RULE:case.optionality.explicit -->
+- Declare optionality when something consumes it. `.required(false)` and
+  omitting `.required()` are different statements in the emitted plan — the
+  builder writes `isRequired` only when you call it — and a
+  `required-stages-completed` exit reads that flag to decide which stages gate
+  completion. When a stage or task is deliberately optional, say so explicitly
+  rather than relying on a default the schema leaves unstated. Secondary lanes
+  are the common case: an `exceptionStage(...)` that gates normal completion is
+  almost never what was meant.
+
+## Design fidelity
+
+<!-- RULE:case.sdd.declared-shapes -->
+- When the request supplies an SDD, its declared task TYPES are part of the
+  contract, not a hint. A task the SDD calls `process` stays a process even when
+  an agent looks like a better fit for the described work, and a
+  `wait-for-timer` stays a timer even when its duration reads like a connector
+  poll. Substituting the type silently answers a different question, and no
+  static check can see it because both spellings validate. Where the SDD is
+  genuinely unresolvable, use `.unresolved('<kind>')` — which preserves the
+  declared kind — rather than picking a different one.
 
 ## Brownfield editing
 
@@ -68,6 +129,16 @@ make from syntax alone. Exact signatures remain in [the generated API](api.md).
   repointing a bound task also requires the orphan cleanup under
   [Connections and external work](#connections-and-external-work); compilation
   and resource refresh do not remove solution declarations.
+
+<!-- RULE:case.brownfield.recompile -->
+- Repair by recompiling from source, not by editing the emitted JSON. The
+  compiler owns everything synthetic in the plan — a formal argument's slot `id`
+  is minted from its name rather than copied from it, task and condition ids are
+  derived, and companions are wired to match. A hand-edit fixes the field you
+  looked at and leaves the derived ones carrying whatever the broken input had,
+  which is a class of defect `uip maestro case validate` does not report: it
+  checks the contract, not whether an id was supposed to be distinct from the
+  name beside it. Round-tripping the whole plan re-derives all of them at once.
 
 ## Product boundary
 

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 86e3d32. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 3d5a94e. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -23,6 +23,24 @@ An existing Flow JSON can also be decompiled back into TypeScript for editing.
 
 The workspace installs `@uipath/flow-sdk` in `node_modules/`; `examples/` contains authored examples, and `references/` contains the details routed from this guide.
 To author a Flow, create a root-level `<Name>.flow.ts` and import the package directly.
+
+**The source lives at the root; the compiled artifact does not.** Scaffold the project
+before authoring, then emit into it — `compile -o` is the authority over where the
+emitted file is written:
+
+```bash
+uip solution init <Name>Sol
+( cd <Name>Sol && uip maestro flow init <Name> )
+uip maestro flow compile <Name> -o <Name>Sol/<Name>/<Name>.flow
+```
+
+Exactly one emitted `<Name>.flow` may exist, at that path. Never leave a second copy
+at the workspace root, and never leave behind the trigger-only stub `flow init` writes —
+validators and evidence collectors cannot choose safely between duplicates, and an
+abandoned stub outranks the real work. Emitting to the root is correct only for the
+packaged-SDK local gates, which never scaffold a project; pick the loop first
+([`references/CLI-LOOP.md`](references/CLI-LOOP.md)) and do not mix the two.
+
 Integrations with non-UiPath systems are handled through connectors.
 Connectors require a root-level [`bindings.json`](references/bindings.md).
 `uip maestro registry pull` writes a descriptor per referenced connector to `connectors/<key>.ts`, and caches the library itself outside the project.
@@ -62,6 +80,21 @@ wiring. Insert a step by moving the old edge through it, not by creating a
 second path. If only emitted `.flow` JSON exists, decompile it, compile the
 pristine baseline, edit narrowly, and merge the delta back into the original.
 These are before/after judgments; no final-artifact checker can prove them.
+
+For a narrow edit — moving one node, adding an output, renaming a step — do not
+drive those four commands by hand. `decompile` writes `<Name>.pipeline.mjs`,
+which runs the whole loop in two invocations and gets the baseline ordering
+right, which is the step that costs retries when done manually:
+
+```bash
+uip maestro flow decompile <Name>.flow -o <Name>.flow.ts
+node <Name>.pipeline.mjs      # captures the pristine baseline
+# edit <Name>.flow.ts narrowly
+node <Name>.pipeline.mjs      # compiles the edit and merges it back
+uip maestro flow validate <Name>.merged.flow --output json
+```
+
+Validate the merged artifact, never the intermediate edited compile.
 
 **True-brownfield procedure:**
 **[`references/brownfield.md`](references/brownfield.md)**.
@@ -109,6 +142,9 @@ under `examples/` resolve inside this skill folder.
 | Scheduled trigger | `core.trigger.scheduled` | `scheduled(...)` | [Scheduled trigger](#scheduled-trigger) | [scheduled-trigger.md](references/scheduled-trigger.md) | `examples/HerbariumDispatch.flow.ts` |
 | Connector event trigger | `uipath.connector.trigger.<key>.<event>` | `onEvent(...)` | [Connector events](#connector-events) | [event-trigger.md](references/event-trigger.md) | `examples/DoorbellLog.flow.ts` |
 | Connector event wait | `uipath.connector.event.<key>.<event>` | `waitForEvent(...)` | [Connector events](#connector-events) | [event-trigger.md](references/event-trigger.md) | `examples/PlanetariumConfirmation.flow.ts` |
+| Form trigger | `core.trigger.form` | `formTrigger(...)` | [Form trigger](#form-trigger) | [form-trigger.md](references/form-trigger.md) | `examples/BakeOffEntryForm.flow.ts` |
+| Conversation trigger | `core.trigger.conversation` | `conversationTrigger(...)` | [Conversational](#conversational) | [conversational.md](references/conversational.md) | `examples/LibraryDeskChat.flow.ts` |
+| Voice trigger | `core.trigger.voice` | `voiceTrigger(...)` | [Voice](#voice) | [voice.md](references/voice.md) | `examples/HarbourRadioLine.flow.ts` |
 | Standalone HTTP | `core.action.http` | `http({ managed: false, ... })` | [HTTP](#http) | [http.md](references/http.md) | `examples/LighthouseSignal.flow.ts` |
 | Managed HTTP | `core.action.http.v2` | `http({ managed: true, ... })` | [HTTP](#http) | [http.md](references/http.md) | `examples/ObservatorySeeing.flow.ts` |
 | Script | `core.action.script` | `script(...)` | [Script](#script) | [script.md](references/script.md) | `examples/GreenhouseWatering.flow.ts` |
@@ -117,6 +153,8 @@ under `examples/` resolve inside this skill folder.
 | Map | `core.action.transform.map` | `transform({ variant: 'map', ... })` | [Transform](#transform) | [transform.md](references/transform.md) | `examples/TrailLogSummary.flow.ts` |
 | Group by | `core.action.transform.group-by` | `transform({ variant: 'group-by', ... })` | [Transform](#transform) | [transform.md](references/transform.md) | `examples/TrailLogSummary.flow.ts` |
 | Integration Service action | `uipath.connector.<key>.<action>` (Data Service: `uipath.connector.uipath-uipath-dataservice.*`) | `connector(...)` | [Integration Service connectors](#integration-service-connectors) | [connector-params.md](references/connector-params.md) | `examples/ClubDirectory.flow.ts` |
+| Data Fabric read | `core.datafabric.read` | `dataFabricRead(...)` | [Data Fabric](#data-fabric) | [data-fabric.md](references/data-fabric.md) | `examples/BeeHiveLedger.flow.ts` |
+| Data Fabric update | `core.datafabric.update` | `dataFabricUpdate(...)` | [Data Fabric](#data-fabric) | [data-fabric.md](references/data-fabric.md) | `examples/BeeHiveLedger.flow.ts` |
 | Subflow | `core.subflow` | `subflow(...)` | [Subflow](#subflow) | [subflow.md](references/subflow.md) | `examples/RecipeScaler.flow.ts` |
 | Human task | `uipath.human-in-the-loop` | `hitl(...)` | [Human task](#human-task) | [hitl.md](references/hitl.md) | `examples/GallerySubmission.flow.ts` |
 | Human quick form | `uipath.human-in-the-loop.quick-form` | `hitl({ variant: 'quick-form', ... })` | [Human task](#human-task) | [hitl.md](references/hitl.md) | `examples/FieldTripQuickForm.flow.ts` |
@@ -129,6 +167,7 @@ under `examples/` resolve inside this skill folder.
 | Switch | `core.logic.switch` | `.switch(...)` | [Switch](#switch) | [switch.md](references/switch.md) | `examples/BeltProgression.flow.ts` |
 | Parallel / Merge | `core.logic.merge` | `.parallel(...)` | [Parallel branches](#parallel-branches) | [parallel-merge.md](references/parallel-merge.md) | `examples/ConcertSoundcheck.flow.ts` |
 | Loop | `core.logic.loop` | `.loop(...)` | [Loops](#loops) | [loops.md](references/loops.md) | `examples/ClubDirectory.flow.ts` |
+| Do while | `core.logic.dowhile` | `.doWhile(...)` | [Do while](#do-while) | [loops.md](references/loops.md) | `examples/MeteorShowerPages.flow.ts` |
 | Return / End | `core.control.end` | `.return(...)` | [Return and end](#return-and-end) | [return.md](references/return.md) | `examples/GreenhouseWatering.flow.ts` |
 | Terminate | `core.logic.terminate` | `.terminate(...)` | [Terminate](#terminate) | [terminate.md](references/terminate.md) | `examples/AquariumSafetyStop.flow.ts` |
 | Placeholder | `core.logic.mock` | `mock()` | [Placeholder](#placeholder) | [placeholder.md](references/placeholder.md) | `examples/FestivalMapScaffold.flow.ts` |
@@ -139,6 +178,15 @@ under `examples/` resolve inside this skill folder.
 | Agent resource | `uipath.core.agent.<key>` | `agent(...)` | [Agent resource](#agent-resource) | [agent.md](references/agent.md) | `examples/PlantNameAdvisor.flow.ts` |
 | Inline agent | `uipath.agent.autonomous` | `inlineAgent(...)` | [Inline agent](#inline-agent) | [inline-agent.md](references/inline-agent.md) | `examples/PostcardCaption.flow.ts` |
 | IxP extraction | `uipath.ixp.<project>.<version>-<folder>` | `ixpExtract(...)` | [Document extraction](#document-extraction) | [ixp.md](references/ixp.md) | `examples/ArchiveCardExtract.flow.ts` |
+| Document classify | `uipath.document.classify` | `documentClassify(...)` | [Document classify and Dynamic Extract](#document-classify-and-dynamic-extract) | [document-pipeline.md](references/document-pipeline.md) | `examples/SeedPacketReader.flow.ts` |
+| Dynamic extract | `uipath.ixp.extract-document-builder` | `dynamicExtract(...)` | [Document classify and Dynamic Extract](#document-classify-and-dynamic-extract) | [document-pipeline.md](references/document-pipeline.md) | `examples/SeedPacketReader.flow.ts` |
+| Published function | `uipath.core.function.<key>` | `publishedFunction(...)` | [Published function](#published-function) | [published-function.md](references/published-function.md) | `examples/TideTableConverter.flow.ts` |
+| Conversation message wait | `uipath.conversational.wait-for-message` | `waitForMessage(...)` | [Conversational](#conversational) | [conversational.md](references/conversational.md) | `examples/LibraryDeskChat.flow.ts` |
+| Conversational agent | `uipath.agent.conversational` | `conversationalAgent(...)` | [Conversational](#conversational) | [conversational.md](references/conversational.md) | `examples/LibraryDeskChat.flow.ts` |
+| Conversation send message | `uipath.conversational.send-message` | `sendMessage(...)` | [Conversational](#conversational) | [conversational.md](references/conversational.md) | `examples/LibraryDeskChat.flow.ts` |
+| Voice outgoing call | `uipath.conversational.voice.create-outgoing-call` | `createOutgoingCall(...)` | [Voice](#voice) | [voice.md](references/voice.md) | `examples/PotteryStudioCallback.flow.ts` |
+| Voice agent | `uipath.agent.voice` | `voiceAgent(...)` | [Voice](#voice) | [voice.md](references/voice.md) | `examples/PotteryStudioCallback.flow.ts` |
+| Voice end call | `uipath.conversational.voice.end-call` | `endCall(...)` | [Voice](#voice) | [voice.md](references/voice.md) | `examples/PotteryStudioCallback.flow.ts` |
 
 ## Manual trigger
 
@@ -310,7 +358,6 @@ Copy identity fields from a freshly pulled tenant registry; never construct them
 Classify a document (`uipath.document.classify`), or extract fields against an
 INLINE schema (`uipath.ixp.extract-document-builder`) instead of a published
 IxP project's trained fields.
-
 Signatures: `documentClassify({ fileRef, pageRange?, splitPages?, modelConfig? })`;
 `dynamicExtract({ fileRef, schema, model: { modelName, folderKey, ... }, pageRange? })`.
 
@@ -484,8 +531,7 @@ Use native Data Fabric nodes only when the scenario names Data Fabric
 (`core.datafabric.read` / `.update`). “Data Service” instead names the
 `uipath-uipath-dataservice` connector; route it to `connector(...)`.
 Signatures: `dataFabricRead({ entity, filters? })` and
-`dataFabricUpdate({ entity, record, set })` — `record` is exactly one of
-`{ byId }` or `{ fromRead: '<read step name>' }`.
+`dataFabricUpdate({ entity, record, set })` — `record` is exactly one of `{ byId }` or `{ fromRead: '<read step name>' }`.
 
 ```ts
 .step('lookup', dataFabricRead({ entity: 'Invoices',

--- a/preview/uipath-maestro-flow/examples/BakeOffEntryForm.flow.ts
+++ b/preview/uipath-maestro-flow/examples/BakeOffEntryForm.flow.ts
@@ -1,0 +1,27 @@
+/**
+ * CAPABILITY: start a flow from a submitted FORM (`core.trigger.form`).
+ *
+ * `formTrigger()` takes no arguments. The form's fields are derived from
+ * `.input()` — one field per input, required unless the input has a default —
+ * so the submitted values ARE the flow's inputs and are read from
+ * `$vars.start.output.<name>` exactly like a manual trigger's.
+ *
+ * Generic scenario: accept an entry into a village bake-off.
+ *
+ * No local rung renders a form; supply the values with `--input` when running.
+ */
+import { flow, formTrigger, script, out, types } from '@uipath/flow-sdk';
+
+export default flow('bake-off-entry-form')
+  .name('BakeOffEntryForm')
+  .version('1.0.0')
+  .input({ bakerName: types.string, category: types.string, servings: types.number })
+  .output({ confirmation: types.string })
+  .trigger(formTrigger())
+  .step('confirmEntry', script({
+    code:
+      'return $vars.start.output.bakerName + " entered " + $vars.start.output.category'
+      + ' + " with " + String($vars.start.output.servings) + " servings";',
+  }))
+  .return({ confirmation: out('confirmEntry') })
+  .build();

--- a/preview/uipath-maestro-flow/examples/BeeHiveLedger.flow.ts
+++ b/preview/uipath-maestro-flow/examples/BeeHiveLedger.flow.ts
@@ -1,0 +1,36 @@
+/**
+ * CAPABILITY: read and update a native Data Fabric entity.
+ *
+ * Use `dataFabricRead` / `dataFabricUpdate` (`core.datafabric.read` /
+ * `.update`) only when the scenario names DATA FABRIC. "Data Service" names the
+ * `uipath-uipath-dataservice` connector instead, which routes to `connector(...)`.
+ *
+ * `record` is exactly one of `{ byId }` or `{ fromRead: '<read step name>' }`.
+ * Chaining the update off the read — as here — avoids carrying an id by hand.
+ * Filters default to `operator: '='`; `or: true` joins a row with OR.
+ *
+ * Generic scenario: find a hive by its tag and record today's inspection.
+ */
+import { flow, dataFabricRead, dataFabricUpdate, script, input, out, types } from '@uipath/flow-sdk';
+
+export default flow('bee-hive-ledger')
+  .name('BeeHiveLedger')
+  .version('1.0.0')
+  .input({ hiveTag: types.string, inspectedOn: types.string })
+  .output({ ledgerNote: types.string })
+  .step('findHive', dataFabricRead({
+    entity: 'Hives',
+    filters: [{ field: 'HiveTag', value: input('hiveTag') }],
+  }))
+  .step('recordInspection', dataFabricUpdate({
+    entity: 'Hives',
+    record: { fromRead: 'findHive' },
+    set: { LastInspectedOn: input('inspectedOn'), Status: 'Inspected' },
+  }))
+  .step('noteLedger', script({
+    code:
+      'return "hive " + $vars.start.output.hiveTag'
+      + ' + " inspected on " + $vars.start.output.inspectedOn;',
+  }))
+  .return({ ledgerNote: out('noteLedger') })
+  .build();

--- a/preview/uipath-maestro-flow/examples/HarbourRadioLine.flow.ts
+++ b/preview/uipath-maestro-flow/examples/HarbourRadioLine.flow.ts
@@ -1,0 +1,31 @@
+/**
+ * CAPABILITY: answer an INBOUND phone call (`core.trigger.voice`).
+ *
+ * `voiceTrigger()` takes no arguments — the platform hands the flow a call that
+ * has already connected, and the start step publishes its `callContext`. That
+ * is the only difference from the outbound shape in
+ * `PotteryStudioCallback.flow.ts`, which dials first and reads the context off
+ * the dial step instead.
+ *
+ * Pass `out('start', 'callContext')` whole. It is an OBJECT; reaching inside it
+ * for `conversationId` passes the file's schema and then fails at dispatch.
+ *
+ * Generic scenario: answer the harbour's information line.
+ */
+import { flow, voiceTrigger, voiceAgent, endCall, out, types } from '@uipath/flow-sdk';
+
+export default flow('harbour-radio-line')
+  .name('HarbourRadioLine')
+  .version('1.0.0')
+  .output({ callSummary: types.string })
+  .trigger(voiceTrigger())
+  .step('greet', voiceAgent({
+    systemPrompt:
+      'Answer the harbour information line. Give tide times and berth availability, '
+      + 'and take a message for the harbourmaster if you cannot help.',
+    callContext: out('start', 'callContext'),
+    voice: { model: 'gemini-3.1-flash-live-preview', persona: 'Kore' },
+  }))
+  .step('hangUp', endCall({ callContext: out('start', 'callContext') }))
+  .return({ callSummary: out('greet') })
+  .build();

--- a/preview/uipath-maestro-flow/examples/LibraryDeskChat.flow.ts
+++ b/preview/uipath-maestro-flow/examples/LibraryDeskChat.flow.ts
@@ -1,0 +1,39 @@
+/**
+ * CAPABILITY: work a live CHAT — wait for a message, answer it, post a reply.
+ *
+ * Every conversational step is keyed by a `conversationId`, and
+ * `conversationTrigger()` publishes it as `out('start', 'conversationId')`.
+ *
+ * `waitForMessage` SUSPENDS the flow — it is a catch event, not a poll. Use
+ * `conversationalAgent` when the model decides what to say and `sendMessage`
+ * when the flow does; this example shows both, so the agent answers and the
+ * flow closes the exchange itself.
+ *
+ * Generic scenario: answer a question at a library help desk.
+ */
+import {
+  flow, conversationTrigger, waitForMessage, conversationalAgent, sendMessage,
+  out, types,
+} from '@uipath/flow-sdk';
+
+export default flow('library-desk-chat')
+  .name('LibraryDeskChat')
+  .version('1.0.0')
+  .output({ answered: types.string })
+  .trigger(conversationTrigger())
+  .step('listen', waitForMessage({
+    conversationId: out('start', 'conversationId'),
+  }))
+  .step('answer', conversationalAgent({
+    model: 'gpt-5.4',
+    systemPrompt: 'Answer library questions in one or two sentences. Say so when unsure.',
+    settings: { mode: 'simple', context: out('listen', 'conversationContext') },
+  }))
+  .step('closeExchange', sendMessage({
+    conversationId: out('start', 'conversationId'),
+    exchangeId: out('listen', 'exchangeId'),
+    content: 'Ask again any time — the desk is open until six.',
+    endExchange: true,
+  }))
+  .return({ answered: out('answer') })
+  .build();

--- a/preview/uipath-maestro-flow/examples/MeteorShowerPages.flow.ts
+++ b/preview/uipath-maestro-flow/examples/MeteorShowerPages.flow.ts
@@ -1,0 +1,39 @@
+/**
+ * CAPABILITY: `.doWhile` — run a body, then repeat WHILE a condition holds.
+ *
+ * The condition is checked AFTER each pass, so the body always runs at least
+ * once (`core.logic.dowhile`). That is the difference from `.loop()`, which
+ * iterates a collection it already has.
+ *
+ * The container publishes NO data output. Carry results out through a `.var()`
+ * written from inside the body with `{ updates }` — here `page` advances the
+ * cursor and doubles as the loop's own state. `limit` caps iterations (1–10,000;
+ * blank means the platform default of 10,000), and `body.break()` works exactly
+ * as it does in `.loop()`.
+ *
+ * Generic scenario: page through a meteor-shower sightings feed until it ends.
+ */
+import { flow, http, script, js, tmpl, v, out, types } from '@uipath/flow-sdk';
+
+export default flow('meteor-shower-pages')
+  .name('MeteorShowerPages')
+  .version('1.0.0')
+  .output({ pagesRead: types.string })
+  .var('page', types.number, 1)
+  .doWhile(
+    'paginate',
+    js`$vars.fetchPage.output.body.hasNextPage === true`,
+    (body) => body
+      .step('fetchPage', http({
+        method: 'GET',
+        url: tmpl`https://sightings.example.com/meteors?page=${v('page')}`,
+        managed: false,
+        returns: { hasNextPage: 'boolean' },
+      }), { updates: { page: js`$vars.page + 1` } }),
+    { limit: 50 },
+  )
+  .step('reportPages', script({
+    code: 'return "read " + String($vars.page - 1) + " page(s) of sightings";',
+  }))
+  .return({ pagesRead: out('reportPages') })
+  .build();

--- a/preview/uipath-maestro-flow/examples/PotteryStudioCallback.flow.ts
+++ b/preview/uipath-maestro-flow/examples/PotteryStudioCallback.flow.ts
@@ -1,0 +1,41 @@
+/**
+ * CAPABILITY: place a phone call, talk to the person, hang up.
+ *
+ * The call is identified by a `callContext` OBJECT. Pass the WHOLE thing —
+ * `out('dial', 'callContext')` — never a field inside it. The node's schema
+ * types that field as `object`, so a scalar such as
+ * `out('dial', 'callContext.conversationId')` passes the file's schema and then
+ * fails at dispatch; `check` catches it as `VOICE_CALL_CONTEXT_NOT_OBJECT`.
+ *
+ * `createOutgoingCall` dials out and publishes the context. An inbound flow
+ * instead uses `.trigger(voiceTrigger())`, whose start step publishes the same
+ * `callContext`. A persona belongs to its voice model, and `maxIterations` is
+ * capped at 8.
+ *
+ * Generic scenario: remind a customer their pottery is ready for collection.
+ */
+import {
+  flow, createOutgoingCall, voiceAgent, endCall, input, out, types,
+} from '@uipath/flow-sdk';
+
+export default flow('pottery-studio-callback')
+  .name('PotteryStudioCallback')
+  .version('1.0.0')
+  .input({ customerName: types.string, customerPhone: types.string, pieceCount: types.number })
+  .output({ callSummary: types.string })
+  .step('dial', createOutgoingCall({
+    from: '+15550001111',
+    to: input('customerPhone'),
+  }))
+  .step('talk', voiceAgent({
+    systemPrompt:
+      'Tell {{input.customerName}} that {{input.pieceCount}} finished pieces are ready '
+      + 'for collection, and offer a weekday or weekend pickup.',
+    inputs: { customerName: input('customerName'), pieceCount: input('pieceCount') },
+    callContext: out('dial', 'callContext'),
+    voice: { model: 'gemini-3.1-flash-live-preview', persona: 'Kore' },
+    maxIterations: 4,
+  }))
+  .step('hangUp', endCall({ callContext: out('dial', 'callContext') }))
+  .return({ callSummary: out('talk') })
+  .build();

--- a/preview/uipath-maestro-flow/examples/SeedPacketReader.flow.ts
+++ b/preview/uipath-maestro-flow/examples/SeedPacketReader.flow.ts
@@ -1,0 +1,49 @@
+/**
+ * CAPABILITY: classify a document, then extract fields against an INLINE schema.
+ *
+ * `documentClassify` (`uipath.document.classify`) names the document's type.
+ * `dynamicExtract` (`uipath.ixp.extract-document-builder`) is the other half of
+ * the pair: it carries its own `schema` instead of a published IxP project's
+ * trained fields, which is what makes it "dynamic".
+ *
+ * Dynamic Extract still needs a model DEPLOYMENT identity. `modelName` and
+ * `folderKey` below are placeholders in the shape the tenant serves — copy the
+ * real pair from the tenant; never construct them.
+ *
+ * Generic scenario: read the sowing details off a scanned seed packet.
+ */
+import { flow, documentClassify, dynamicExtract, script, out, types } from '@uipath/flow-sdk';
+
+export default flow('seed-packet-reader')
+  .name('SeedPacketReader')
+  .version('1.0.0')
+  .input({ packetScan: types.file })
+  .output({ summary: types.string })
+  .step('classifyPacket', documentClassify({
+    fileRef: out('start', 'packetScan'),
+    splitPages: false,
+  }))
+  .step('extractSowing', dynamicExtract({
+    fileRef: out('start', 'packetScan'),
+    schema: {
+      type: 'object',
+      properties: {
+        variety: { type: 'string' },
+        sowDepthMm: { type: 'string' },
+        daysToGerminate: { type: 'string' },
+      },
+    },
+    model: {
+      modelName: 'seedpackets-9c41e7b2-ixp',
+      folderKey: '4c9d1f70-6b2e-4a58-9f13-2ad5c8e0b741',
+    },
+  }))
+  .step('summarize', script({
+    code:
+      'const sowing = $vars.extractSowing.output || {};\n'
+      + 'return "type:" + ($vars.classifyPacket.output.DocumentTypeName || "?")\n'
+      + '  + " variety:" + (sowing.variety || "-")\n'
+      + '  + " depth:" + (sowing.sowDepthMm || "-");',
+  }))
+  .return({ summary: out('summarize') })
+  .build();

--- a/preview/uipath-maestro-flow/examples/TideTableConverter.flow.ts
+++ b/preview/uipath-maestro-flow/examples/TideTableConverter.flow.ts
@@ -1,0 +1,35 @@
+/**
+ * CAPABILITY: run a deployed Orchestrator FUNCTION as one step.
+ *
+ * A function is a small unit of code published as its own resource. `key`
+ * becomes part of the node type (`uipath.core.function.<key>`); `name` and
+ * `folderPath` locate the deployment. `returns` declares the fields the
+ * function hands back so downstream steps can read them.
+ *
+ * A function is usually deployed into a folder of its OWN name, and the
+ * binding's `resourceKey` is `<folderPath>.<name>` — read the folder from the
+ * tenant rather than assuming `'Shared'`.
+ *
+ * Generic scenario: convert a tide height between measurement systems.
+ */
+import { flow, publishedFunction, script, input, out, types } from '@uipath/flow-sdk';
+
+export default flow('tide-table-converter')
+  .name('TideTableConverter')
+  .version('1.0.0')
+  .input({ heightFeet: types.number })
+  .output({ reading: types.string })
+  .step('toMetres', publishedFunction({
+    key: 'd41f60c8-27b5-4e19-8a3d-6f0be9147c52',
+    name: 'tide-convert',
+    folderPath: 'Shared/tide-convert',
+    inputs: { feet: input('heightFeet') },
+    returns: { metres: 'number' },
+  }))
+  .step('formatReading', script({
+    code:
+      'return String($vars.start.output.heightFeet) + " ft = "'
+      + ' + String($vars.toMetres.output.metres) + " m";',
+  }))
+  .return({ reading: out('formatReading') })
+  .build();

--- a/preview/uipath-maestro-flow/references/api.md
+++ b/preview/uipath-maestro-flow/references/api.md
@@ -35,7 +35,7 @@ generated from the built types; longer tutorials stay in the node references.
 
 **Option shapes** — [TriggerOptions](#triggeroptions-interface) · [EventSubscription](#eventsubscription-interface) · [ScheduledInputs](#scheduledinputs-interface) · [HttpInputs](#httpinputs-type) · [ScriptInputs](#scriptinputs-interface) · [TransformInputs](#transforminputs-interface) · [HitlInputs](#hitlinputs-interface) · [SummarizeInputs](#summarizeinputs-interface) · [BatchTransformInputs](#batchtransforminputs-interface) · [IxpExtractInputs](#ixpextractinputs-interface) · [DelayInputs](#delayinputs-type) · [RpaWorkflowInputs](#rpaworkflowinputs-interface) · [ApiWorkflowInputs](#apiworkflowinputs-interface) · [PublishedFunctionInputs](#publishedfunctioninputs-interface) · [SendMessageInputs](#sendmessageinputs-interface) · [WaitForMessageInputs](#waitformessageinputs-interface) · [ConversationContextInputs](#conversationcontextinputs-interface) · [CreateOutgoingCallInputs](#createoutgoingcallinputs-interface) · [EndCallInputs](#endcallinputs-interface) · [VoiceAgentInputs](#voiceagentinputs-interface) · [ConversationalAgentInputs](#conversationalagentinputs-interface) · [AgenticProcessInputs](#agenticprocessinputs-type) · [AgentInputs](#agentinputs-interface) · [InlineAgentInputs](#inlineagentinputs-interface) · [DocumentClassifyInputs](#documentclassifyinputs-interface) · [DynamicExtractInputs](#dynamicextractinputs-interface) · [DataFabricReadInputs](#datafabricreadinputs-interface) · [DataFabricUpdateInputs](#datafabricupdateinputs-interface) · [QueueItemInputs](#queueiteminputs-interface) · [ConnectorOpts](#connectoropts-interface) · [NodeOptions](#nodeoptions-interface) · [HttpInputsBase](#httpinputsbase-interface) · [DocValidationInputs](#docvalidationinputs-interface) · [AgenticProcessInputsBase](#agenticprocessinputsbase-interface) · [LoopOptions](#loopoptions-interface) · [DoWhileOptions](#dowhileoptions-interface)
 
-**Supporting types** — [ContributionDiagnostic](#contributiondiagnostic-interface) · [DefinitionReference](#definitionreference-type) · [ContributionContext](#contributioncontext-interface) · [BindingContribution](#bindingcontribution-interface) · [NodeContribution](#nodecontribution-interface) · [FlowNode](#flownode-class) · [FlowAction](#flowaction-class) · [FlowTrigger](#flowtrigger-class) · [FlowResource](#flowresource-class) · [rawNode](#rawnode-function) · [TriggerSpec](#triggerspec-type) · [TriggerDescriptor](#triggerdescriptor-type) · [ChildFlow](#childflow-type) · [Expr](#expr-class) · [SubflowSpec](#subflowspec-interface) · [ActionSpec](#actionspec-type) · [ConnectorDescriptor](#connectordescriptor-type) · [ErrorEnvelopeField](#errorenvelopefield-type) · [ConnectorMeta](#connectormeta-interface) · [TriggerMeta](#triggermeta-interface) · [EventFilter](#eventfilter-interface) · [ScheduleEvery](#scheduleevery-type) · [FlowLayout](#flowlayout-interface) · [StickyNote](#stickynote-interface) · [TypeDesc](#typedesc-type) · [VarSpec](#varspec-interface) · [BuiltFlow](#builtflow-interface) · [ScriptReturns](#scriptreturns-type) · [TransformVariant](#transformvariant-type) · [TransformOperation](#transformoperation-type) · [HitlVariant](#hitlvariant-type) · [AppRef](#appref-interface) · [FormField](#formfield-type) · [Outcome](#outcome-type) · [HitlRecipient](#hitlrecipient-interface) · [OutputColumn](#outputcolumn-interface) · [VoiceSettings](#voicesettings-interface) · [ConversationalAgentSettings](#conversationalagentsettings-interface) · [AgentGuardrail](#agentguardrail-type) · [AgenticProcessCompletion](#agenticprocesscompletion-type) · [AgentLocation](#agentlocation-type) · [AgentFlavour](#agentflavour-type) · [InlineAgentFieldType](#inlineagentfieldtype-type) · [AgentMemoryRef](#agentmemoryref-interface) · [ContextIndexRef](#contextindexref-interface) · [ToolRef](#toolref-type) · [EscalationRef](#escalationref-interface) · [DataFabricFilter](#datafabricfilter-interface) · [QueuePriority](#queuepriority-type) · [SchedulePreset](#schedulepreset-type) · [Step](#step-type) · [FlowActionSpec](#flowactionspec-type) · [CaseValue](#casevalue-type) · [NodeLayout](#nodelayout-interface) · [EdgeRoute](#edgeroute-interface) · [StickyNoteColor](#stickynotecolor-type) · [VarDecl](#vardecl-interface) · [BuiltEntryPoint](#builtentrypoint-interface) · [HttpBranch](#httpbranch-interface) · [ScriptReturnType](#scriptreturntype-type) · [FilterRule](#filterrule-interface) · [FilterMatch](#filtermatch-type) · [FieldMapping](#fieldmapping-interface) · [Aggregation](#aggregation-interface) · [ShownField](#shownfield-interface) · [AskedField](#askedfield-interface) · [InOutField](#inoutfield-interface) · [HitlChannel](#hitlchannel-type) · [HitlAssigneeType](#hitlassigneetype-type) · [HitlConnection](#hitlconnection-interface) · [CustomGuardrail](#customguardrail-interface) · [BuiltInValidatorGuardrail](#builtinvalidatorguardrail-interface) · [BuiltinToolRef](#builtintoolref-interface) · [ConnectorToolRef](#connectortoolref-interface) · [ProcessToolRef](#processtoolref-interface) · [IxpToolRef](#ixptoolref-interface) · [McpToolRef](#mcptoolref-interface) · [RemoteA2aToolRef](#remotea2atoolref-interface) · [ClientSideToolRef](#clientsidetoolref-interface) · [HttpRequestToolRef](#httprequesttoolref-interface) · [SwitchArm](#switcharm-interface) · [FilterCondition](#filtercondition-type) · [Transformation](#transformation-type) · [AggregationOperation](#aggregationoperation-type) · [FormFieldType](#formfieldtype-type) · [GuardrailSelector](#guardrailselector-interface) · [GuardrailAction](#guardrailaction-type) · [GuardrailRule](#guardrailrule-type) · [BuiltinToolName](#builtintoolname-type) · [ProcessToolKind](#processtoolkind-type) · [GuardrailScope](#guardrailscope-type) · [GuardrailFieldReference](#guardrailfieldreference-interface) · [GuardrailFieldSelector](#guardrailfieldselector-type)
+**Supporting types** — [ContributionDiagnostic](#contributiondiagnostic-interface) · [DefinitionReference](#definitionreference-type) · [ContributionContext](#contributioncontext-interface) · [BindingContribution](#bindingcontribution-interface) · [NodeContribution](#nodecontribution-interface) · [FlowNode](#flownode-class) · [FlowAction](#flowaction-class) · [FlowTrigger](#flowtrigger-class) · [FlowResource](#flowresource-class) · [rawNode](#rawnode-function) · [TriggerSpec](#triggerspec-type) · [TriggerDescriptor](#triggerdescriptor-type) · [ChildFlow](#childflow-type) · [Expr](#expr-class) · [SubflowSpec](#subflowspec-interface) · [ActionSpec](#actionspec-type) · [ConnectorDescriptor](#connectordescriptor-type) · [ErrorEnvelopeField](#errorenvelopefield-type) · [ConnectorMeta](#connectormeta-interface) · [TriggerMeta](#triggermeta-interface) · [EventFilter](#eventfilter-interface) · [ScheduleEvery](#scheduleevery-type) · [FlowLayout](#flowlayout-interface) · [StickyNote](#stickynote-interface) · [TypeDesc](#typedesc-type) · [VarSpec](#varspec-interface) · [BuiltFlow](#builtflow-interface) · [ScriptReturns](#scriptreturns-type) · [TransformVariant](#transformvariant-type) · [TransformOperation](#transformoperation-type) · [HitlVariant](#hitlvariant-type) · [AppRef](#appref-interface) · [FormField](#formfield-type) · [Outcome](#outcome-type) · [HitlRecipient](#hitlrecipient-interface) · [OutputColumn](#outputcolumn-interface) · [ReturnFieldType](#returnfieldtype-type) · [VoiceSettings](#voicesettings-interface) · [ConversationalAgentSettings](#conversationalagentsettings-interface) · [AgentGuardrail](#agentguardrail-type) · [AgenticProcessCompletion](#agenticprocesscompletion-type) · [AgentLocation](#agentlocation-type) · [AgentFlavour](#agentflavour-type) · [InlineAgentFieldType](#inlineagentfieldtype-type) · [AgentMemoryRef](#agentmemoryref-interface) · [ContextIndexRef](#contextindexref-interface) · [ToolRef](#toolref-type) · [EscalationRef](#escalationref-interface) · [DataFabricFilter](#datafabricfilter-interface) · [QueuePriority](#queuepriority-type) · [SchedulePreset](#schedulepreset-type) · [Step](#step-type) · [FlowActionSpec](#flowactionspec-type) · [CaseValue](#casevalue-type) · [NodeLayout](#nodelayout-interface) · [EdgeRoute](#edgeroute-interface) · [StickyNoteColor](#stickynotecolor-type) · [VarDecl](#vardecl-interface) · [BuiltEntryPoint](#builtentrypoint-interface) · [HttpBranch](#httpbranch-interface) · [ScriptReturnType](#scriptreturntype-type) · [FilterRule](#filterrule-interface) · [FilterMatch](#filtermatch-type) · [FieldMapping](#fieldmapping-interface) · [Aggregation](#aggregation-interface) · [ShownField](#shownfield-interface) · [AskedField](#askedfield-interface) · [InOutField](#inoutfield-interface) · [HitlChannel](#hitlchannel-type) · [HitlAssigneeType](#hitlassigneetype-type) · [HitlConnection](#hitlconnection-interface) · [CustomGuardrail](#customguardrail-interface) · [BuiltInValidatorGuardrail](#builtinvalidatorguardrail-interface) · [BuiltinToolRef](#builtintoolref-interface) · [ConnectorToolRef](#connectortoolref-interface) · [ProcessToolRef](#processtoolref-interface) · [IxpToolRef](#ixptoolref-interface) · [McpToolRef](#mcptoolref-interface) · [RemoteA2aToolRef](#remotea2atoolref-interface) · [ClientSideToolRef](#clientsidetoolref-interface) · [HttpRequestToolRef](#httprequesttoolref-interface) · [SwitchArm](#switcharm-interface) · [FilterCondition](#filtercondition-type) · [Transformation](#transformation-type) · [AggregationOperation](#aggregationoperation-type) · [FormFieldType](#formfieldtype-type) · [GuardrailSelector](#guardrailselector-interface) · [GuardrailAction](#guardrailaction-type) · [GuardrailRule](#guardrailrule-type) · [BuiltinToolName](#builtintoolname-type) · [ProcessToolKind](#processtoolkind-type) · [GuardrailScope](#guardrailscope-type) · [GuardrailFieldReference](#guardrailfieldreference-interface) · [GuardrailFieldSelector](#guardrailfieldselector-type)
 
 ## SCHEDULE_PRESETS (const)
 
@@ -98,6 +98,8 @@ Behavior and worked examples: [scheduled-trigger.md](scheduled-trigger.md).
 export declare function formTrigger(): TriggerSpec;
 ````
 
+Behavior and worked examples: [form-trigger.md](form-trigger.md).
+
 ## conversationTrigger (function)
 
 ````ts
@@ -108,12 +110,16 @@ export declare function formTrigger(): TriggerSpec;
 export declare function conversationTrigger(): TriggerSpec;
 ````
 
+Behavior and worked examples: [conversational.md](conversational.md).
+
 ## voiceTrigger (function)
 
 ````ts
 /** Start the flow when a phone call comes IN (`core.trigger.voice`). */
 export declare function voiceTrigger(): TriggerSpec;
 ````
+
+Behavior and worked examples: [voice.md](voice.md).
 
 ## STICKY_NOTE_COLORS (const)
 
@@ -288,6 +294,8 @@ Behavior and worked examples: [api-workflow.md](api-workflow.md).
 export declare function publishedFunction(inputs: PublishedFunctionInputs): ActionSpec;
 ````
 
+Behavior and worked examples: [published-function.md](published-function.md).
+
 ## sendMessage (function)
 
 ````ts
@@ -297,6 +305,8 @@ export declare function publishedFunction(inputs: PublishedFunctionInputs): Acti
  */
 export declare function sendMessage(inputs: SendMessageInputs): ActionSpec;
 ````
+
+Behavior and worked examples: [conversational.md](conversational.md).
 
 ## waitForMessage (function)
 
@@ -308,6 +318,8 @@ export declare function sendMessage(inputs: SendMessageInputs): ActionSpec;
  */
 export declare function waitForMessage(inputs: WaitForMessageInputs): ActionSpec;
 ````
+
+Behavior and worked examples: [conversational.md](conversational.md).
 
 ## conversationContext (function)
 
@@ -331,6 +343,8 @@ export declare function conversationContext(inputs: ConversationContextInputs): 
 export declare function createOutgoingCall(inputs: CreateOutgoingCallInputs): ActionSpec;
 ````
 
+Behavior and worked examples: [voice.md](voice.md).
+
 ## endCall (function)
 
 ````ts
@@ -340,6 +354,8 @@ export declare function createOutgoingCall(inputs: CreateOutgoingCallInputs): Ac
  */
 export declare function endCall(inputs: EndCallInputs): ActionSpec;
 ````
+
+Behavior and worked examples: [voice.md](voice.md).
 
 ## voiceAgent (function)
 
@@ -351,6 +367,8 @@ export declare function endCall(inputs: EndCallInputs): ActionSpec;
 export declare function voiceAgent(inputs: VoiceAgentInputs): ActionSpec;
 ````
 
+Behavior and worked examples: [voice.md](voice.md).
+
 ## conversationalAgent (function)
 
 ````ts
@@ -360,6 +378,8 @@ export declare function voiceAgent(inputs: VoiceAgentInputs): ActionSpec;
  */
 export declare function conversationalAgent(inputs: ConversationalAgentInputs): ActionSpec;
 ````
+
+Behavior and worked examples: [conversational.md](conversational.md).
 
 ## agenticProcess (function)
 
@@ -411,6 +431,8 @@ Behavior and worked examples: [inline-agent.md](inline-agent.md).
 export declare function documentClassify(inputs: DocumentClassifyInputs): ActionSpec;
 ````
 
+Behavior and worked examples: [document-pipeline.md](document-pipeline.md).
+
 ## dynamicExtract (function)
 
 ````ts
@@ -423,11 +445,15 @@ export declare function documentClassify(inputs: DocumentClassifyInputs): Action
 export declare function dynamicExtract(inputs: DynamicExtractInputs): ActionSpec;
 ````
 
+Behavior and worked examples: [document-pipeline.md](document-pipeline.md).
+
 ## dataFabricRead (function)
 
 ````ts
 export declare function dataFabricRead(inputs: DataFabricReadInputs): ActionSpec;
 ````
+
+Behavior and worked examples: [data-fabric.md](data-fabric.md).
 
 ## dataFabricUpdate (function)
 
@@ -439,6 +465,8 @@ export declare function dataFabricRead(inputs: DataFabricReadInputs): ActionSpec
  */
 export declare function dataFabricUpdate(inputs: DataFabricUpdateInputs): ActionSpec;
 ````
+
+Behavior and worked examples: [data-fabric.md](data-fabric.md).
 
 ## queueItem (function)
 
@@ -1100,7 +1128,7 @@ export interface RpaWorkflowInputs {
      * The process's OUTPUT arguments — the fields it returns, and their types
      * (e.g. `{ title: 'string' }`). Required if anything reads the step's output.
      */
-    returns?: Record<string, 'string' | 'number' | 'boolean' | 'object' | 'array'>;
+    returns?: Record<string, ReturnFieldType>;
 }
 ````
 
@@ -1134,7 +1162,7 @@ export interface ApiWorkflowInputs {
      * @enforcedBy APIWF_READ_WITHOUT_RETURNS Reading a field off the result requires
      *   declaring it here.
      */
-    returns?: Record<string, 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array'>;
+    returns?: Record<string, ReturnFieldType>;
 }
 ````
 
@@ -1174,7 +1202,7 @@ export interface PublishedFunctionInputs {
      * @enforcedBy FUNCTION_READ_WITHOUT_RETURNS Reading a field off the result requires
      *   declaring it here.
      */
-    returns?: Record<string, 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array'>;
+    returns?: Record<string, ReturnFieldType>;
 }
 ````
 
@@ -1391,7 +1419,7 @@ export interface AgentInputs {
      * @enforcedBy AGENT_READ_WITHOUT_RETURNS Reading a field off the result requires
      *   declaring it here.
      */
-    returns?: Record<string, 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array'>;
+    returns?: Record<string, ReturnFieldType>;
     /**
      * Whether the published resource is a CODED agent project (LangGraph /
      * LlamaIndex / OpenAI Agents) or a low-code one built in Agent Builder.
@@ -1624,7 +1652,7 @@ export interface QueueItemInputs {
      * `HTTP 409: Duplicate Reference`, so derive it from the flow's input rather
      * than hard-coding it.
      */
-    reference?: string;
+    reference?: string | Expr;
     /** Earliest the item may be processed, ISO-8601 (e.g. `'2026-08-01T09:00:00Z'`). */
     deferDate?: string;
     /** Latest the item should be processed, ISO-8601. What an SLA is measured against. */
@@ -1640,7 +1668,7 @@ export interface QueueItemInputs {
      * their types (e.g. `{ approved: 'boolean' }`). Required if anything reads the
      * step's output.
      */
-    returns?: Record<string, 'string' | 'number' | 'boolean' | 'object' | 'array'>;
+    returns?: Record<string, ReturnFieldType>;
 }
 
 // QueuePriority = 'Low' | 'Normal' | 'High'
@@ -1755,7 +1783,7 @@ interface HttpInputsBase {
      * and the same word, as
      * `rpaWorkflow`'s `returns`.
      */
-    returns?: Record<string, 'string' | 'number' | 'boolean' | 'object' | 'array'>;
+    returns?: Record<string, ReturnFieldType>;
     /**
      * How long to wait for the response before giving up, as an **ISO-8601
      * duration** — `'PT30S'` is "give up after 30 seconds", `'PT1M'` one minute,
@@ -2400,6 +2428,14 @@ export interface OutputColumn {
 }
 ````
 
+## ReturnFieldType (type)
+
+````ts
+export type ReturnFieldType = InlineAgentFieldType;
+
+// InlineAgentFieldType = 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array'
+````
+
 ## VoiceSettings (interface)
 
 ````ts
@@ -2454,7 +2490,7 @@ export type AgenticProcessCompletion = {
      * @enforcedBy AGENTIC_READ_WITHOUT_RETURNS Reading a field off the result requires
      * declaring it here.
      */
-    returns?: Record<string, 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array'>;
+    returns?: Record<string, ReturnFieldType>;
 } | {
     /**
      * Dispatch the process and continue immediately — the platform's

--- a/preview/uipath-maestro-flow/references/brownfield.md
+++ b/preview/uipath-maestro-flow/references/brownfield.md
@@ -4,6 +4,25 @@ Use this procedure when a task supplies a deployed `.flow` and no `.flow.ts`.
 Do not hand-transcribe the graph: decompile it to builder source, edit that
 source, and merge only the delta back into the original.
 
+## The short loop
+
+`decompile` writes `<Name>.pipeline.mjs` alongside the source. Prefer it for any
+narrow edit: it chains all four steps below, and it captures the baseline before
+your edit rather than after, which is the ordering mistake that forces a rebuild.
+
+```bash
+uip maestro flow decompile Deployed.flow -o Deployed.flow.ts
+node Deployed.pipeline.mjs    # compiles the pristine baseline; stops there
+# Edit Deployed.flow.ts narrowly; preserve existing step ids.
+node Deployed.pipeline.mjs    # compiles the edit, merges into Deployed.merged.flow
+```
+
+Re-running it after further edits repeats only the compile and merge — the
+baseline is captured once and reused. Pass `--no-pipeline` to `decompile` when
+you deliberately want the manual sequence instead.
+
+## The same loop by hand
+
 ```bash
 uip maestro flow decompile Deployed.flow -o Deployed.flow.ts
 uip maestro flow compile Deployed -o Deployed.baseline.flow
@@ -38,9 +57,7 @@ whose definition is MISSING from the file — nothing can carry it, so it lowers
 to `mock() /* TODO: unsupported node type … */`; leave that node untouched and
 merge restores the original.
 
-Validate `Deployed.merged.flow`, not the intermediate edited compile. The
-decompiler also emits `Deployed.pipeline.mjs`, which chains the same four
-steps when a single command is more convenient.
+Validate `Deployed.merged.flow`, not the intermediate edited compile.
 
 ## Split (`$ref`) artifacts
 

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -149,46 +149,43 @@ uip is resources describe <connector-key> <object> --connection-id <id> \
 
 ## Structured filters (CEQL)
 
-For an Integration Service list operation, preserve the FilterBuilder contract
-as a structured tree. A raw CEQL string such as `status='Active'` is only the
-runtime query; it does not describe the filter tree Studio Web needs.
+An Integration Service list operation takes a server-side filter through a
+FilterBuilder parameter — usually `where`, sometimes `q`. **Write the CEQL
+string; the SDK derives the tree.**
 
-```json
-{
-  "groupOperator": 0,
-  "index": 0,
-  "filters": [
-    {
-      "id": "status",
-      "operator": "Equals",
-      "value": {
-        "value": "Active",
-        "rawString": "\"Active\"",
-        "isLiteral": true
-      }
-    }
-  ],
-  "groups": []
-}
+```ts
+connector('uipath-microsoft-azureactivedirectory', 'list-groups',
+  { where: "displayName = 'active' AND createdDateTime >= '2026-01-01T00:00:00Z'" },
+  { connection: 'entra', folder: 'shared' })
 ```
 
-`groupOperator` is numeric (`0` for And, `1` for Or). Use the field id from the
-operation schema and the product operator name, such as `Equals`; do not replace
-the tree with `{ "ceql": "..." }` or an ad-hoc description object.
+That emits BOTH halves the artifact must carry: the runtime query at
+`inputs.detail.queryParameters.where`, and the design-time tree at
+`essentialConfiguration.savedFilterTrees.where` inside the node's
+`configuration`. Studio Web renders the FilterBuilder from the tree; product
+validation rejects a filter that has only one of the two, so a string alone
+fails `validate` even though the run would have worked.
 
-When the environment provides the node-configure authoring command, pass the
-tree under `filter` so the CLI can emit both the runtime CEQL query and the
-design-time saved filter tree:
+Supported: `=` `!=` `<` `<=` `>` `>=`, `Contains`, `Starts With`, `Ends With`,
+`Like`, their `Not` forms, and `Is Null` / `Is Not Null`. Combine with `AND` or
+`OR`, and parenthesise to nest — `(a = 1 OR b = 2) AND c = 'x'`. Mixing `AND`
+and `OR` at one level is refused rather than guessed, because a tree carries one
+operator per level.
 
-```bash
-uip maestro flow node configure <flow-file> <node-id> \
-  --detail '{"filter": {"groupOperator": 0, "index": 0, "filters": [{"id": "status", "operator": "Equals", "value": {"value": "Active", "rawString": "\"Active\"", "isLiteral": true}}], "groups": []}}' \
-  --output json
-```
+Three spellings are compile errors here rather than a tenant-side
+`[102003] Integration Services bad request`:
 
-If the request is offline and asks only for a reviewable filter plan, save this
-same tree in the requested JSON artifact. Do not fabricate a connected node or
-resource binding when no tenant connection exists.
+| Wrong | Why | Right |
+|---|---|---|
+| `'accountNumber' = 'ACC123'` | a quoted token is a VALUE to CEQL | `accountNumber = 'ACC123'` |
+| `accountNumber = "ACC123"` | double quotes mark a COLUMN reference | `accountNumber = 'ACC123'` |
+| `status eq 'Open'` | `eq`/`ne`/`gt`/`ge`/`lt`/`le` are OData | `status = 'Open'` |
+
+**A filter built from a runtime value keeps the runtime half only.** The tree
+holds literals, so a `js` template in `where` emits the query and no tree — which
+`validate` rejects. Where the filter must vary per run, filter server-side on
+what is constant and narrow the rest downstream, or accept the design-time gap
+deliberately.
 
 ## Schema-dynamic operations: the parent-field loop
 


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `86e3d32` to current `UiPath/flow-builder-sdk@main` (`3d5a94e`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)