### PR TITLE
fix(uipath-api-workflow): require publish approval before inspecting `publish --help` in Studio Web [PILOT-7268]

### DIFF
--- a/skill-flavors/studioweb/uipath-api-workflow/SKILL.md
+++ b/skill-flavors/studioweb/uipath-api-workflow/SKILL.md
@@ -13,7 +13,7 @@ Studio Web provides a browser sandbox, a virtual `/solution` filesystem, an embe
 - **Activity discovery:** use `ExecuteBashCommand` for `uip api-workflow registry resolve` / `stub` and read-only Integration Service discovery such as `uip is connectors list`, `activities list`, `connections list` / `ping`, and `resources list` / `describe`. Authentication comes from the active Studio Web session. Keep `--output json` whenever output is parsed.
 - **Validation:** from the target project root, run `uip api-workflow validate Workflow.json --output json` until `Data.Status` is `Valid`.
 - **Execution:** state concrete external side effects and require an explicit user yes. Then inspect `/skills/synthetic/proxy-tools-Api/SKILL.md`, inspect the live `RunProject` schema, invoke exactly its declared fields for the target project, and use the actual tool result as evidence.
-- **Publication:** for an explicit publish request, obtain publish approval first; then optionally inspect `uip solution publish --help` and run host-intercepted `uip solution publish` with supported flags. The active solution is implicit. Treat command success as request acceptance and verify final completion in Studio Web's Publish history.
+- **Publication:** for an explicit approved publish request, run host-intercepted `uip solution publish` with supported flags. The active solution is implicit. Treat command success as request acceptance and verify final completion in Studio Web's Publish history.
 
 Authentication and tenant context are inherited from the active Studio Web session. Report authentication or capability failures as host-level blockers and retry after the relevant host state changes.
 <!--skill-flavor:host-command-contract:end-->
@@ -67,7 +67,7 @@ From the target project directory, run `uip api-workflow validate Workflow.json 
 <!--skill-flavor:validation-run-lifecycle:end-->
 
 <!--skill-flavor:deployment-lifecycle:start-->
-For an explicit publish request, obtain publish approval first; then optionally inspect `uip solution publish --help` and invoke host-intercepted `uip solution publish` for the active solution with supported flags: `--description`, `--release-notes`, `--version`, `--location`, `--location-name`, and `--personal-workspace`. On hosts that predate help interception, `uip solution publish --help` performs a real publish — never run it before approval. Command success means Unified Build accepted the request and started background packaging. Verify the terminal status in Studio Web's Publish history. Use schema-inspected host capabilities for other lifecycle and published-workflow operations.
+For an explicit publish request, obtain publish approval first; then optionally inspect `uip solution publish --help` and invoke host-intercepted `uip solution publish` for the active solution with supported flags: `--description`, `--release-notes`, `--version`, `--location`, `--location-name`, and `--personal-workspace`. Command success means Unified Build accepted the request and started background packaging. Verify the terminal status in Studio Web's Publish history. Use schema-inspected host capabilities for other lifecycle and published-workflow operations.
 <!--skill-flavor:deployment-lifecycle:end-->
 
 <!--skill-flavor:runtime-troubleshooting:start-->
@@ -81,7 +81,7 @@ Fix failures in category order — **Structure > Expression > Activity Config > 
 2. Call `CreateProjects` for an API Workflow project using the schema-declared parameters and enum values.
 3. Verify the returned `/solution/<projectName>` directory, then edit `/solution/<projectName>/Workflow.json` and add user activities after `WorkflowStart` inside the root sequence.
 4. Set the embedded command working directory to `/solution/<projectName>`. Run `uip api-workflow validate Workflow.json --output json` until valid. State side effects and ask for explicit consent; on approval, inspect `/skills/synthetic/proxy-tools-Api/SKILL.md` and invoke the live `RunProject` operation with exactly its schema-declared fields.
-5. When publication is explicitly requested, obtain approval first, then optionally inspect `uip solution publish --help` and run host-intercepted `uip solution publish` for the active solution with supported bridge flags. Treat acceptance as background work and verify completion in Studio Web's Publish history.
+5. When publication is explicitly requested, obtain approval and run host-intercepted `uip solution publish` for the active solution with supported bridge flags. Treat acceptance as background work and verify completion in Studio Web's Publish history.
 <!--skill-flavor:quick-start-create:end-->
 
 <!--skill-flavor:project-creation-antipatterns:start-->

--- a/skill-flavors/studioweb/uipath-api-workflow/SKILL.md
+++ b/skill-flavors/studioweb/uipath-api-workflow/SKILL.md
@@ -13,7 +13,7 @@ Studio Web provides a browser sandbox, a virtual `/solution` filesystem, an embe
 - **Activity discovery:** use `ExecuteBashCommand` for `uip api-workflow registry resolve` / `stub` and read-only Integration Service discovery such as `uip is connectors list`, `activities list`, `connections list` / `ping`, and `resources list` / `describe`. Authentication comes from the active Studio Web session. Keep `--output json` whenever output is parsed.
 - **Validation:** from the target project root, run `uip api-workflow validate Workflow.json --output json` until `Data.Status` is `Valid`.
 - **Execution:** state concrete external side effects and require an explicit user yes. Then inspect `/skills/synthetic/proxy-tools-Api/SKILL.md`, inspect the live `RunProject` schema, invoke exactly its declared fields for the target project, and use the actual tool result as evidence.
-- **Publication:** for an explicit approved publish request, run host-intercepted `uip solution publish` with supported flags. The active solution is implicit. Treat command success as request acceptance and verify final completion in Studio Web's Publish history.
+- **Publication:** for an explicit approved publish request, run host-intercepted `uip solution publish` with supported flags. The active solution is implicit. Read the terminal state from the command output; a client-side pack or upload failure exits nonzero. Orchestrator deployment is never confirmed by the command — confirm the published version with `uip or packages versions <packageName> --folder-path <path>`.
 
 Authentication and tenant context are inherited from the active Studio Web session. Report authentication or capability failures as host-level blockers and retry after the relevant host state changes.
 <!--skill-flavor:host-command-contract:end-->
@@ -67,7 +67,7 @@ From the target project directory, run `uip api-workflow validate Workflow.json 
 <!--skill-flavor:validation-run-lifecycle:end-->
 
 <!--skill-flavor:deployment-lifecycle:start-->
