### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@2a58ed9

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 3d5a94e. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 2a58ed9. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 3d5a94e. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 2a58ed9. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 3d5a94e. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 2a58ed9. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -81,10 +81,9 @@ second path. If only emitted `.flow` JSON exists, decompile it, compile the
 pristine baseline, edit narrowly, and merge the delta back into the original.
 These are before/after judgments; no final-artifact checker can prove them.
 
-For a narrow edit — moving one node, adding an output, renaming a step — do not
-drive those four commands by hand. `decompile` writes `<Name>.pipeline.mjs`,
-which runs the whole loop in two invocations and gets the baseline ordering
-right, which is the step that costs retries when done manually:
+For a narrow edit in an external staging directory, `decompile` writes
+`<Name>.pipeline.mjs`, which runs the loop in two invocations and gets the
+baseline ordering right:
 
 ```bash
 uip maestro flow decompile <Name>.flow -o <Name>.flow.ts
@@ -95,6 +94,11 @@ uip maestro flow validate <Name>.merged.flow --output json
 ```
 
 Validate the merged artifact, never the intermediate edited compile.
+If the source must stay inside the Flow project (for example, to preserve
+relative sidecars), keep baseline, edited, and candidate `.flow` files in an
+external `.flow-work/` directory. Validate the candidate, replace the canonical
+artifact, and leave exactly one `.flow` under the project. The reference below
+contains the copyable safe-project sequence.
 
 **True-brownfield procedure:**
 **[`references/brownfield.md`](references/brownfield.md)**.

--- a/preview/uipath-maestro-flow/references/api.md
+++ b/preview/uipath-maestro-flow/references/api.md
@@ -880,6 +880,13 @@ export type HttpInputs = HttpInputsBase & ({
     connection?: string;
     /** Symbolic folder name declared in bindings.json. */
     folder?: string;
+    /**
+     * Connector key whose authentication the HTTP proxy should reuse.
+     * Defaults to `uipath-uipath-http`. Set this for a connector-specific
+     * fallback endpoint, for example `uipath-salesforce-slack`.
+     * Requires both `connection` and `folder`.
+     */
+    targetConnector?: string;
 });
 ````
 

--- a/preview/uipath-maestro-flow/references/brownfield.md
+++ b/preview/uipath-maestro-flow/references/brownfield.md
@@ -4,7 +4,37 @@ Use this procedure when a task supplies a deployed `.flow` and no `.flow.ts`.
 Do not hand-transcribe the graph: decompile it to builder source, edit that
 source, and merge only the delta back into the original.
 
-## The short loop
+## The safe project loop
+
+Keep authored source beside the canonical Flow so relative sidecars still
+resolve, but put every compiled working artifact outside the Flow project. The
+project must contain exactly one `.flow` file when product validation discovers
+it recursively.
+
+```bash
+PROJECT=Solution/Deployed
+CANONICAL="$PROJECT/Deployed.flow"
+WORK=.flow-work/Deployed
+mkdir -p "$WORK"
+
+uip maestro flow decompile "$CANONICAL" -o "$PROJECT/Deployed.flow.ts" --no-pipeline
+uip maestro flow compile "$PROJECT/Deployed.flow.ts" -o "$WORK/baseline.flow"
+# Edit $PROJECT/Deployed.flow.ts narrowly; preserve existing step ids.
+uip maestro flow compile "$PROJECT/Deployed.flow.ts" -o "$WORK/edited.flow"
+uip maestro flow merge "$CANONICAL" "$WORK/edited.flow" \
+  -o "$WORK/candidate.flow" --baseline "$WORK/baseline.flow"
+
+uip maestro flow validate "$WORK/candidate.flow" --output json
+cp "$WORK/candidate.flow" "$CANONICAL"
+uip maestro flow validate "$CANONICAL" --output json
+```
+
+Replace the canonical artifact only after the candidate validates. Do not copy
+`baseline.flow`, `edited.flow`, or `candidate.flow` into the project, and do not
+leave an earlier `*.merged.flow` there: the project validator treats every
+`.flow` below the project directory as a deliverable.
+
+## The generated pipeline
 
 `decompile` writes `<Name>.pipeline.mjs` alongside the source. Prefer it for any
 narrow edit: it chains all four steps below, and it captures the baseline before
