### PR TITLE
fix(maestro-flow): accept supported Slack lookup routes

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
@@ -210,3 +210,23 @@ def test_multiselect_prompt_names_slack_as_the_required_connector() -> None:
     prompt = _prompt_text(_task_text("connector_features/multiselect.yaml")).lower()
 
     assert "slack group direct message" in prompt
+
+
+def test_paginated_lookup_accepts_both_supported_resolution_routes() -> None:
+    text = _task_text("connector_features/paginated_reference_lookup.yaml")
+    patterns = re.findall(r"(?m)^\s+command_pattern:\s*'([^']+)'", text)
+    resolve_pattern, pagination_pattern = map(re.compile, patterns[:2])
+
+    manual_commands = (
+        "uip is resources run list uipath-salesforce-slack conversations "
+        "--connection-id id --query nextPage=token"
+    )
+    sdk_command = (
+        "uip maestro flow registry prepare uipath-salesforce-slack "
+        "send-message-to-channel --resolve channel:name=simple"
+    )
+
+    assert resolve_pattern.search(manual_commands)
+    assert pagination_pattern.search(manual_commands)
+    assert resolve_pattern.search(sdk_command)
+    assert pagination_pattern.search(sdk_command)

--- a/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
@@ -5,10 +5,10 @@ task_id: skill-flow-paginated-reference-lookup
 description: >
   Build a Flow with a Slack `Send Message to Channel` node targeting the
   `simple` channel. The channel lives on a later page of the `is-sandboxes`
-  curated_channels list, so resolving the Slack channel id forces the agent
-  to paginate `uip is resources run list`. Triggered by the `resources.md`
-  read-before-call rule added in #1059 (ENGCE-58198) — old behavior was to
-  abandon pagination after page 1 and bail to AskUserQuestion.
+  Slack channel resources, so resolving the Slack channel id requires either
+  explicit pagination or the SDK's lookup resolver. Triggered by the
+  `resources.md` read-before-call rule added in #1059 (ENGCE-58198) — old
+  behavior was to abandon pagination after page 1 and bail to AskUserQuestion.
 tags:
   - uipath-maestro-flow
   - integration
@@ -38,23 +38,21 @@ initial_prompt: |
   planning and implementation. Build the complete flow end-to-end in a single pass.
 
 success_criteria:
+# TWO ROUTES ARE CORRECT, and these criteria accept either. Manual discovery
+# may expose the channel collection as `conversations` or `curated_channels`;
+# the final artifact criterion below is the authority on the resolved id.
   - type: command_executed
-    description: "Agent invoked `uip is resources run list ... curated_channels` more than once (pagination loop ran)"
+    description: "Agent resolved the channel through the library — either a paged Slack channel-resource loop or `registry prepare --resolve`"
     tool_name: "Bash"
-    # Commands are recorded as the raw `bash -lc '...'`/`bash -lc "..."` wrapper. When the
-    # command carries an --output-filter with an embedded single-quoted JMESPath
-    # (items[?name=='simple']), the wrapper switches to double quotes and backslash-escapes the
-    # inner quotes (\"uipath-salesforce-slack\"). Allow an optional escaping backslash before each
-    # quote so both quoting styles match; otherwise paginated calls are silently uncounted.
-    command_pattern: 'uip\s+is\s+resources\s+run\s+list\s+\\?"?uipath-salesforce-slack\\?"?\s+\\?"?curated_channels'
-    min_count: 2
+    command_pattern: '(uip\s+is\s+resources\s+run\s+list\s+\\?"?uipath-salesforce-slack\\?"?\s+\\?"?(curated_channels|conversations)|registry\s+prepare\s+\\?"?uipath-salesforce-slack)'
+    min_count: 1
     weight: 3.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used `nextPage=<token>` to advance pagination at least once"
+    description: "Agent went past page 1 — `nextPage=<token>` by hand, or `--resolve channel:` which pages inside `prepare`"
     tool_name: "Bash"
-    command_pattern: 'nextPage='
+    command_pattern: '(nextPage=|--resolve\s+\\?"?channel:)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

- accept both Slack channel resource names exposed by the CLI (`conversations` and `curated_channels`)
- accept the Flow SDK `registry prepare --resolve` route introduced by UiPath/flow-builder-sdk#657
- keep the resolved channel ID as the authoritative outcome and preserve criterion count and weights
- add a regression test covering the observed manual command and the SDK resolver command

## Source boundary

Canonical preview-skill and SDK documentation changes shipped in UiPath/flow-builder-sdk#657 and were migrated by `.github/workflows/sync-maestro-sdk-preview.yml` through UiPath/skills#2948. This PR does not modify generated `preview/` files.

The campaign branch is rebased onto Skills `main@f7ebf510`, and this PR is a single checker commit on top.

## RCA evidence

In the 2026-08-31 same-ground run, preview correctly paginated `conversations`, resolved `simple` to `C083AN4E61E`, validated the Flow, and passed the artifact criterion. The task failed only because its telemetry regex required the older `curated_channels` spelling.

## Verification

- `uvx --from pytest pytest tests/tasks/uipath-maestro-flow/ -q` (329 passed)

Related: UiPath/flow-builder-sdk#657, UiPath/skills#2948

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)