### PR TITLE
fix(tests): remaining wrapper-blind matchers in api-workflow tasks

### DIFF
--- a/tests/tasks/uipath-api-workflow/evals/gate_create/gate_create.yaml
+++ b/tests/tasks/uipath-api-workflow/evals/gate_create/gate_create.yaml
@@ -48,9 +48,16 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
+    # Two accepted shapes: an inspector verb naming a project path, OR a bare
+    # enumeration of the sandbox (`rg --files`, `ls`, `find .`, `tree`) — which
+    # surfaces AddNumbers/evals in its output without naming it in the command
+    # text. The 2026-09-01 run discovered via `rg --files | sed` and scored a
+    # false 0/1 under the old verb-plus-path-only pattern. Still Bash-text-only:
+    # an agent inspecting via native Read/Glob tools is invisible here — if a
+    # harness variant hits that, make this advisory like the runner checks.
     description: "Discovery happened: the agent inspected the project / its evals folder before stopping (an agent that does nothing fails this)"
     tool_name: "Bash"
-    command_pattern: '(ls|find|cat|tree|head|jq|python3|grep)\s[^\n]*(AddNumbers|evals|Workflow\.json)'
+    command_pattern: '((ls|find|cat|tree|head|tail|sed|awk|jq|rg|python3?|grep)\s[^\n]*(AddNumbers|evals|Workflow\.json)|rg\s+--files|\bfind\s+\.|\btree\b|\bls\b)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-api-workflow/evals/gate_edit/gate_edit.yaml
+++ b/tests/tasks/uipath-api-workflow/evals/gate_edit/gate_edit.yaml
@@ -43,9 +43,16 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
+    # Two accepted shapes: an inspector verb naming a project path, OR a bare
+    # enumeration of the sandbox (`rg --files`, `ls`, `find .`, `tree`) — which
+    # surfaces GradeCheck/evals in its output without naming it in the command
+    # text (same false negative gate_create hit in the 2026-09-01 run via
+    # `rg --files | sed`). Still Bash-text-only: an agent inspecting via native
+    # Read/Glob tools is invisible here — if a harness variant hits that, make
+    # this advisory like the runner checks.
     description: "Discovery happened: the agent inspected the project / its evals folder before stopping (an agent that does nothing fails this)"
     tool_name: "Bash"
-    command_pattern: '(ls|find|cat|tree|head|jq|python3|grep)\s[^\n]*(GradeCheck|evals|Workflow\.json)'
+    command_pattern: '((ls|find|cat|tree|head|tail|sed|awk|jq|rg|python3?|grep)\s[^\n]*(GradeCheck|evals|Workflow\.json)|rg\s+--files|\bfind\s+\.|\btree\b|\bls\b)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-api-workflow/operate/run_execute/run_execute.yaml
+++ b/tests/tasks/uipath-api-workflow/operate/run_execute/run_execute.yaml
@@ -5,11 +5,11 @@ description: >
   mode:operate: the artifact is correct; the graded behavior is running it via
   `uip api-workflow run` and getting the right output, NOT authoring or repairing.
   Complements the build-mode authoring tasks and the diagnose-mode repair tasks
-  with the third scorecard mode (running live). Graded on side effects: the agent
-  invoked the runner once per input and saved each run's raw output to its own
-  file (run_85.json grades PASS, run_40.json grades FAIL). Behavioral credit thus
-  depends on real CLI output the agent captured — the valid seed cannot earn it,
-  and the answer cannot be satisfied by transcribing a grade from the prompt.
+  with the third scorecard mode (running live). Graded on side effects: each
+  run's raw output was saved to its own file (run_85.json grades PASS,
+  run_40.json grades FAIL). Behavioral credit thus depends on real CLI output
+  the agent captured — the valid seed cannot earn it, and the answer cannot be
+  satisfied by transcribing a grade from the prompt.
 tags: [uipath-api-workflow, integration, mode:operate, lifecycle:discover]
 
 sandbox:
@@ -32,10 +32,15 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent executed the workflow with the local runner, once per input (the operate action)"
+    # min_count 1, not 2: the matcher runs one search per Bash tool call, so
+    # both runs chained with && in a single call count once (the 2026-09-01 run
+    # scored a false 1/2 that way). One visible invocation still anchors that
+    # the agent drove the runner; per-input evidence lives in the envelope
+    # checks on run_85.json / run_40.json below.
+    description: "Agent executed the workflow with the local runner (both runs may share one chained Bash call)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+api-workflow\s+run'
-    min_count: 2
+    min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
@@ -51,17 +56,24 @@ success_criteria:
     weight: 0.5
     pass_threshold: 1.0
 
