### PR TITLE
fix(maestro-flow): accept equivalent connector artifacts

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/test_connector_checker_representation_parity.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_connector_checker_representation_parity.py
@@ -1,0 +1,248 @@
+"""Regression tests for semantic parity across live and SDK Flow artifacts."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+TASK_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _run(relative: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(TASK_ROOT / relative)],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _filter_tree() -> dict:
+    return {
+        "groupOperator": 1,
+        "index": 0,
+        "filters": [
+            {"id": "active", "operator": "Equals", "value": {"value": True}},
+            {"id": "score", "operator": "GreaterThanOrEqual", "value": {"value": 8.5}},
+            {"id": "viewCount", "operator": "GreaterThanOrEqual", "value": {"value": 1000}},
+            {"id": "title", "operator": "Equals", "value": {"value": "FilterFixture-Matrix"}},
+            {"id": "description", "operator": "Contains", "value": {"value": "sci-fi"}},
+            {"id": "releaseDate", "operator": "LessThan", "value": {"value": "2025-01-01"}},
+            {"id": "lastUpdated", "operator": "GreaterThanOrEqual", "value": {"value": "2024-01-01"}},
+            {"id": "externalId", "operator": "Equals", "value": {"value": "7f4d8f1e-5c2b-4a6e-9d31-2b7c8e0f1a45"}},
+            {"id": "description", "operator": "IsNull", "value": {"value": None}},
+        ],
+        "groups": [],
+    }
+
+
+def _query_detail(representation: str, *, start: int, ascending: bool) -> dict:
+    detail = {
+        "bodyParameters": {"_sortFieldName": "score"},
+        "queryParameters": {
+            "queryExpression": (
+                "active = true OR score >= 8.5 OR viewCount >= 1000 OR "
+                "title = 'FilterFixture-Matrix' OR description LIKE '%sci-fi%' OR "
+                "releaseDate < '2025-01-01' OR lastUpdated >= '2024-01-01' OR "
+                "externalId = '7f4d8f1e-5c2b-4a6e-9d31-2b7c8e0f1a45' OR description IS NULL"
+            ),
+            "start": start,
+            "limit": 2,
+            "isAscending": ascending,
+        },
+    }
+    if representation == "sdk":
+        detail["filter"] = _filter_tree()
+    elif representation == "live":
+        detail["configuration"] = "=jsonString:" + json.dumps(
+            {"essentialConfiguration": {"savedFilterTrees": {"queryExpression": _filter_tree()}}}
+        )
+    return detail
+
+
+@pytest.mark.parametrize("representation", ["live", "sdk"])
+def test_smoke_query_accepts_both_filter_tree_locations(
+    tmp_path: Path, representation: str
+) -> None:
+    details = [
+        _query_detail(representation, start=0, ascending=True),
+        _query_detail(representation, start=2, ascending=True),
+        _query_detail(representation, start=0, ascending=False),
+    ]
+    _write_json(
+        tmp_path / "queries.flow",
+        {
+            "nodes": [
+                {
+                    "type": "uipath.connector.uipath-uipath-dataservice.query-entity-records",
+                    "inputs": {"detail": detail},
+                }
+                for detail in details
+            ]
+        },
+    )
+
+    result = _run("connector_features/datafabric_connector/check_smoke_query_filter.py", tmp_path)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_smoke_query_rejects_runtime_text_without_contains_operator(tmp_path: Path) -> None:
+    details = [
+        _query_detail("runtime-only", start=0, ascending=True),
+        _query_detail("runtime-only", start=2, ascending=True),
+        _query_detail("runtime-only", start=0, ascending=False),
+    ]
+    _write_json(
+        tmp_path / "queries.flow",
+        {
+            "nodes": [
+                {
+                    "type": "uipath.connector.uipath-uipath-dataservice.query-entity-records",
+                    "inputs": {"detail": detail},
+                }
+                for detail in details
+            ]
+        },
+    )
+
+    result = _run("connector_features/datafabric_connector/check_smoke_query_filter.py", tmp_path)
+
+    assert result.returncode != 0
+    assert "multiline" in result.stderr
+
+
+def _lifecycle_flow(representation: str, *, query_entity: str = "ContractRegistry") -> dict:
+    def entity_detail(name: str, extra: dict | None = None) -> dict:
+        value = ({"entityName": name} if representation == "sdk"
+                 else {"pathParameters": {"entityName": name}})
+        value.update(extra or {})
+        return value
+
+    return {
+        "nodes": [
+            {
+                "id": "created",
+                "type": "uipath.connector.trigger.uipath-uipath-dataservice.record-created",
+                "inputs": {"detail": {
+                    "objectName": "ContractRegistry",
+                    "filterExpression": "dueDate < '2026-08-04'",
+                }},
+            },
+            {
+                "id": "query",
+                "type": "uipath.connector.uipath-uipath-dataservice.query-entity-records",
+                "inputs": {"detail": entity_detail(query_entity, {"queryParameters": {
+                    "queryExpression": "dueDate < '2026-08-04'", "limit": 100,
+                }})},
+            },
+            {
+                "id": "updated",
+                "type": "uipath.connector.trigger.uipath-uipath-dataservice.record-updated",
+                "inputs": {"detail": {"objectName": "FileUploadVerify_20260618"}},
+            },
+            {
+                "id": "get",
+                "type": "uipath.connector.uipath-uipath-dataservice.get-entity-record-by-id",
+                "inputs": {"detail": entity_detail("FileUploadVerify_20260618", {
+                    "queryParameters": {"recordId": "=js:$vars.updated.output.Id"},
+                })},
+            },
+            {
+                "id": "delete",
+                "type": "uipath.connector.uipath-uipath-dataservice.delete-entity-record",
+                "inputs": {"detail": entity_detail("FileUploadVerify_20260618", {
+                    "queryParameters": {"recordId": "=js:$vars.get.output.Id"},
+                })},
+            },
+        ]
+    }
+
+
+@pytest.mark.parametrize("representation", ["live", "sdk"])
+def test_trigger_lifecycle_accepts_both_entity_locations(
+    tmp_path: Path, representation: str
+) -> None:
+    _write_json(tmp_path / "lifecycle.flow", _lifecycle_flow(representation))
+
+    result = _run("connector_features/datafabric_connector/check_trigger_lifecycle.py", tmp_path)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_trigger_lifecycle_rejects_wrong_query_entity(tmp_path: Path) -> None:
+    _write_json(tmp_path / "lifecycle.flow", _lifecycle_flow("sdk", query_entity="Other"))
+
+    result = _run("connector_features/datafabric_connector/check_trigger_lifecycle.py", tmp_path)
+
+    assert result.returncode != 0
+    assert "Query Entity Records" in result.stderr
+
+
+def _where_plan() -> dict:
+    return {
+        "filter": {
+            "groupOperator": 0,
+            "filters": [
+                {"id": "displayName", "operator": "Equals", "value": {"value": "active"}}
+            ],
+        }
+    }
+
+
+@pytest.mark.parametrize("representation", ["live", "sdk"])
+def test_ceql_where_accepts_curated_and_generic_groups_operations(
+    tmp_path: Path, representation: str
+) -> None:
+    if representation == "live":
+        connector = {
+            "type": "uipath.connector.uipath-microsoft-azureactivedirectory.list-groups",
+            "inputs": {"detail": {}},
+        }
+    else:
+        connector = {
+            "type": "uipath.connector.uipath-microsoft-azureactivedirectory.list-all-records",
+            "inputs": {"detail": {"objectName": "groups", "endpoint": "/groups"}},
+        }
+    _write_json(tmp_path / "where_detail.json", _where_plan())
+    _write_json(
+        tmp_path / "CeqlWhereTest.flow",
+        {"nodes": [connector, {"type": "core.logic.terminate"}], "edges": []},
+    )
+
+    result = _run("connector_features/check_ceql_where_flow.py", tmp_path)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_ceql_where_rejects_generic_operation_for_another_object(tmp_path: Path) -> None:
+    _write_json(tmp_path / "where_detail.json", _where_plan())
+    _write_json(
+        tmp_path / "CeqlWhereTest.flow",
+        {
+            "nodes": [
+                {
+                    "type": "uipath.connector.uipath-microsoft-azureactivedirectory.list-all-records",
+                    "inputs": {"detail": {"objectName": "users", "endpoint": "/users"}},
+                },
+                {"type": "core.logic.terminate"},
+            ],
+            "edges": [],
+        },
+    )
+
+    result = _run("connector_features/check_ceql_where_flow.py", tmp_path)
+
+    assert result.returncode != 0
+    assert "list-groups" in result.stderr

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
@@ -137,6 +137,23 @@ def _find_flow() -> str:
     return find_flow_file(flow_glob=os.path.basename(FLOW_GLOB))
 
 
+def _is_groups_operation(node: dict) -> bool:
+    node_type = str(node.get("type") or "").lower()
+    if CONNECTOR_KEY not in node_type:
+        return False
+    if "group" in node_type:
+        return True
+
+    detail = node.get("inputs", {}).get("detail", {}) or {}
+    object_name = detail.get("objectName") or (detail.get("pathParameters") or {}).get("objectName")
+    endpoint = str(detail.get("endpoint") or "").rstrip("/").lower()
+    return (
+        node_type.endswith(".list-all-records")
+        and str(object_name or "").lower() == "groups"
+        and (not endpoint or endpoint.endswith("/groups"))
+    )
+
+
 def _check_flow_structure() -> None:
     flow_path = _find_flow()
     raw = open(flow_path).read()
@@ -155,12 +172,7 @@ def _check_flow_structure() -> None:
             "the registered key with `uip maestro flow registry search`."
         )
 
-    found_groups = False
-    for node in flow.get("nodes", []):
-        node_type = node.get("type", "")
-        if CONNECTOR_KEY in node_type and "group" in node_type.lower():
-            found_groups = True
-            break
+    found_groups = any(_is_groups_operation(node) for node in flow.get("nodes", []))
     if not found_groups:
         sys.exit(
             f"FAIL: No connector node of type "

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_query_filter.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_query_filter.py
@@ -23,17 +23,6 @@ EXPECTED = {
 
 
 def structured_filter_leaves(detail):
-    config = detail.get("configuration")
-    if not isinstance(config, str):
-        return []
-    raw = config.removeprefix("=jsonString:")
-    try:
-        parsed = json.loads(raw)
-    except (TypeError, ValueError):
-        return []
-    trees = (parsed.get("essentialConfiguration", {})
-             .get("savedFilterTrees", {}))
-    tree = trees.get("queryExpression", {}) if isinstance(trees, dict) else {}
     leaves = []
 
     def walk(group):
@@ -43,7 +32,28 @@ def structured_filter_leaves(detail):
         for child in group.get("groups") or []:
             walk(child)
 
-    walk(tree)
+    # The live authoring loop stores the design-time tree in the encoded
+    # configuration. The SDK emit-only loop preserves the same semantic tree
+    # directly at detail.filter until product tooling normalizes the artifact.
+    trees = [detail.get("filter")]
+    direct_saved = detail.get("savedFilterTrees") or {}
+    if isinstance(direct_saved, dict):
+        trees.append(direct_saved.get("queryExpression"))
+
+    config = detail.get("configuration")
+    if isinstance(config, str):
+        raw = config.removeprefix("=jsonString:")
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError):
+            parsed = {}
+        saved = (parsed.get("essentialConfiguration", {})
+                 .get("savedFilterTrees", {}))
+        if isinstance(saved, dict):
+            trees.append(saved.get("queryExpression"))
+
+    for tree in trees:
+        walk(tree)
     return leaves
 
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_trigger_lifecycle.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_trigger_lifecycle.py
@@ -21,6 +21,10 @@ def text(value):
     return str(value or "").lower()
 
 
+def entity_name(d):
+    return d.get("entityName") or (d.get("pathParameters") or {}).get("entityName")
+
+
 def has_due_filter(d):
     values = [d.get("filterExpression"), d.get("filter")]
     config = d.get("configuration")
@@ -62,7 +66,7 @@ def main():
 
     contract_queries = []
     for _, n in queries:
-        if (detail(n).get("pathParameters") or {}).get("entityName") == "ContractRegistry":
+        if entity_name(detail(n)) == "ContractRegistry":
             contract_queries.append(n)
     if not contract_queries:
         print("FAIL: Query Entity Records after ContractRegistry trigger missing", file=sys.stderr)
@@ -80,8 +84,8 @@ def main():
         print("FAIL: Record Updated trigger for FileUploadVerify_20260618 missing", file=sys.stderr)
         return 1
     trigger_ids = {n.get("id", "") for n in file_updated}
-    file_gets = [n for _, n in gets if (detail(n).get("pathParameters") or {}).get("entityName") == "FileUploadVerify_20260618"]
-    file_deletes = [n for _, n in deletes if (detail(n).get("pathParameters") or {}).get("entityName") == "FileUploadVerify_20260618"]
+    file_gets = [n for _, n in gets if entity_name(detail(n)) == "FileUploadVerify_20260618"]
+    file_deletes = [n for _, n in deletes if entity_name(detail(n)) == "FileUploadVerify_20260618"]
     if not file_gets or not file_deletes:
         print("FAIL: FileUploadVerify updated flow must contain Get and Delete activities", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

- Accept live and SDK locations for Data Service filter trees and entity names.
- Accept the generic Azure AD groups operation when object and endpoint identify groups.
- Add positive parity fixtures and negative controls for all three checker contracts.

Fixes #2917

## Verification

- pytest -q tests/tasks/uipath-maestro-flow (326 passed)
- Retained source artifacts now pass the smoke-query, trigger-lifecycle, and CEQL-where checkers.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)