### PR TITLE
fix(tests): stop grading incidental details in the dashboard edit/routing tasks

### DIFF
--- a/tests/tasks/uipath-coded-apps/dashboard/edit/dashboard_edit_remove_widget.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/edit/dashboard_edit_remove_widget.yaml
@@ -65,10 +65,17 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  # The remove went through the incremental editor as a REMOVE op.
-  - type: run_command
-    description: "edit-intent.json present with a REMOVE op"
-    command: "sh -c 'grep -rq --include=edit-intent.json --exclude-dir=node_modules REMOVE .'"
+  # The removal must go through the incremental editor, not hand-edited files.
+  # Assert the INVOCATION, not a surviving edit-intent.json: that file is an
+  # INPUT to the build script, the skill never says to keep it, and the script
+  # does not delete it — so whether it survives is agent housekeeping. Agents
+  # that correctly tidy the spent intent (and the orphaned metric module
+  # alongside it) were failing a task they had actually completed.
+  - type: command_executed
+    description: "Removal applied through the incremental editor (build-dashboard.mjs edit-intent.json)"
+    tool_name: "Bash"
+    command_pattern: 'build-dashboard\.mjs\S*\s+\S*edit-intent\.json'
+    min_count: 1
     timeout: 15
     expected_exit_code: 0
     weight: 2.0

--- a/tests/tasks/uipath-coded-apps/dashboard/routing/dashboard_agent_job_classification.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/routing/dashboard_agent_job_classification.yaml
@@ -1,12 +1,16 @@
 task_id: uipath-coded-apps-dashboard-agent-job-classification
 description: >
-  Regression guard for the agent-job classification trap. When a dashboard
-  derives agent metrics from job runs, the metric module must filter the
-  OData query with the RAW field name (ProcessType eq 'Agent') and match the
-  agent discriminator client-side on the SDK-mapped field (packageType ===
-  'Agent'). Using sourceType (the trigger origin, not the agent discriminator)
-  or filtering on a mapped field name like processName is wrong and returns
-  the wrong rows. The skill teaches this in sdk/orchestrator.md.
+  Regression guard for the agent-job classification trap. An agent job is
+  identified by the packageType/processType discriminator — NOT by sourceType,
+  which is the trigger origin (an agent job can be triggered manually, and a
+  manual job can have sourceType 'Agent'). Filtering on sourceType is wrong in
+  both directions, and referencing a mapped field name like processName inside
+  an OData filter throws. The skill teaches this in sdk/orchestrator.md.
+
+  Field SPELLING is deliberately not graded: the SDK rewrites SDK names to raw
+  API names inside filter/orderby/select/expand (packageType -> processType),
+  so the skill states that either spelling works. Requiring one literal
+  capitalisation failed agents that had followed the skill exactly.
 tags: [uipath-coded-apps, integration, dashboard, mode:build, lifecycle:generate]
 
 sandbox:
@@ -37,12 +41,12 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  # Correct agent-job classification: raw OData filter + no sourceType discriminator.
+  # Correct agent-job classification: any spelling of the discriminator, never sourceType.
   - type: run_command
-    description: "Metric module filters jobs with ProcessType eq 'Agent' and does not use sourceType as the discriminator"
+    description: "Metric module discriminates agent jobs on the packageType/processType field and never on sourceType"
     command: >
       python3 $SKILLS_REPO_PATH/tests/tasks/uipath-coded-apps/dashboard/_shared/check_dashboard.py
-      --min-metrics 1 --require-substr "ProcessType eq 'Agent'" --forbid-substr "sourceType"
+      --min-metrics 1 --require-substr "eq 'Agent'" --forbid-substr "sourceType"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0


### PR DESCRIPTION
> Stacked on #2944 — review/merge that first. Base is `fix/dashboard-scaffold-tar-ownership`; GitHub retargets this to `main` once #2944 lands.

Two dashboard tasks failed agents that had done the work correctly. Both graded an incidental detail instead of the behaviour under test. Neither is caused by #2944 — that PR only made them *visible*, by stopping the grader from failing earlier on the wrong directory.

## 1. `agent-job-classification` — graded OData field spelling

Required the literal `"ProcessType eq 'Agent'"`, matched with a case-sensitive Python `in`.

The skill teaches the opposite: [`sdk/orchestrator.md:40-41`](https://github.com/UiPath/skills/blob/main/skills/uipath-coded-apps/references/sdk/orchestrator.md#L40-L41) recommends `packageType eq 'Agent'`, and line 46 states the SDK rewrites SDK names to raw API names inside `filter`/`orderby`/`select`/`expand` (`packageType → processType`), **"so either spelling works."** An agent following the skill exactly failed.

| agent writes | per skill | OLD | NEW |
|---|---|---|---|
| `ProcessType eq 'Agent'` | valid | PASS | PASS |
| `packageType eq 'Agent'` | valid (skill's recommendation) | **FAIL** | PASS |
| `processType eq 'Agent'` | valid | **FAIL** | PASS |
| `sourceType eq 'Agent'` | **wrong — the real trap** | FAIL | FAIL |

`--require-substr` relaxed to `"eq 'Agent'"`. The `--forbid-substr "sourceType"` half carries the test's value and is unchanged.

## 2. `edit-remove-widget` — graded a transient input file

Required a surviving `edit-intent.json` containing `REMOVE`. That file is an **input** to `build-dashboard.mjs`; the skill says to write it and run the script, never to keep it, and the script doesn't delete it — so its survival is agent housekeeping.

What the failing run actually did:

```
38  Write  edit-intent.json → {"ops":[{"op":"REMOVE","target":"JobFailures"}]}
39  Bash   node build-dashboard.mjs edit-intent.json
           → TSC_PASS  INCREMENTAL_READY:{"count":1,"ops":[{"op":"REMOVE",...}]}
40  Bash   rm -f metrics/job-failures.ts edit-intent.json
```

It used the editor correctly, then tidied the spent intent alongside the orphaned metric module — and failed a task it had completed. `state.json` records final state only, with no edit history, so nothing durable on disk proves the editor ran.

Now asserts the **invocation** via `command_executed`, which the transcript records and cleanup can't erase. Paired with the existing "exactly 1 metric module remains", that covers mechanism and outcome.

Regex verified against six invocation forms (unquoted, single- and double-quoted path, quoted arg), confirmed NOT to match a full build (`build-dashboard.mjs intent.json`) or `--prewarm`, and replayed against the failing transcript — matches, criterion would PASS.

## Verification

Both files parse. Measurements taken on top of #2944's deterministic selector — under the old coin-flip selector these criteria can't be measured reliably run to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)