### PR TITLE
fix(maestro-flow): sync registry command guidance

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 67710ff. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 7fb8412. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 67710ff. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 7fb8412. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 67710ff. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 7fb8412. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -43,7 +43,7 @@ packaged-SDK local gates, which never scaffold a project; pick the loop first
 
 Integrations with non-UiPath systems are handled through connectors.
 Connectors require a root-level [`bindings.json`](references/bindings.md).
-`uip maestro registry pull` writes a descriptor per referenced connector to `connectors/<key>.ts`, and caches the library itself outside the project.
+`npx flow-sdk registry pull` writes a descriptor per referenced connector to `connectors/<key>.ts`, and caches the library itself outside the project.
 Prepared connector modules live at `connectors-local/<key>.ts`; their descriptor data is kept separately below `connectors-local/descriptors/<key>/`.
 
 ### Hello world Flow

--- a/preview/uipath-maestro-flow/references/bindings.md
+++ b/preview/uipath-maestro-flow/references/bindings.md
@@ -17,7 +17,7 @@ connectors-local/
       ...generated descriptor data...
 ```
 
-`uip maestro registry prepare` prints the import for
+`npx flow-sdk registry prepare` prints the import for
 `connectors-local/<connector-key>.ts`.
 The generated descriptor data lives below `connectors-local/descriptors/`; do
 not import it directly. `bindings.json` stays at the root and is independent of

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -48,7 +48,7 @@ environment. It is not baked into the npm package, so when those variables are
 unset, fetch one into the project:
 
 ```bash
-uip maestro registry pull
+npx flow-sdk registry pull
 ```
 
 The library and its Markdown go to a shared cache
@@ -59,17 +59,15 @@ The library and its Markdown go to a shared cache
 To read the Markdown directly, ask where it is:
 
 ```bash
-FLOW_SDK_LIBRARY_MD="$(uip maestro registry path --library-md)"
+FLOW_SDK_LIBRARY_MD="$(npx flow-sdk registry path --library-md)"
 ```
 
-The four library verbs are `pull`, `search`, `path` and `prepare`. Like the
-authoring verbs they need a prerelease `@uipath/cli`, and they hold no logic of
-their own — each one runs the `@uipath/flow-sdk` installed in this workspace. In
-a workspace with no `uip`, `npx flow-sdk registry <verb>` is the same command
-with the same arguments.
+The four library verbs are `pull`, `search`, `path` and `prepare`. Run them
+through the `flow-sdk` binary installed in this workspace; `npx` resolves that
+local package without downloading another version.
 
-**`uip maestro registry` is not `uip maestro flow registry`.** The names are one
-word apart and the jobs are unrelated: this one is the connector library the
+**`flow-sdk registry` is not `uip maestro flow registry`.** The names are
+similar but the jobs are unrelated: the former is the connector library the
 compilers resolve operations against, while `uip maestro flow registry
 pull|search|get` syncs the tenant's **node manifests** — the node types other
 references reach for (`uipath.core.function`, `uipath.core.agent.<name>`). A
@@ -90,10 +88,10 @@ the tenant, so it needs a live Integration Service connection and a logged-in
 `uip`; without one, fall back to the curated operation in the markdown library.
 
 ```bash
-uip maestro registry prepare <connector-key> <action> \
+npx flow-sdk registry prepare <connector-key> <action> \
   --connection-id <connection-id>
 # Generic operation: materialize the one connected object the task uses.
-uip maestro registry prepare <connector-key> <action> \
+npx flow-sdk registry prepare <connector-key> <action> \
   --connection-id <connection-id> --object <api-object-name>
 # Use --all-objects only when the task truly needs the full connected catalog.
 ```
@@ -283,7 +281,7 @@ For Jira, `/project/{key}/issuetypes` has no object of its own; `project_statuse
 **3. Prepare with every parent.** Pass them all as `-f NAME=VALUE`:
 
 ```bash
-uip maestro registry prepare <connector-key> <action> --connection-id <connection-id> \
+npx flow-sdk registry prepare <connector-key> <action> --connection-id <connection-id> \
   -f fields.project.key=IN -f fields.issuetype.id=10620
 ```
 


### PR DESCRIPTION
## Summary

- sync the Maestro Flow preview skill from `UiPath/flow-builder-sdk@7fb8412`
- replace removed `uip maestro registry` commands with the installed `npx flow-sdk registry` binary
- retain generated-source provenance for Flow, Case, and BPMN snapshots

## Verification

- `node --test tests/scripts/sync-maestro-sdk-preview.test.mjs` (2 passed)
- `npm run skills:validate`
- `npm run skills:check-links`
- `git diff --check`

The broader `npm run skills:test` suite passed 50/52; two existing npm publish dry-run assertions fail because npm refuses to apply `latest` to the fixtures prerelease/lower versions.

## RCA evidence

The `uipath-maestro-flow` v1/v2 cohort repeatedly followed the old command, received `unknown command prepare`, and emitted a Jira schema-dynamic connector without `customFieldsRequestDetails`.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)