-For an explicit publish request, obtain publish approval first; then optionally inspect `uip solution publish --help` and invoke host-intercepted `uip solution publish` for the active solution with supported flags: `--description`, `--release-notes`, `--version`, `--location`, `--location-name`, and `--personal-workspace`. Command success means Unified Build accepted the request and started background packaging. Verify the terminal status in Studio Web's Publish history. Use schema-inspected host capabilities for other lifecycle and published-workflow operations.
+For an explicit publish request, obtain publish approval first; then optionally inspect `uip solution publish --help` and invoke host-intercepted `uip solution publish` for the active solution with supported flags: `--description`, `--release-notes`, `--version`, `--location`, `--location-name`, and `--personal-workspace`. Command output names the state reached: package built and uploaded, packaging on the server, or packaging still running in the tab after the command stopped waiting; a nonzero exit means the publish failed. No state confirms Orchestrator deployment — confirm the published version with `uip or packages versions <packageName> --folder-path <path>`. Studio Web's Publish history is a human-only check. Use schema-inspected host capabilities for other lifecycle and published-workflow operations.
 <!--skill-flavor:deployment-lifecycle:end-->
 
 <!--skill-flavor:runtime-troubleshooting:start-->
@@ -81,7 +81,7 @@ Fix failures in category order — **Structure > Expression > Activity Config > 
 2. Call `CreateProjects` for an API Workflow project using the schema-declared parameters and enum values.
 3. Verify the returned `/solution/<projectName>` directory, then edit `/solution/<projectName>/Workflow.json` and add user activities after `WorkflowStart` inside the root sequence.
 4. Set the embedded command working directory to `/solution/<projectName>`. Run `uip api-workflow validate Workflow.json --output json` until valid. State side effects and ask for explicit consent; on approval, inspect `/skills/synthetic/proxy-tools-Api/SKILL.md` and invoke the live `RunProject` operation with exactly its schema-declared fields.
