### PR TITLE
fix(api-workflow): guard loop output against empty collections; fix run_execute grader

### DIFF
--- a/skills/uipath-api-workflow/assets/templates/conditional-workflow-example.json
+++ b/skills/uipath-api-workflow/assets/templates/conditional-workflow-example.json
@@ -147,7 +147,7 @@
                         }
                       }
                     ],
-                    "output": { "as": "${$context.outputs.For_Each_1}" },
+                    "output": { "as": "${$context.outputs?.For_Each_1}" },
                     "metadata": { "activityType": "ForEach", "displayName": "Process Transactions", "fullName": "ForEach" }
                   }
                 },

--- a/skills/uipath-api-workflow/assets/templates/loop-aggregation-example.json
+++ b/skills/uipath-api-workflow/assets/templates/loop-aggregation-example.json
@@ -135,7 +135,7 @@
             "For_Each_1": {
               "for": {
                 "each": "term",
-                "in": "${$context.outputs.Do_While_1.results ?? []}",
+                "in": "${$context.outputs?.Do_While_1?.results ?? []}",
                 "at": "termIndex"
               },
               "do": [
@@ -168,7 +168,7 @@
           },
           {
             "Response_1": {
-              "response": "${{ lastTerm: $context.variables.current, iterationsRun: $context.variables.iteration, fibSum: $context.variables.sum, classified: $context.outputs.For_Each_1.results }}",
+              "response": "${{ lastTerm: $context.variables.current, iterationsRun: $context.variables.iteration, fibSum: $context.variables.sum, classified: $context.outputs?.For_Each_1?.results ?? [] }}",
               "markJobAsFailed": false,
               "then": "end",
               "export": { "as": "{ ...$context, outputs: { ...$context?.outputs, \"Response_1\": $output } }" },

--- a/skills/uipath-api-workflow/assets/templates/loop-aggregation-example.json
+++ b/skills/uipath-api-workflow/assets/templates/loop-aggregation-example.json
@@ -127,7 +127,7 @@
                   }
                 }
               ],
-              "output": { "as": "${$context.outputs.Do_While_1}" },
+              "output": { "as": "${$context.outputs?.Do_While_1}" },
               "metadata": { "activityType": "DoWhile", "displayName": "Generate Fibonacci Series", "fullName": "DoWhile" }
             }
           },
@@ -162,7 +162,7 @@
                   }
                 }
               ],
-              "output": { "as": "${$context.outputs.For_Each_1}" },
+              "output": { "as": "${$context.outputs?.For_Each_1}" },
               "metadata": { "activityType": "ForEach", "displayName": "Classify Each Term", "fullName": "ForEach" }
             }
           },

--- a/skills/uipath-api-workflow/assets/templates/nested-control-flow-example.json
+++ b/skills/uipath-api-workflow/assets/templates/nested-control-flow-example.json
@@ -213,7 +213,7 @@
                               }
                             }
                           ],
-                          "output": { "as": "${$context.outputs.Do_While_1}" },
+                          "output": { "as": "${$context.outputs?.Do_While_1}" },
                           "metadata": { "activityType": "DoWhile", "displayName": "Retry Loop", "fullName": "DoWhile" }
                         }
                       },
@@ -269,7 +269,7 @@
                   }
                 }
               ],
-              "output": { "as": "${$context.outputs.For_Each_1}" },
+              "output": { "as": "${$context.outputs?.For_Each_1}" },
               "metadata": { "activityType": "ForEach", "displayName": "Process Each Task", "fullName": "ForEach" }
             }
           },

--- a/skills/uipath-api-workflow/references/task-types.md
+++ b/skills/uipath-api-workflow/references/task-types.md
@@ -219,7 +219,7 @@ Iterates over a collection. Requires `#Body` inside `do`.
 
 **Output pattern:** `${$context.outputs?.For_Each_N}`
 
