### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@d9cd1b2

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 67710ff. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ d9cd1b2. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 67710ff. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ d9cd1b2. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 67710ff. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ d9cd1b2. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -45,6 +45,21 @@ Integrations with non-UiPath systems are handled through connectors.
 Connectors require a root-level [`bindings.json`](references/bindings.md).
 `uip maestro registry pull` writes a descriptor per referenced connector to `connectors/<key>.ts`, and caches the library itself outside the project.
 Prepared connector modules live at `connectors-local/<key>.ts`; their descriptor data is kept separately below `connectors-local/descriptors/<key>/`.
+
+### Schema-dynamic connector gate
+
+If the request mentions `loadByDefault`, dependent dropdowns, preselected
+reference values, `customFieldsRequestDetails`, or other connection-specific
+fields, the static library descriptor is not sufficient. Before authoring the
+connector call, resolve the real parent values, run `uip maestro registry
+prepare <connector-key> <action> --connection-id <id>` with every required
+`-f NAME=VALUE`, and import the generated `connectors-local/<key>.ts` descriptor.
+
+Do not substitute manual `resources run list` lookups plus a static
+`connectors/<key>.ts` import: the lookups choose values but do not create the
+design-time schema-replay cache. After compiling, inspect the emitted connector
+configuration. `flow validate` can accept a missing cache, so completion requires
+non-null `customFieldsRequestDetails` whose parent values match the runtime inputs.
 
 ### Hello world Flow
 

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -186,6 +186,14 @@ That emits BOTH halves the artifact must carry: the runtime query at
 validation rejects a filter that has only one of the two, so a string alone
 fails `validate` even though the run would have worked.
 
+If the task also asks for the filter tree as a separate review artifact,
+compile first and copy the emitted
+`configuration.essentialConfiguration.savedFilterTrees.<parameter>` value
+verbatim into that file (directly or under a named top-level property). Do not
+replace it with an ad hoc `{ field, operator, value }` object or only the CEQL
+string. The serialized tree must retain its numeric `groupOperator` and
+`filters` array.
+
 Supported: `=` `!=` `<` `<=` `>` `>=`, `Contains`, `Starts With`, `Ends With`,
 `Like`, their `Not` forms, and `Is Null` / `Is Not Null`. Combine with `AND` or
 `OR`, and parenthesise to nest — `(a = 1 OR b = 2) AND c = 'x'`. Mixing `AND`


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `67710ff` to current `UiPath/flow-builder-sdk@main` (`d9cd1b2`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)