-5. When publication is explicitly requested, obtain approval and run host-intercepted `uip solution publish` for the active solution with supported bridge flags. Treat acceptance as background work and verify completion in Studio Web's Publish history.
+5. When publication is explicitly requested, obtain approval and run host-intercepted `uip solution publish` for the active solution with supported bridge flags. Read the terminal state from the command output and confirm the published version with `uip or packages versions <packageName> --folder-path <path>`.
 <!--skill-flavor:quick-start-create:end-->
 
 <!--skill-flavor:project-creation-antipatterns:start-->

--- a/skill-flavors/studioweb/uipath-api-workflow/SKILL.md
+++ b/skill-flavors/studioweb/uipath-api-workflow/SKILL.md
@@ -13,7 +13,7 @@ Studio Web provides a browser sandbox, a virtual `/solution` filesystem, an embe
 - **Activity discovery:** use `ExecuteBashCommand` for `uip api-workflow registry resolve` / `stub` and read-only Integration Service discovery such as `uip is connectors list`, `activities list`, `connections list` / `ping`, and `resources list` / `describe`. Authentication comes from the active Studio Web session. Keep `--output json` whenever output is parsed.
 - **Validation:** from the target project root, run `uip api-workflow validate Workflow.json --output json` until `Data.Status` is `Valid`.
 - **Execution:** state concrete external side effects and require an explicit user yes. Then inspect `/skills/synthetic/proxy-tools-Api/SKILL.md`, inspect the live `RunProject` schema, invoke exactly its declared fields for the target project, and use the actual tool result as evidence.
-- **Publication:** for an explicit approved publish request, optionally inspect `uip solution publish --help`, then run host-intercepted `uip solution publish` with supported flags. The active solution is implicit. Treat command success as request acceptance and verify final completion in Studio Web's Publish history.
+- **Publication:** for an explicit publish request, obtain publish approval first; then optionally inspect `uip solution publish --help` and run host-intercepted `uip solution publish` with supported flags. The active solution is implicit. Treat command success as request acceptance and verify final completion in Studio Web's Publish history.
 
 Authentication and tenant context are inherited from the active Studio Web session. Report authentication or capability failures as host-level blockers and retry after the relevant host state changes.
 <!--skill-flavor:host-command-contract:end-->