-> The `?.` after `outputs` is required. The bucket is created by the body's export — zero iterations (empty collection) means no export, and `$context.outputs.For_Each_N` without `?.` crashes the run with `Cannot read properties of undefined`.
+> The `?.` after `outputs` is required — **and so is guarding every downstream read of the bucket.** The bucket is created by the body's export, so zero iterations (empty collection) means no export: `$context.outputs.For_Each_N` without `?.` crashes the run with `Cannot read properties of undefined (reading 'For_Each_N')`, and so does a Response, `for.in`, or Assign that reads `$context.outputs.For_Each_N.results` — a trailing `?? []` does not help because `.results` already threw. Read the bucket downstream as `${$context.outputs?.For_Each_N?.results ?? []}`.
 
 **Minimal JSON:**
 ```json
@@ -257,7 +257,7 @@ Inside the body, the iterator and index are accessible as globals **with a `$` p
 **Nesting:**
 - Each ForEach activity's iterator and index variable names are scoped to that loop. Inner loops MUST use distinct names — e.g. outer `for.each: "outerItem"` / inner `for.each: "innerItem"`. Reusing `currentItem` in both loops shadows the outer one.
 - An `If`, another `ForEach`, a `DoWhile`, or a `TryCatch` placed inside a `#Body` is fine — drop them into the body's `do` array. Each gets its own `export.as` as usual; the body's outer `export.as` (the index-aware accumulation) is unchanged.
-- The body's accumulation export merges per-iteration `$output` into `$context.outputs.For_Each_N.results`. If you want per-iteration data, capture it via Assign / JsInvoke inside the body — those activities' `$output` become the body's per-iteration `$output`.
+- The body's accumulation export merges per-iteration `$output` into `$context.outputs.For_Each_N.results`; downstream, read it as `$context.outputs?.For_Each_N?.results ?? []` (the bucket is absent after zero iterations). If you want per-iteration data, capture it via Assign / JsInvoke inside the body — those activities' `$output` become the body's per-iteration `$output`.
 
 ---
 

--- a/skills/uipath-api-workflow/references/task-types.md
+++ b/skills/uipath-api-workflow/references/task-types.md
@@ -217,7 +217,9 @@ Iterates over a collection. Requires `#Body` inside `do`.
 { ...$context, outputs: { ...$context?.outputs, "For_Each_N": { ...$context?.outputs?.For_Each_N, results: [ ...($currentItemIndex == 0 ? [] : ($context?.outputs?.For_Each_N?.results ?? [])), ...([$output] ?? []) ] } } }
 ```
 
-**Output pattern:** `${$context.outputs.For_Each_N}`
+**Output pattern:** `${$context.outputs?.For_Each_N}`
+
+> The `?.` after `outputs` is required. The bucket is created by the body's export — zero iterations (empty collection) means no export, and `$context.outputs.For_Each_N` without `?.` crashes the run with `Cannot read properties of undefined`.
 
 **Minimal JSON:**
 ```json
@@ -238,7 +240,7 @@ Iterates over a collection. Requires `#Body` inside `do`.
         }
       }
     ],
-    "output": { "as": "${$context.outputs.For_Each_1}" },
+    "output": { "as": "${$context.outputs?.For_Each_1}" },
     "metadata": { "activityType": "ForEach", "displayName": "For Each", "fullName": "ForEach" }
   }
 }
@@ -286,7 +288,7 @@ Repeat-until loop. Body always executes at least once.
         }
       }
     ],
-    "output": { "as": "${$context.outputs.Do_While_1}" },
+    "output": { "as": "${$context.outputs?.Do_While_1}" },
     "metadata": { "activityType": "DoWhile", "displayName": "Do While", "fullName": "DoWhile" }
   }
 }

--- a/skills/uipath-api-workflow/references/troubleshooting.md
+++ b/skills/uipath-api-workflow/references/troubleshooting.md
@@ -60,6 +60,11 @@ Common failure modes when authoring, running, packaging, or publishing API workf
 - **Cause:** Using `$context.outputs` without optional chaining when no outputs exist yet
 - **Fix:** Always use `$context?.outputs` in export patterns
 
+### `Cannot read properties of undefined (reading 'For_Each_N')` — only when the collection is empty
+- **Symptom:** the run succeeds for a non-empty input and fails with this error for `[]`, thrown from the loop's `output.as` or from a downstream Response / `for.in` / Assign that reads `$context.outputs.For_Each_N.results`
+- **Cause:** the `For_Each_N` bucket is created by the body's export; zero iterations means it never exists. A trailing `?? []` does not help — the `.results` access already threw
+- **Fix:** guard every read of a loop bucket, not only the loop's own `output.as`: `${$context.outputs?.For_Each_N?.results ?? []}`. Use the same shape for `Do_While_N` buckets
+
 ### ForEach body export missing index reset
 - **Symptom:** Results array grows incorrectly across loop iterations
 - **Cause:** Using the simpler DoWhile accumulation pattern instead of the ForEach index-aware pattern

