### PR TITLE
docs(uipath-test): tell agents to pass --project-id when they already have it

### DIFF
--- a/skills/uipath-test/SKILL.md
+++ b/skills/uipath-test/SKILL.md
@@ -40,6 +40,17 @@ CLI tool for UiPath Test Manager (`uip tm`). Use `uip tm --help` and `uip tm <co
 
 Common `uip tm` commands organized by resource type.
 
+### Naming the project: --project-key or --project-id
+
+Every project-scoped `tm` command takes either flag; pass one.
+
+- `--project-key <KEY>` — the prefix from the Test Manager URL (e.g. `DEMO`). Costs one lookup per command.
+- `--project-id <UUID>` — used as-is, no lookup.
+
+**Prefer `--project-id` when you already have the ID** — because it was given to you, or because `project create` just returned it. Reuse it for the rest of the run. Do not call `project list` merely to look an ID up: that spends the request you would have saved. Given only a key, use `--project-key`. Passing both is fine; the ID wins.
+
+The tables below show `--project-key`; substitute `--project-id <UUID>` anywhere you have the ID. Key-only commands: `project create` / `update` / `delete`, `project owners list`, `tm pack`.
+
 ### Project Commands
 
 | Command | Purpose |

--- a/skills/uipath-test/references/publish-and-link-guide.md
+++ b/skills/uipath-test/references/publish-and-link-guide.md
@@ -19,6 +19,7 @@ uip tm wait              → block until terminal
 - Logged in: `uip login status --output json`. If not, `uip login`.
 - Project builds clean: `uip rpa build "<PROJECT_DIR>" --output json` returns `Result: "Success"`.
 - Test case exists in Test Manager: `uip tm testcases list --project-key <PROJECT_KEY> --output json`. Capture the `ObjKey` (e.g. `DEMO:1`) — it is the `--test-case-key` value.
+- If you already hold the project's `Id` (it was given to you, or `project create` returned it), pass `--project-id <PROJECT_ID>` in place of `--project-key <PROJECT_KEY>` below — it skips a project lookup on each of the five calls this flow makes. Don't fetch the ID just for this. See [/uipath:uipath-test § Naming the project](../SKILL.md#naming-the-project---project-key-or---project-id).
 
 ## Step 1 — Pack
 


### PR DESCRIPTION
Follow-up to [UiPath/cli#3897](https://github.com/UiPath/cli/pull/3897) / [TMHUB-33023](https://uipath.atlassian.net/browse/TMHUB-33023), which makes every project-scoped `uip tm` command take either `--project-key` or `--project-id`.

`--project-key` costs an extra request per command, because the CLI has to look the key up to get the project ID. `--project-id` is used as-is.

Agents are the callers that benefit most: they usually already hold the ID (`project create` and `project list` both return `Id`), and one run fires several commands at the same project. Without this note the skill keeps steering them to `--project-key`, so they pay the lookup on every call and the new option goes unused.

## What changed

- `skills/uipath-test/SKILL.md` — a "Naming the project" section immediately before the command tables.
- `skills/uipath-test/references/publish-and-link-guide.md` — one line pointing at it, since that flow runs five commands against a single project.

I added a section rather than rewriting every table row to show both flags. There are ~40 rows; showing `--project-key <KEY> | --project-id <UUID>` in each would roughly double their width for no new information. The section states that the ID may be substituted anywhere the tables show a key.

It also names the commands that take `--project-key` only — `project create` / `update` / `delete`, `project owners list`, `tm pack` — so an agent doesn't try the ID there and hit a parse error. On those, the key is the subject of the command rather than a way to reach an ID.

## Checks

- `node scripts/check-skill-links.mjs` — 6462 links resolve (this change adds one anchor link).
- `node scripts/compose-skill-flavor.mjs validate` — OK, 27 skills both flavors.

Docs only; no hooks touched, so the twin-hook rule doesn't apply.

Draft because the CLI side is still a draft — this should land after, or with, UiPath/cli#3897, since the guidance is wrong until `--project-id` ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TMHUB-33023]: https://uipath.atlassian.net/browse/TMHUB-33023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