### PR TITLE
fix(uipath-agents): surface LangGraph retriever guidance where agents actually read

### DIFF
--- a/skills/uipath-agents/references/coded/frameworks/langgraph-integration.md
+++ b/skills/uipath-agents/references/coded/frameworks/langgraph-integration.md
@@ -283,6 +283,54 @@ Or have the terminal node compute the full aggregate and emit it.
 
 ---
 
+## Available Tools
+
+The `uipath-langchain` package provides UiPath-specific LangChain tools:
+
+| Tool | Import | Purpose |
+|------|--------|---------|
+| Process invocation | `uipath_langchain.agent.tools import create_process_tool` | Trigger UiPath processes |
+| Escalation (HITL) | `uipath_langchain.agent.tools import create_escalation_tool` | Send to human reviewer |
+| Context search | `uipath_langchain.retrievers import ContextGroundingRetriever` | Search Context Grounding indexes |
+| MCP tools | `uipath_langchain.agent.tools import open_mcp_tools` | Connect to MCP servers |
+
+> **Context Grounding retrieval in LangGraph:** always use `ContextGroundingRetriever` from `uipath_langchain.retrievers` — not `sdk.context_grounding.search()` / `search_async()`. The LangChain retriever integrates natively with the graph pipeline and declares `index_name` + `folder_path` at one call site — the exact shape the `index` binding entry needs (see [../lifecycle/bindings-reference.md](../lifecycle/bindings-reference.md)). See [../capabilities/context-grounding.md](../capabilities/context-grounding.md) for usage examples.
+
+### Context Grounding RAG Example
+
+Minimal RAG shape: retrieval node + answer node.
+
+```python
+from typing import TypedDict
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from uipath_langchain.chat.models import UiPathAzureChatOpenAI
+from uipath_langchain.retrievers import ContextGroundingRetriever
+
+class GraphState(TypedDict):
+    question: str
+    snippets: list[str]
+    answer: str
+
+async def retrieve(state: GraphState) -> dict:
+    retriever = ContextGroundingRetriever(index_name="company_docs", folder_path="Shared")
+    documents = await retriever.ainvoke(state["question"])
+    return {"snippets": [doc.page_content for doc in documents]}
+
+async def answer(state: GraphState) -> dict:
+    context = "\n\n".join(state["snippets"])
+    llm = UiPathAzureChatOpenAI(temperature=0)
+    response = await llm.ainvoke([
+        SystemMessage(content="Answer only from the provided context."),
+        HumanMessage(content=f"Context:\n{context}\n\nQuestion: {state['question']}"),
+    ])
+    return {"answer": response.content}
+```
+
+Wire `retrieve → answer` as in § Building the Graph.
+
+---
+
 ## Tracing
 
 LangGraph agents get **automatic tracing** — you do NOT need `@traced()` on graph nodes. The UiPath LangGraph runtime instruments all node executions, LLM calls, and tool invocations automatically.
@@ -393,19 +441,3 @@ Both are valid — pick based on the agent's needs:
 See `../capabilities/conversational-agents.md` § Running Locally for the `--keep-state-file` flag (required on every turn) and § Wire Envelope for the `turn1.json` shape.
 
 ---
-
-## Available Tools
-
-The `uipath-langchain` package provides UiPath-specific LangChain tools:
-
-| Tool | Import | Purpose |
-|------|--------|---------|
-| Process invocation | `uipath_langchain.agent.tools import create_process_tool` | Trigger UiPath processes |
-| Escalation (HITL) | `uipath_langchain.agent.tools import create_escalation_tool` | Send to human reviewer |
-| Context search | `uipath_langchain.retrievers import ContextGroundingRetriever` | Search Context Grounding indexes |
-| MCP tools | `uipath_langchain.agent.tools import open_mcp_tools` | Connect to MCP servers |
-
-> **Context Grounding retrieval in LangGraph:** always use `ContextGroundingRetriever` from `uipath_langchain.retrievers` — not `sdk.context_grounding.search()` / `search_async()`. The LangChain retriever integrates natively with the graph pipeline and auto-generates the correct `index` binding. See [../capabilities/context-grounding.md](../capabilities/context-grounding.md) for usage examples.
-
----
-


### PR DESCRIPTION
## Problem

Nightly `skill-agent-coded-rag-langgraph` failed (0.2, codex/gpt-5.6-terra): the agent built a functionally correct RAG agent but used `ContextGroundingVectorStore` instead of the mandated `ContextGroundingRetriever`, failing the shape checker.

Root cause from the run transcript: the "**always use `ContextGroundingRetriever`**" callout sat at **line 408 of 411** in `langgraph-integration.md` — the agent read only `sed -n '1,260p'` / `'1,300p'` windows and never reached it, while `context-grounding.md` (which it read in full) presents a VectorStore-based "RAG Pattern" with no LangGraph steer.

## Changes (single file: `langgraph-integration.md`)

- **Move `## Available Tools`** (with the retriever callout) from the file tail to just before `## Tracing`, adjacent to the design-time/authoring sections — inside the window partial reads actually cover
- **Add `### Context Grounding RAG Example`**: minimal `retrieve → answer` graph, `ContextGroundingRetriever(index_name=..., folder_path=...)` and LLM constructed inside node bodies
- **Correct an unsupported claim** in the callout ("auto-generates the correct `index` binding"): verified empirically that `uip codedagent init` regenerates only an empty bindings skeleton (`"resources": []`) — the retriever *declares* `index_name` + `folder_path` in the shape the `index` binding entry needs; the entry itself comes from the `bindings-reference.md` sync workflow

## Validation

- `npm run skills:validate` — OK (default + studioweb; file has no flavor markers/overrides)
- `npm run skills:check-links` — all 6,461 links resolve
- Task re-run locally against the updated skill, **1.0 on both harnesses**: claude-code / claude-sonnet-5 (221s) and codex / gpt-5.6-terra (133s)

Note: both harnesses also passed pre-change locally — the nightly failure is probabilistic (read-window dependent), so the real confirmation signal is the next few nightly codex runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)