### PR TITLE
fix(maestro-flow): clarify task resource scope

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
@@ -68,6 +68,10 @@ def _tagged_tasks() -> list[tuple[str, Path, str]]:
     return tasks
 
 
+def _task_text(relative: str) -> str:
+    return (FLOW_TASKS / relative).read_text()
+
+
 def _referenced_python_files(task_path: Path, criterion: str) -> list[Path]:
     paths = []
     for token in re.findall(
@@ -191,3 +195,18 @@ def test_external_graders_use_package_qualified_shared_imports() -> None:
             if module in shared_modules:
                 offenders.add(relative.as_posix())
     assert offenders == set()
+
+
+def test_reconfigure_prompt_requires_a_tenant_wide_connection_inventory() -> None:
+    prompt = _prompt_text(
+        _task_text("bindings/reconfigure_different_connection.yaml")
+    ).lower()
+
+    assert "tenant-wide" in prompt
+    assert "every folder" in prompt
+
+
+def test_multiselect_prompt_names_slack_as_the_required_connector() -> None:
+    prompt = _prompt_text(_task_text("connector_features/multiselect.yaml")).lower()
+
+    assert "slack group direct message" in prompt

--- a/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
@@ -19,9 +19,10 @@ run_limits:
 
 initial_prompt: |
   PRECONDITION CHECK — do this FIRST, before any flow work:
-  Inspect the available Integration Service connections once. Group the enabled
-  connections by connector key and find a connector with two or more enabled
-  connections. That connector supplies A and B.
+  Inspect the tenant-wide Integration Service connection inventory once,
+  including connections in every folder. Group the enabled connections by
+  connector key and find a connector with two or more enabled connections.
+  That connector supplies A and B.
 
   If no connector has two or more enabled connections, the precondition
   is not met for this tenant. Stop IMMEDIATELY: write

--- a/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
@@ -16,7 +16,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a flow file to create a group direct message between
+  Create a flow file to create a Slack group direct message between
   Coder Evals, IS-sandboxes@uipath.com and E2E-testing.
   Use the connection present in Shared/uipath-maestro-flow.
 


### PR DESCRIPTION
## Summary

- State that connection replacement starts from a tenant-wide inventory covering every folder.
- Name Slack as the connector required by the multiselect task.
- Pin both prompt contracts with corpus tests.

Fixes #2918

## Verification

- pytest -q tests/tasks/uipath-maestro-flow (319 passed)
- coder-eval plan validates both changed task definitions.
- CLI verb reachability checks are clean for both tasks.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)