@@ -67,7 +67,7 @@ From the target project directory, run `uip api-workflow validate Workflow.json 
 <!--skill-flavor:validation-run-lifecycle:end-->
 
 <!--skill-flavor:deployment-lifecycle:start-->
-For an explicit publish request, optionally inspect `uip solution publish --help`, obtain publish approval, and invoke host-intercepted `uip solution publish` for the active solution with supported flags: `--description`, `--release-notes`, `--version`, `--location`, `--location-name`, and `--personal-workspace`. Command success means Unified Build accepted the request and started background packaging. Verify the terminal status in Studio Web's Publish history. Use schema-inspected host capabilities for other lifecycle and published-workflow operations.
+For an explicit publish request, obtain publish approval first; then optionally inspect `uip solution publish --help` and invoke host-intercepted `uip solution publish` for the active solution with supported flags: `--description`, `--release-notes`, `--version`, `--location`, `--location-name`, and `--personal-workspace`. On hosts that predate help interception, `uip solution publish --help` performs a real publish — never run it before approval. Command success means Unified Build accepted the request and started background packaging. Verify the terminal status in Studio Web's Publish history. Use schema-inspected host capabilities for other lifecycle and published-workflow operations.
 <!--skill-flavor:deployment-lifecycle:end-->
 
 <!--skill-flavor:runtime-troubleshooting:start-->
@@ -81,7 +81,7 @@ Fix failures in category order — **Structure > Expression > Activity Config > 
 2. Call `CreateProjects` for an API Workflow project using the schema-declared parameters and enum values.
 3. Verify the returned `/solution/<projectName>` directory, then edit `/solution/<projectName>/Workflow.json` and add user activities after `WorkflowStart` inside the root sequence.
 4. Set the embedded command working directory to `/solution/<projectName>`. Run `uip api-workflow validate Workflow.json --output json` until valid. State side effects and ask for explicit consent; on approval, inspect `/skills/synthetic/proxy-tools-Api/SKILL.md` and invoke the live `RunProject` operation with exactly its schema-declared fields.
-5. When publication is explicitly requested, optionally inspect `uip solution publish --help`, obtain approval, and run host-intercepted `uip solution publish` for the active solution with supported bridge flags. Treat acceptance as background work and verify completion in Studio Web's Publish history.
+5. When publication is explicitly requested, obtain approval first, then optionally inspect `uip solution publish --help` and run host-intercepted `uip solution publish` for the active solution with supported bridge flags. Treat acceptance as background work and verify completion in Studio Web's Publish history.
 <!--skill-flavor:quick-start-create:end-->
 
 <!--skill-flavor:project-creation-antipatterns:start-->

--- a/skill-flavors/studioweb/uipath-api-workflow/references/cli-reference.md
+++ b/skill-flavors/studioweb/uipath-api-workflow/references/cli-reference.md
@@ -92,7 +92,7 @@ Supported bridge flags:
 | `--location-name <value>` | Target location name accepted by the Studio Web bridge. |
 | `--personal-workspace` | Publish to the personal workspace target. |
 
-The active Studio Web solution is implicit. A successful command result means Unified Build accepted the request and background packaging began. Check Studio Web's Publish history for the final success or failure state.
+The active Studio Web solution is implicit. A successful command result names the state reached: package built and uploaded, packaging on the server, or packaging still running in the tab; a nonzero exit means the publish failed. Orchestrator deployment is never confirmed here — confirm the published version with `uip or packages versions <packageName> --folder-path <path>`.
 <!--skill-flavor:local-solution-lifecycle:end-->
 
 <!--skill-flavor:command-existence-guidance:start-->

--- a/skill-flavors/studioweb/uipath-api-workflow/references/cli-reference.md
+++ b/skill-flavors/studioweb/uipath-api-workflow/references/cli-reference.md
@@ -69,7 +69,7 @@ Use `CreateProjects` for project creation and schema-inspected Studio Web capabi
 
 ### Publish the active Studio Web solution
 
-Studio Web intercepts `solution:publish` through Unified Build. The help form is read-only:
+Studio Web intercepts `solution:publish` through Unified Build. After publish approval, inspect the supported flags and destinations — on hosts that predate help interception this command performs a real publish, so never run it before approval:
 
 ```bash
 uip solution publish --help

--- a/skill-flavors/studioweb/uipath-api-workflow/references/cli-reference.md
+++ b/skill-flavors/studioweb/uipath-api-workflow/references/cli-reference.md
@@ -69,7 +69,7 @@ Use `CreateProjects` for project creation and schema-inspected Studio Web capabi
 
 ### Publish the active Studio Web solution
 