@@ -19,7 +49,10 @@ node Deployed.pipeline.mjs    # compiles the edit, merges into Deployed.merged.f
 
 Re-running it after further edits repeats only the compile and merge — the
 baseline is captured once and reused. Pass `--no-pipeline` to `decompile` when
-you deliberately want the manual sequence instead.
+you deliberately want the manual sequence instead. The pipeline writes its
+`.flow` artifacts beside the `.flow.ts`; use it only when that source directory
+is already outside the canonical Flow project. When source must remain in the
+project for relative sidecars, use the safe project loop above.
 
 ## The same loop by hand
 
@@ -57,7 +90,9 @@ whose definition is MISSING from the file — nothing can carry it, so it lowers
 to `mock() /* TODO: unsupported node type … */`; leave that node untouched and
 merge restores the original.
 
-Validate `Deployed.merged.flow`, not the intermediate edited compile.
+Validate `Deployed.merged.flow`, not the intermediate edited compile. Before
+placing it in a solution, copy it over the canonical artifact rather than next
+to it, then validate the canonical project path again.
 
 ## Split (`$ref`) artifacts
 

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -20,6 +20,26 @@ Signatures:
   { connection: 'jira', folder: 'shared' }))
 ```
 
+## Three contracts to settle before authoring
+
+Check these before the first connector call; they are the common places where a
+plausible Flow compiles but loses the intended runtime or Studio Web contract:
+
+1. **Runtime strings use `tmpl`, not `js`.** For example,
+   ``where: tmpl`invoiceNumber = '${input('invoiceNumber')}'` `` builds a string.
+   ``js`invoiceNumber = '${input('invoiceNumber')}'` `` is JavaScript assignment
+   syntax and evaluates to only the assigned value. See
+   [Structured filters](#structured-filters-ceql).
+2. **Schema-dynamic fields require a prepared descriptor.** Resolving parent
+   values is not enough: run `registry prepare` with those values and import the
+   generated descriptor so the Flow retains its schema-replay metadata. See
+   [the parent-field loop](#schema-dynamic-operations-the-parent-field-loop).
+3. **Paged reference lookups use exactly `nextPage`.** When
+   `Pagination.HasMore` is true, pass `Pagination.NextPageToken` as
+   `--query "nextPage=<token>"`; do not guess `page`, `pageToken`, or
+   `nextPageToken`. See
+   [Resolving connection-scoped reference values](#resolving-connection-scoped-reference-values).
+
 ## Discovering operations and fields
 
 `$FLOW_SDK_LIBRARY_MD` (markdown, for reading) and `$FLOW_SDK_LIBRARY_JSON`

--- a/preview/uipath-maestro-flow/references/http.md
+++ b/preview/uipath-maestro-flow/references/http.md
@@ -10,7 +10,7 @@ The one factory selects two distinct product nodes:
   path.
 
 Signature:
-`http({ method?, url, managed, connection?, folder?, headers?, query?, body?, contentType?, timeout?, retryCount?, returns? })`.
+`http({ method?, url, managed, connection?, folder?, targetConnector?, headers?, query?, body?, contentType?, timeout?, retryCount?, returns? })`.
 
 ```ts
 .step('policy', http({ method: 'GET', url: policyUrl,
@@ -66,6 +66,23 @@ node detail and the emitted flow's resource bindings:
 Connection mode emits `authentication: "connector"`, targets
 `uipath-uipath-http`, and treats `url` as a path relative to the connection's
 configured base URL. Supplying only one of `connection` or `folder` is an error.
+
+For an HTTP fallback authenticated by another connector, set its connector key
+as `targetConnector`. The node remains the managed HTTP wrapper, while the
+proxied request reuses that connector's authentication:
+
+```ts
+.step('emoji', http({
+  managed: true,
+  method: 'GET',
+  url: '/emoji.list',
+  connection: 'slack',
+  folder: 'shared',
+  targetConnector: 'uipath-salesforce-slack',
+}))
+```
+
+`targetConnector` requires both bindings and is not valid on standalone HTTP.
 
 ## Response branches
 


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `3d5a94e` to current `UiPath/flow-builder-sdk@main` (`2a58ed9`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)