### PR TITLE
fix(datafabric): use UI-compatible column types in the DF Flow fixtures

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_create_all_types.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_create_all_types.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 """Verify smoke_create_all_types: single .flow with a DF Create node whose
-bodyParameters cover all 8 supported field types on FlowCodeEvalEntity, each
+bodyParameters cover all 8 UI-compatible field types on FlowCodeEvalEntity, each
 carrying either the correct JSON literal shape or a `=js:` expression binding.
+
+The vocabulary here must match the one entity-schema.md sanctions. INTEGER,
+DATETIME and UUID are on its "never emit" list, so viewCount is DECIMAL
+(decimalPrecision 0), lastUpdated is DATETIME_WITH_TZ and externalId is a plain
+STRING. Grading the forbidden spellings taught the agent to emit types the CLI
+now refuses outright at `entities create`.
 
 Any value starting with `=js:` is accepted for the type-check (agent may be
 binding the value to a workflow variable — grade wiring, not literal choice)."""
@@ -11,9 +17,10 @@ import re
 import sys
 
 ENTITY = "FlowCodeEvalEntity"
-UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2})?")
+# DATETIME_WITH_TZ is the only UI-compatible timestamp, and the offset is the point of it:
+# accept Z or +/-HH:MM, reject a naive local timestamp.
+DATETIME_TZ_RE = re.compile(r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})$")
 
 
 def _is_expression(v):
@@ -29,10 +36,6 @@ def _check_number(v):
     return isinstance(v, (int, float)) and not isinstance(v, bool)
 
 
-def _check_int(v):
-    return isinstance(v, int) and not isinstance(v, bool)
-
-
 def _check_bool(v):
     return isinstance(v, bool)
 
@@ -41,23 +44,19 @@ def _check_date(v):
     return isinstance(v, str) and bool(DATE_RE.match(v))
 
 
-def _check_datetime(v):
-    return isinstance(v, str) and bool(DATETIME_RE.match(v))
-
-
-def _check_uuid(v):
-    return isinstance(v, str) and bool(UUID_RE.match(v))
+def _check_datetime_tz(v):
+    return isinstance(v, str) and bool(DATETIME_TZ_RE.match(v))
 
 
 EXPECTED = {
     "title":        ("STRING",         _check_str),
     "description":  ("MULTILINE_TEXT", _check_str),
     "score":        ("DECIMAL",        _check_number),
-    "viewCount":    ("INTEGER",        _check_int),
+    "viewCount":    ("DECIMAL",        _check_number),
     "active":       ("BOOLEAN",        _check_bool),
     "releaseDate":  ("DATE",           _check_date),
-    "lastUpdated":  ("DATETIME",       _check_datetime),
-    "externalId":   ("UUID",           _check_uuid),
+    "lastUpdated":  ("DATETIME_WITH_TZ", _check_datetime_tz),
+    "externalId":   ("STRING",         _check_str),
 }
 
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/contract_registry.entity.json
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/contract_registry.entity.json
@@ -4,7 +4,7 @@
   "fields": [
     {"name": "contractTitle", "type": "STRING",  "lengthLimit": 200},
     {"name": "status",        "type": "STRING",  "lengthLimit": 100},
-    {"name": "priority",      "type": "INTEGER"},
+    {"name": "priority",      "type": "DECIMAL", "decimalPrecision": 0},
     {"name": "dueDate",       "type": "DATE"},
     {"name": "value",         "type": "DECIMAL"},
     {"name": "isUrgent",      "type": "BOOLEAN"}

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/e2e_contract_intake_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/e2e_contract_intake_pipeline.yaml
@@ -21,7 +21,7 @@ pre_run:
 
 initial_prompt: |
   Build a UiPath Flow against the `ContractRegistry` Data Fabric entity
-  (fields: contractTitle STRING, status STRING, priority INTEGER,
+  (fields: contractTitle STRING, status STRING, priority DECIMAL (whole),
   dueDate DATE, value DECIMAL, isUrgent BOOLEAN) that exercises the
   bulk-CRUD lifecycle with ForEach loops:
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/flow_code_eval_entity.entity.json
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/flow_code_eval_entity.entity.json
@@ -5,11 +5,11 @@
     {"name": "title",        "type": "STRING",         "lengthLimit": 200},
     {"name": "description",  "type": "MULTILINE_TEXT", "lengthLimit": 2000},
     {"name": "score",        "type": "DECIMAL"},
-    {"name": "viewCount",    "type": "INTEGER"},
+    {"name": "viewCount",    "type": "DECIMAL",        "decimalPrecision": 0},
     {"name": "active",       "type": "BOOLEAN"},
     {"name": "releaseDate",  "type": "DATE"},
-    {"name": "lastUpdated",  "type": "DATETIME"},
-    {"name": "externalId",   "type": "UUID"},
+    {"name": "lastUpdated",  "type": "DATETIME_WITH_TZ"},
+    {"name": "externalId",   "type": "STRING",         "lengthLimit": 36},
     {"name": "file1",        "type": "FILE"}
   ]
 }

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/integration_create_get.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/integration_create_get.yaml
@@ -28,7 +28,7 @@ initial_prompt: |
     * viewCount: 420
     * active: true
     * releaseDate: '2023-08-20'