-Studio Web intercepts `solution:publish` through Unified Build. After publish approval, inspect the supported flags and destinations — on hosts that predate help interception this command performs a real publish, so never run it before approval:
+Studio Web intercepts `solution:publish` through Unified Build. The help form is read-only and lists the supported flags and publish destinations:
 
 ```bash
 uip solution publish --help

--- a/skill-flavors/studioweb/uipath-api-workflow/references/troubleshooting.md
+++ b/skill-flavors/studioweb/uipath-api-workflow/references/troubleshooting.md
@@ -144,7 +144,7 @@ Host-intercepted publication starts Unified Build packaging in the background. A
 
 First distinguish bridge rejection from background failure:
 
-- After publish approval, `uip solution publish --help` confirms the supported bridge flags and destinations (hosts that predate help interception treat it as a real publish).
+- `uip solution publish --help` confirms the supported bridge flags and destinations.
 - For an explicit approved publication, invoke `uip solution publish [--description <text>] [--release-notes <text>] [--version <version>] [--location <value>] [--location-name <value>] [--personal-workspace]` for the active solution.
 - Immediate command failure is a request, flag, or authorization problem; report the exact host result.
 - Immediate success means request accepted. Check Studio Web's Publish history for the terminal packaging and publication status and diagnose from that entry.

--- a/skill-flavors/studioweb/uipath-api-workflow/references/troubleshooting.md
+++ b/skill-flavors/studioweb/uipath-api-workflow/references/troubleshooting.md
@@ -144,7 +144,7 @@ Host-intercepted publication starts Unified Build packaging in the background. A
 
 First distinguish bridge rejection from background failure:
 
-- `uip solution publish --help` confirms the supported bridge flags.
+- After publish approval, `uip solution publish --help` confirms the supported bridge flags and destinations (hosts that predate help interception treat it as a real publish).
 - For an explicit approved publication, invoke `uip solution publish [--description <text>] [--release-notes <text>] [--version <version>] [--location <value>] [--location-name <value>] [--personal-workspace]` for the active solution.
 - Immediate command failure is a request, flag, or authorization problem; report the exact host result.
 - Immediate success means request accepted. Check Studio Web's Publish history for the terminal packaging and publication status and diagnose from that entry.

--- a/skill-flavors/studioweb/uipath-api-workflow/references/troubleshooting.md
+++ b/skill-flavors/studioweb/uipath-api-workflow/references/troubleshooting.md
@@ -136,7 +136,7 @@ Inspect the live Studio Web diagnostic or published-workflow tool schema and use
 <!--skill-flavor:local-packaging-errors:start-->
 ## Packaging Errors in Studio Web
 
-Host-intercepted publication starts Unified Build packaging in the background. A successful `uip solution publish` response means the request was accepted. Inspect Studio Web's Publish history for the final packaging or publication error. Use the host-generated project tree and `CreateProjects` result as project evidence.
+Host-intercepted publication starts Unified Build packaging in the background. The `uip solution publish` output names the state reached; a client-side pack or upload failure exits nonzero. Confirm the published version with `uip or packages versions <packageName> --folder-path <path>`. Use the host-generated project tree and `CreateProjects` result as project evidence.
 <!--skill-flavor:local-packaging-errors:end-->
 
 <!--skill-flavor:local-publish-errors:start-->
@@ -147,7 +147,7 @@ First distinguish bridge rejection from background failure:
 - `uip solution publish --help` confirms the supported bridge flags and destinations.
 - For an explicit approved publication, invoke `uip solution publish [--description <text>] [--release-notes <text>] [--version <version>] [--location <value>] [--location-name <value>] [--personal-workspace]` for the active solution.
 - Immediate command failure is a request, flag, or authorization problem; report the exact host result.
-- Immediate success means request accepted. Check Studio Web's Publish history for the terminal packaging and publication status and diagnose from that entry.
+- Immediate success names the state reached: built and uploaded, packaging on the server, or still packaging in the tab. Confirm the published version with `uip or packages versions <packageName> --folder-path <path>`; Studio Web's Publish history is a human-only check.
 <!--skill-flavor:local-publish-errors:end-->
 
 <!--skill-flavor:outbound-ip-symptom:start-->


### PR DESCRIPTION
## Problem

[PILOT-7268](https://uipath.atlassian.net/browse/PILOT-7268): in Studio Web, `uip solution publish --help` did not print help — the host's publish interceptor had no help branch, so the command performed a **real publish of the active solution to the Personal Workspace**.

The studioweb flavor of `uipath-api-workflow` made this worse by telling the agent to inspect `uip solution publish --help` **before** obtaining publish approval — so the "safe" inspection step shipped an unapproved package version and burned the next auto-resolved version number.

The host-side fix (help interception that returns usage instead of publishing) lands in [UiPath/Autopilot#5453](https://github.com/UiPath/Autopilot/pull/5453); this PR assumes hosts ship that fix.

## Changes (studioweb flavor of `uipath-api-workflow` only)

- Publish instructions require approval before any `--help` inspection, and the optional `uip solution publish --help` inspection is now mentioned only once, in the deployment-lifecycle block (removed from the host-command-contract bullet and quick-start step 5).
- `references/cli-reference.md`: the help form is documented as read-only, listing the supported flags and publish destinations (the fixed help output enumerates destinations, making it genuinely useful for picking `--location`).
- `references/troubleshooting.md`: the `--help` diagnostic step now also mentions destinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PILOT-7268]: https://uipath.atlassian.net/browse/PILOT-7268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