### PR TITLE
test(maestro-bpmn): generous task/turn timeouts for 15 slow BPMN tasks

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/author/gateway_sequence_flows.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/gateway_sequence_flows.yaml
@@ -5,6 +5,8 @@ description: >
 tags: [uipath-maestro-bpmn, smoke, mode:build, lifecycle:generate, shape:multi-node, node:gateway]
 
 run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
   expected_turns: 21
   max_turns: 80
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-bpmn/author/simple_approval_bpmn.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/simple_approval_bpmn.yaml
@@ -7,6 +7,8 @@ description: >
 tags: [uipath-maestro-bpmn, integration, "mode:build", lifecycle:generate, shape:multi-node, node:gateway, node:script, node:service-task, resource]
 
 run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
   expected_turns: 24
   max_turns: 90
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-bpmn/e2e/invoice_exception_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/invoice_exception_triage.yaml
@@ -8,8 +8,9 @@ description: >
 tags: [uipath-maestro-bpmn, e2e, "mode:build", "lifecycle:generate", "shape:multi-node", "node:decision", "node:hitl", "feature:approval-gate"]
 
 run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
   expected_turns: 25
-  turn_timeout: 1200
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-maestro-bpmn/expressions/error_mapping/error_mapping.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/expressions/error_mapping/error_mapping.yaml
@@ -8,6 +8,8 @@ description: >
 tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate"]
 
 run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
   expected_turns: 18
   max_turns: 75
 

--- a/tests/tasks/uipath-maestro-bpmn/hitl/smoke_completed_wired/smoke_completed_wired.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/hitl/smoke_completed_wired/smoke_completed_wired.yaml
@@ -7,6 +7,8 @@ description: >
 tags: [uipath-maestro-bpmn, smoke, "mode:build", "lifecycle:generate", "shape:multi-node", "node:hitl", "feature:approval-gate"]
 
 run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
   expected_turns: 18
   max_turns: 80
 

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -11,8 +11,9 @@ description: >
 tags: [uipath-maestro-bpmn, e2e, "mode:build", "lifecycle:generate", "shape:multi-node", "node:decision", "node:transform"]
 
 run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
   expected_turns: 28
-  turn_timeout: 1200
   max_turns: 90
 
 sandbox:

--- a/tests/tasks/uipath-maestro-bpmn/patterns/approval_chain/near_miss.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/patterns/approval_chain/near_miss.yaml
@@ -8,6 +8,8 @@ description: >
 tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:hitl"]
 
 run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
   expected_turns: 28
   max_turns: 70
 

--- a/tests/tasks/uipath-maestro-bpmn/patterns/composition/nested_review.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/patterns/composition/nested_review.yaml
@@ -8,8 +8,9 @@ description: >
 tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:hitl"]
 
 run_limits:
-  expected_turns: 45
+  task_timeout: 2400
   turn_timeout: 1800
+  expected_turns: 45
   max_turns: 90
 
 sandbox:

--- a/tests/tasks/uipath-maestro-bpmn/patterns/external_wait/greenfield.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/patterns/external_wait/greenfield.yaml
@@ -7,6 +7,8 @@ description: >
 tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node"]
 
 run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
   expected_turns: 42
   max_turns: 70
 

--- a/tests/tasks/uipath-maestro-bpmn/patterns/failure_escalation/greenfield.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/patterns/failure_escalation/greenfield.yaml
@@ -7,6 +7,8 @@ description: >
 tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:hitl"]
 
 run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
   expected_turns: 30
   max_turns: 70
 

--- a/tests/tasks/uipath-maestro-bpmn/patterns/high_volume_batch/greenfield.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/patterns/high_volume_batch/greenfield.yaml
@@ -6,6 +6,8 @@ description: >
 tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node"]
 
 run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
   expected_turns: 26
   max_turns: 70
 

--- a/tests/tasks/uipath-maestro-bpmn/patterns/no_pattern/no_pattern.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/patterns/no_pattern/no_pattern.yaml
@@ -7,6 +7,8 @@ description: >
 tags: [uipath-maestro-bpmn, smoke, "mode:build", "lifecycle:generate", "shape:multi-node"]
 
 run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
   expected_turns: 24
   max_turns: 40
 

--- a/tests/tasks/uipath-maestro-bpmn/patterns/queue_distribution/greenfield.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/patterns/queue_distribution/greenfield.yaml
@@ -6,8 +6,9 @@ description: >
 tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node"]
 
 run_limits:
-  expected_turns: 40
+  task_timeout: 2400
   turn_timeout: 1800
+  expected_turns: 40
   max_turns: 70
 
 sandbox:

--- a/tests/tasks/uipath-maestro-bpmn/patterns/smart_triage/greenfield.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/patterns/smart_triage/greenfield.yaml
@@ -6,8 +6,9 @@ description: >
 tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:hitl"]
 
 run_limits:
-  expected_turns: 26
+  task_timeout: 2400
   turn_timeout: 1800
+  expected_turns: 26
   max_turns: 70
 
 sandbox:

--- a/tests/tasks/uipath-maestro-bpmn/structural/event_based_gateway/event_based_gateway.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/structural/event_based_gateway/event_based_gateway.yaml
@@ -8,6 +8,8 @@ description: >
 tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "node:gateway"]
 
 run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
   expected_turns: 20
   max_turns: 80
 


### PR DESCRIPTION
## Why

Today's nightly (`2026-08-31_04-15-47`, claude-code / sonnet-5) failed **15 `uipath-maestro-bpmn` tasks on `agent_timeout`** while the Codex daily passed all of them (Claude 62/79 vs Codex 78/79 on the tag).

Investigation ([Slack thread](https://uipath-product.slack.com/archives/C0A2T23NJ59/p1788170582569059)) showed it is **model throughput, not correctness**: ~96% of the 900s/1200s budget is per-turn Bedrock latency across 52–193 assistant turns; Codex finishes the identical tasks in **one turn / ~90–180s**. Several tasks had a valid BPMN already authored when the clock killed them.

**Bai Li's call in the thread:** *"let's increase the timeouts of these tasks to something generous (so all harnesses have enough time even if codex doesn't need as much)."*

## Change

Adds a generous ceiling to all 15 tasks' `run_limits`:
- `task_timeout: 2400` (was inherited 1200)
- `turn_timeout: 1800` (was inherited 900)

**Key fix:** three tasks (`composition/nested_review`, `queue_distribution`, `smart_triage`) already set `turn_timeout: 1800` but **still hit TIMEOUT at 1200s** — because `task_timeout` was never overridden and stayed at the inherited 1200, capping the whole task before the raised turn budget could apply (that's why they showed `TIMEOUT`, not `ERROR`). This adds the missing `task_timeout` so the turn budget actually takes effect. `task_timeout` (2400) is kept above `turn_timeout` (1800) so the task wrapper never pre-empts the turn.

Fast harnesses (Codex, etc.) are unaffected — they finish in ~90–180s and never approach these caps.

## Scope
Config-only change to 15 task YAMLs (+30/−5). No skill content, no experiment defaults touched — the generous caps are scoped to exactly the tasks that need them.

## Validation
coder-eval dispatched on the 15 tasks from this branch (link in comments). Expectation: the `agent_timeout`/`TIMEOUT` failures convert to completed runs graded on merit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
