### PR TITLE
fix(maestro-bpmn): batch registry-get calls, forbid CLI-bundle spelunking

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -159,8 +159,11 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    every selection with the user (use AskUserQuestion). Never fabricate an identifier.
    See [references/registry-workflow.md](references/registry-workflow.md).
 2. **Get templates.** `uip maestro bpmn registry get <type> --output json` for
-   each chosen registry-owned node only. Enrich `Intsvc.*` connector nodes with
-   `--connection-id`/`--object-name`. Do not call `registry get` for structural
+   each chosen registry-owned node only. Fetch every chosen template in **one**
+   Bash call, not one command per turn — each shell round-trip is a model turn
+   and dozens of them exhaust the run's time budget before authoring finishes:
+   `for t in TypeA TypeB TypeC; do uip maestro bpmn registry get "$t" --output json; done`.
+   Enrich `Intsvc.*` connector nodes with `--connection-id`/`--object-name`. Do not call `registry get` for structural
    gaps the registry never owns: sequence flows, gateways, events, boundary
    events, multi-instance/loop markers, `errorMapping`/retry structure, or
    diagrams. If a registry template's BPMN host tag is PascalCase (for example
@@ -171,8 +174,9 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    [references/structural-bpmn.md](references/structural-bpmn.md#a-complete-minimal-file-author-from-this-not-from-examples)
    plus each node's `xmlTemplate` (fill placeholders only). That skeleton already
    shows variables, the entry point, a branch, and the diagram. **Do not
-   reverse-engineer authoring patterns from task fixtures or generated package
-   files** — fixture spelunking is the top reason authoring runs out of time.
+   reverse-engineer authoring patterns from task fixtures, generated package
+   files, or the CLI's compiled bundle (`@uipath/cli/dist/*.js`)** — such
+   spelunking is the top reason authoring runs out of time.
    Add only the structural pieces your process needs (extra
    gateways, events, boundary events, containers, multi-instance markers,
    expression/error mappings, retry attributes), then run


### PR DESCRIPTION
## Why

Today's coder-eval daily (`2026-08-31_04-15-47`, claude-code / sonnet-5) failed **15 `uipath-maestro-bpmn` tasks on `agent_timeout`** while the Codex daily passed all of them (Claude 62/79 vs Codex 78/79 on the `uipath-maestro-bpmn` tag).

Root-cause from each task's `task.json`:
- **~96% of the 900s/1200s budget is model latency**, not tool execution — tool exec is only **12–37s** for 13 of 15 tasks.
- The agent runs **52–193 assistant turns / 55–96 Bash calls** per task; on Sonnet-5/Bedrock's per-turn latency this blows the single streamed-turn wall clock before the graded deliverable is done.
- Codex completes the identical tasks in **1 turn / ~90–180s**.

The dominant cost is harness/model throughput (coder_eval runs the whole task as one `turn_timeout=900s` streamed turn) — raised separately with the harness team. This PR is an **interim, skill-side turn-reducer**.

## Change

Two targeted edits to `skills/uipath-maestro-bpmn/SKILL.md`. Main already carries generic batching guidance in its Working-style header; these operationalize it for the observed hot paths:

1. **Step 2 — batch `registry get`:** fetch all chosen templates in one Bash loop instead of one `registry get` per turn.
2. **Step 3 — anti-spelunking:** extend the existing "don't reverse-engineer from fixtures/package files" rule to the CLI's compiled bundle (`@uipath/cli/dist/*.js`). One task (`event-based-gateway`) burned ~74s grepping it to infer schema.

Body-only edit — `description` frontmatter untouched (no activation-gate impact).

## Validation

coder-eval dispatched on the 15 timeout tasks from this branch (link in comments). Success bar: the timeouts convert to completed runs and turn count drops materially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