--- a/tests/tasks/uipath-api-workflow/operate/run_execute/run_execute.yaml
+++ b/tests/tasks/uipath-api-workflow/operate/run_execute/run_execute.yaml
@@ -31,17 +31,27 @@ initial_prompt: |
   Do NOT ask for approval or confirmation.
 
 success_criteria:
+  # One criterion per input, each anchored on its score inside the SAME command
+  # segment (the lookahead stops at newline / && / || / ; / | / the next uip), so
+  # two runs chained in one Bash call still count once each, and a hand-written
+  # run_40.json cannot stand in for the score-40 run (CONTRIBUTING.md: do not
+  # score self-reports). A single pattern with min_count: 2 was a false negative
+  # for && chaining (2026-09-01); min_count: 1 was a false positive for
+  # one-real-run-plus-fabrication.
   - type: command_executed
-    # min_count 1, not 2: the matcher runs one search per Bash tool call, so
-    # both runs chained with && in a single call count once (the 2026-09-01 run
-    # scored a false 1/2 that way). One visible invocation still anchors that
-    # the agent drove the runner; per-input evidence lives in the envelope
-    # checks on run_85.json / run_40.json below.
-    description: "Agent executed the workflow with the local runner (both runs may share one chained Bash call)"
+    description: "Agent ran the workflow with the local runner for score 85"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+api-workflow\s+run'
+    command_pattern: '(uip|\$UIP)\s+api-workflow\s+run(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*(?<![A-Za-z0-9])85(?![0-9]))'
     min_count: 1
-    weight: 2.0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran the workflow with the local runner for score 40"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+api-workflow\s+run(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*(?<![A-Za-z0-9])40(?![0-9]))'
+    min_count: 1
+    weight: 1.0
     pass_threshold: 1.0
 
   - type: file_exists


### PR DESCRIPTION
Two fixes from the 2026-08-27 codereval failures on `uipath-api-workflow`. Rebased on main (the `run_execute.yaml` conflict with #2953 is resolved by the new grader design below).

## 1. Skill bug: loop buckets are undefined after zero iterations

The `outputs.For_Each_N` bucket is created by the loop body's export. If the loop runs zero times, the bucket never exists, and **any** read of it crashes the run with `Cannot read properties of undefined (reading 'For_Each_N')` — the loop's own `output.as`, but equally a Response, `for.in`, or Assign downstream that reads `$context.outputs.For_Each_N.results`. A trailing `?? []` does not help; `.results` already threw.

This is what failed the `diagnose-unsupported-activity-type` eval: the agent copied the skill's pattern faithfully, and count=0 crashed.

**Fix:** guard every read of a loop bucket with `?.`:
- `output.as` → `${$context.outputs?.For_Each_N}` in `task-types.md` and all three loop templates (DoWhile too)
- downstream reads → `${$context.outputs?.For_Each_N?.results ?? []}`: the loop-aggregation template's `for.in` over `Do_While_1.results` and its Response's `classified`; task-types note + nesting bullet now state the rule; new troubleshooting entry for the error

**Verified on uip 1.202.0:** unguarded Response + `items: []` → `Failure … reading 'For_Each_1'`; guarded → `Success {Results: []}`; `items: [1,2,3]` → `{Results: [2,4,6]}` either way. All three templates validate; the loop-aggregation template runs.

## 2. Test bug: `run_execute` graded the run count, not the runs

The `command_executed` criterion counts Bash tool calls, not pattern occurrences. `min_count: 2` was a false negative for two runs chained with `&&` in one call; relaxing to `min_count: 1` (as this PR first did, and as #2953 did on main) is a false positive — one real run plus a hand-written `run_40.json` passes the envelope check and scores 100%, which is grading a self-report.

**Fix:** two `command_executed` criteria, one per input, each anchoring its score inside the same command segment (README segment idiom). Chained runs count once each; a fabricated second file fails the score-40 criterion.

## Checks

- `npm run skills:validate` and `npm run skills:build` pass
- CLI verb check: clean
- Regex checked against 6 chained / single / fabricated / `--input-file` / `840` samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)