-    * lastUpdated: '2023-08-20T14:00:00'
+    * lastUpdated: '2023-08-20T14:00:00Z'
     * externalId: 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff'
   Retrieve it by Id and delete when done.
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/seed_flow_code_eval_records.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/seed_flow_code_eval_records.py
@@ -20,7 +20,7 @@ ROWS = [
         "viewCount": 5000,
         "active": True,
         "releaseDate": "1999-03-31",
-        "lastUpdated": "2024-01-01T10:00:00",
+        "lastUpdated": "2024-01-01T10:00:00Z",
         "externalId": "11111111-1111-1111-1111-111111111111",
     },
     {
@@ -30,7 +30,7 @@ ROWS = [
         "viewCount": 3000,
         "active": True,
         "releaseDate": "2016-11-11",
-        "lastUpdated": "2024-06-15T12:00:00",
+        "lastUpdated": "2024-06-15T12:00:00Z",
         "externalId": "22222222-2222-2222-2222-222222222222",
     },
     {
@@ -40,7 +40,7 @@ ROWS = [
         "viewCount": 2000,
         "active": False,
         "releaseDate": "1972-05-13",
-        "lastUpdated": "2023-05-13T09:30:00",
+        "lastUpdated": "2023-05-13T09:30:00Z",
         "externalId": "33333333-3333-3333-3333-333333333333",
     },
     {
@@ -50,7 +50,7 @@ ROWS = [
         "viewCount": 100,
         "active": False,
         "releaseDate": "2020-01-01",
-        "lastUpdated": "2022-01-01T00:00:00",
+        "lastUpdated": "2022-01-01T00:00:00Z",
         "externalId": "44444444-4444-4444-4444-444444444444",
     },
 ]

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_create_all_types.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_create_all_types.yaml
@@ -1,8 +1,8 @@
 task_id: skill-flow-datafabric-smoke-create-all-types
 description: >
   Smoke: DF Create node on FlowCodeEvalEntity binds all 8 supported field
-  types (STRING, MULTILINE_TEXT, DECIMAL, INTEGER, BOOLEAN, DATE, DATETIME,
-  UUID) with correct JSON literal shapes. Static-validate only; runtime
+  types (STRING, MULTILINE_TEXT, DECIMAL, BOOLEAN, DATE, DATETIME_WITH_TZ)
+  with correct JSON literal shapes. Static-validate only; runtime
   `flow debug` skipped to avoid live tenant side effects. Full CRUD /
   negative-path coverage lives in e2e_contract_intake_pipeline.
 tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, shape:single-node, connector, uipath-uipath-dataservice]
@@ -24,11 +24,11 @@ initial_prompt: |
   * title: "AllTypesTest-Smoke" (STRING)
   * description: "A sci-fi smoke test record covering all supported field types. A must-watch film." (MULTILINE_TEXT)
   * score: 7.25 (DECIMAL)
-  * viewCount: 350 (INTEGER)
+  * viewCount: 350 (DECIMAL, decimalPrecision 0)
   * active: true (BOOLEAN)
   * releaseDate: "2024-03-10" (DATE)
-  * lastUpdated: "2024-03-10T09:00:00" (DATETIME)
-  * externalId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" (UUID)
+  * lastUpdated: "2024-03-10T09:00:00Z" (DATETIME_WITH_TZ)
+  * externalId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" (STRING)
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_query.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_query.yaml
@@ -1,7 +1,7 @@
 task_id: skill-flow-datafabric-smoke-query
 description: >
   Smoke: read-only record queries against FlowCodeEvalEntity covering boolean,
-  numeric, text, date, datetime, UUID, and null filters, ordered pages, and
+  numeric, text, date, datetime, string-id, and null filters, ordered pages, and
   offset pagination. FILE attachments are not filterable.
 tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, connector, uipath-uipath-dataservice]
 