+  # Envelope checks, not bare greps: a fabricated file containing the string
+  # "PASS" must not pass — the file has to be a real runner envelope
+  # ({"Result": "Success", "Data": {...grade...}}).
   - type: run_command
-    description: "Behavioral: the captured score-85 run output grades PASS"
-    command: 'grep -q ''"PASS"'' run_85.json'
+    description: "Behavioral: the captured score-85 output is a real run envelope grading PASS"
+    command: >-
+      python3 -c "import json,sys; d=json.load(open('run_85.json'));
+      sys.exit(0 if d.get('Result')=='Success' and 'PASS' in json.dumps(d.get('Data')) else 1)"
     timeout: 10
     expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Behavioral: the captured score-40 run output grades FAIL"
-    command: 'grep -q ''"FAIL"'' run_40.json'
+    description: "Behavioral: the captured score-40 output is a real run envelope grading FAIL"
+    command: >-
+      python3 -c "import json,sys; d=json.load(open('run_40.json'));
+      sys.exit(0 if d.get('Result')=='Success' and 'FAIL' in json.dumps(d.get('Data')) else 1)"
     timeout: 10
     expected_exit_code: 0
     weight: 1.5


### PR DESCRIPTION
## Summary

Follow-up to #2927. Analysis of the five archived replicates from the 2026-09-01 codereval run (`gpt-5.6-terra`) showed every `FAILURE` traced to grader defects, not agent work: three were the `_shared` path bug #2927 already fixed, and two matcher bugs remained. This PR fixes those two, plus the same latent bug in a sibling task.

## Changes

**`operate/run_execute/run_execute.yaml`**
- The grader runs one `pattern.search()` per Bash tool call, so both runner invocations chained with `&&` in a single call scored a false 1/2 against `min_count: 2`. Dropped to `min_count: 1` — one visible invocation still anchors that the agent drove the runner.
- Hardened the two content checks from bare `grep '"PASS"'` into envelope assertions (`Result == "Success"` plus the grade inside `Data`), so relaxing the count gate does not open a fabrication path: a hand-written `{"grade":"PASS"}` file no longer passes.

**`evals/gate_create/gate_create.yaml` + `evals/gate_edit/gate_edit.yaml`**
- The discovery matcher required an inspector verb *naming a project path in the command text*, but the failing agent discovered via `rg --files | sed` — which never names `AddNumbers` at all — scoring a false 0/1 on a gating weight-2.0 criterion. The pattern now accepts two shapes: an inspector verb naming a project path (verb list extended with `sed|awk|rg|tail`), or bare sandbox enumeration (`rg --files`, `ls`, `find .`, `tree`).
- `gate_edit` carried the identical latent pattern (with `GradeCheck`) and gets the same fix.

## Verification

- All three YAMLs parse; `scripts/check-cli-verbs.py` reports nothing actionable (discovery patterns are Info/skipped as too dynamic, as before).
- Envelope checks replayed against the 2026-09-01 run's captured artifacts: real `run_85.json`/`run_40.json` pass, fabricated `{"grade":"PASS"}` is rejected.
- New gate discovery pattern replay-matches the captured `gpt-5.6-terra` failing command (`rg --files ... | sed ...`) and the plain `cat`/`ls`/`find` shapes, and does not match `echo` or `uip api-workflow validate`.
- `/lint-task` on the target files: Low verdicts only (residual, documented in-file: discovery is still Bash-text-only; run_execute retains minor single-run gameability), no Medium+.

## Passing-run claim

Local runs on this branch, coder-eval 0.11.5, `experiments/default.yaml`, agent `claude-code` / `sonnet` (2026-09-01):

- **`run_execute`** — `status=SUCCESS, 6/6 criteria, weighted score 1.000` (42s, 1 iteration). Run dir: `tests/runs/pr2953-run-execute`.
- **`gate_create` + `gate_edit`** — the agents completed correctly, but the grading phase errored before scoring any criterion: `checker_context.api_route` requires `CODEX_BASE_URL`/`CODEX_API_KEY` (the `llm_judge` transport), unavailable locally — the task descriptions call this out ("without it this task cannot pass, by design"). All deterministic criteria were graded manually against the preserved sandboxes and transcripts (run dir: `tests/runs/pr2953-gates`):
  - `check_gate.py`: exit 0 on both ("nothing authored" / "workflow and dataset untouched")
  - `command_not_executed` (no runner invocation): PASS on both
  - **the changed discovery matcher: PASS on both** (2/2 Bash commands match — `ls`/`find`/`cat` over the project)
  - `llm_judge`: ungraded locally; both final responses verbatim ask the two gate questions (tests? loop mode?)

Caveat: not re-run on `gpt-5.6-terra` (codex route needs `CODEX_*` credentials). The terra-specific evidence is the replay of the new matchers against that run's captured commands and artifacts, listed under Verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)