@@ -26,12 +26,12 @@ initial_prompt: |
   one query activity:
   - active equals true (boolean)
   - score is greater than or equal to 8.5 (decimal)
-  - viewCount is greater than or equal to 1000 (integer)
+  - viewCount is greater than or equal to 1000 (decimal, whole)
   - title equals "FilterFixture-Matrix" (string)
   - description contains "sci-fi" (multiline text)
   - releaseDate is less than 2025-01-01 (date)
-  - lastUpdated is greater than or equal to 2024-01-01T00:00:00 (datetime)
-  - externalId equals "11111111-1111-1111-1111-111111111111" (UUID)
+  - lastUpdated is greater than or equal to 2024-01-01T00:00:00Z (datetime with tz)
+  - externalId equals "11111111-1111-1111-1111-111111111111" (string)
   - description is null
 
   Query 1 must retrieve the first 2 records sorted by score ascending, with


### PR DESCRIPTION
## What

The two Data Fabric Flow connector fixture entities declare column types that
[`entity-schema.md`](../blob/main/skills/uipath-platform/references/data-fabric/entity-schema.md#ui-broken-types--do-not-use)
lists under **"UI-broken types — do NOT use"**. The CLI now refuses them outright rather than warning:

```
uip df entities create FlowCodeEvalEntity --file flow_code_eval_entity.entity.json
{ "Result": "Failure",
  "Message": "Field 'viewCount' uses type 'INTEGER' which the Data Fabric UI cannot render",
  "Instructions": "The server accepts 'INTEGER' but the UI cannot render, filter, or edit the column.
                   Use DECIMAL with decimalPrecision: 0 instead.
                   UI-broken types: INTEGER, BIG_INTEGER, FLOAT, DOUBLE, UUID, DATETIME." }
```

Substitutions are exactly the ones that reference prescribes:

| Field | Was | Now |
|---|---|---|
| `viewCount` | `INTEGER` | `DECIMAL`, `decimalPrecision: 0` |
| `lastUpdated` | `DATETIME` | `DATETIME_WITH_TZ` |
| `externalId` | `UUID` | `STRING`, `lengthLimit: 36` |
| `priority` (ContractRegistry) | `INTEGER` | `DECIMAL`, `decimalPrecision: 0` |

## Why it was invisible until now

`ensure_entity.py` is idempotent and only creates when the entity is absent. On a long-lived tenant
the entity predates the CLI validation, so nothing ever breaks. On a **fresh** tenant creation is
mandatory and fails, taking 8 tasks down as pre-run errors before the agent starts.

Measured on an Automation Suite eval run (`skill-flow-datafabric-*`): all 8 errored at `pre_run`,
while the same 8 passed on the cloud nightly with an identical task set.

Three fields were affected, not one — fixing only `viewCount` would have moved the error to
`lastUpdated`, then `externalId`.

## The part worth a careful look

`check_smoke_create_all_types.py` graded the forbidden spellings. Its docstring claimed to cover
*"all 8 supported field types"* while three of them were types the skill tells agents **never to
emit** — so the task was teaching and rewarding the wrong vocabulary. It now grades the sanctioned
set, and its timestamp check requires the offset that is the whole point of `DATETIME_WITH_TZ`
(a naive `2024-03-10T09:00:00` is now rejected).

**This changes what these tasks instruct and grade on cloud as well as on-prem**, which is why it
wants your sign-off rather than a rubber stamp. Task prompts and seed records carry matching
literals; the four naive seed timestamps gained a `Z`.

`check_smoke_query_filter.py` is deliberately untouched — its `EXPECTED` keys are internal labels
and it matches on field names and value prefixes, both unchanged.

## Verified locally

- both entity JSONs parse; every `*.yaml` in the directory parses; every `*.py` compiles
- the checker accepts the literals the prompts now instruct, and rejects a naive (offset-free) timestamp
- no forbidden spelling remains in the fixture directory except the docstring that explains the change

Not yet run against a live tenant — the create path needs a fresh tenant to exercise, which is the
next Automation Suite eval run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)