### PR TITLE
fix(tests): score guardrail review evals on report evidence, not command telemetry

### DIFF
--- a/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py
+++ b/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Cross-check the guardrail catalog's availability against what the report claims.
+
+WHAT THIS FIXES. The paired `command_executed` criterion on
+`uip\\s+agent\\s+guardrails\\s+catalog` carries `require_success: true`, which
+reads the *wrapper's* exit code (`agents/codex_agent.py`). Agents batch several
+CLI calls into one `bash -lc` script that opens `set +e` and closes `exit 0`, so
+the wrapper always reports success. Observed twice in live Codex runs: the
+criterion scored 1.00 while the command itself returned
+`unknown command 'catalog'`. That is a silent false pass -- the eval reported
+catalog-grounded findings as verified when the catalog was never read.
+
+WHAT THIS DOES NOT DO. Unlike the review-CLI provenance check, this cannot prove
+the AGENT fetched the catalog. There is no artifact to prove it with: the
+catalog's unique fields (`DetectionMethod`, `Examples[].Name`) are never required
+in a report, the mandated "matched catalog clause" is paraphrased in practice,
+and the `.guardrails-catalog-cache.json` that Step 0 asks for was absent from the
+final sandbox in 10 of 10 measured runs (agents redirect to /tmp, pipe to `head`,
+or clean up). So the paired `command_executed` is deliberately KEPT as the
+behavioural signal, and this criterion closes the hole that flag cannot:
+it establishes whether the catalog was actually reachable, and holds the report
+to the skill's contract for the unreachable case.
+
+  reachable + report silent            -> PASS   (normal healthy run)
+  reachable + report says unavailable  -> FAIL   (contradiction; usually a CLI
+                                                  divergence, sometimes a false claim)
+  unreachable + report says unavailable-> PASS   (Critical Rule 11 honoured)
+  unreachable + report silent          -> FAIL   (catalog-grounded verdicts with
+                                                  no catalog, and no disclosure)
+
+Exit 0 on PASS; sys.exit(str) on failure.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from report_evidence import cli_identity, declares_unavailable
+
+# Names a report may use for the catalog when declaring it skipped.
+CATALOG_SUBJECT = r"guardrails?\s+catalog|catalog|live\s+catalog"
+
+
+def _fetch_catalog(uip: str) -> tuple[bool, list, str]:
+    """Return (reachable, validators, diagnostic)."""
+    argv = [uip, "agent", "guardrails", "catalog", "--output", "json"]
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=180)
+    except FileNotFoundError:
+        return False, [], f"{uip} not on PATH"
+    except subprocess.TimeoutExpired:
+        return False, [], "catalog fetch timed out after 180s"
+    # The CLI writes both success and error JSON to stdout (guardrails-review.md
+    # Step 0), so a non-zero exit is not the only failure shape to handle.
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        tail = (proc.stderr or proc.stdout or "").strip()[-300:]
+        return False, [], f"non-JSON output (exit {proc.returncode}): {tail}"
+    if payload.get("Code") == "GuardrailCatalogUnavailable":
+        return False, [], "CLI reported GuardrailCatalogUnavailable"
+    if payload.get("Result") != "Success":
+        return False, [], f"Result={payload.get('Result')}: {str(payload.get('Message'))[:200]}"
+    validators = [g.get("ValidatorId") for g in (payload.get("Data") or {}).get("Guardrails") or []]
+    if not validators:
+        return False, [], "catalog returned zero validators"
+    return True, validators, ""
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--report", default="_review_report.md")
+    args = ap.parse_args()
+
+    report = Path(os.getcwd()) / args.report
+    if not report.is_file():
+        sys.exit(f"FAIL: {report} not found")
+    text = report.read_text(encoding="utf-8", errors="replace")
+
+    uip = os.environ.get("UIP", "uip")
+    print(f"Checker resolved `{uip}` -> {cli_identity(uip)}")
+    reachable, validators, why = _fetch_catalog(uip)
+    declared = declares_unavailable(text, CATALOG_SUBJECT)
+
+    if reachable:
+        print(f"Catalog reachable: {len(validators)} validators {validators}")
+        if declared:
+            sys.exit(
+                "FAIL: the report declares the guardrail catalog unavailable under 'Rules Skipped', "
+                f"but this checker fetched it successfully via {cli_identity(uip)} "
+                f"({len(validators)} validators). Either the agent resolved a different `uip` than the "
+                "checker (compare `which -a uip`; a login shell or a per-task HOME from "
+                "sandbox.mock_path_dirs can pick a stale one), or the claim is false. Fix the "
+                "environment before reading this as a skill regression."
+            )
+        print("OK: catalog is reachable and the report does not claim otherwise")
+        print("PASS")
+        return
+
+    print(f"WARN: catalog NOT reachable from the sandbox ({why})")
+    if declared:
+        print("OK: report declares the guardrail catalog unavailable under 'Rules Skipped'")
+        print("PASS")
+        return
+    sys.exit(
+        f"FAIL: the guardrail catalog could not be fetched at check time ({why}), and the report "
+        "does not declare it unavailable under 'Rules Skipped'. Any catalog-grounded finding in "
+        "this report is therefore unverified (guardrails-review.md Step 0 requires recording the "
+        "catalog-dependent rules as skipped when the catalog is missing)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-review/_shared/check_review_cli_provenance.py
+++ b/tests/tasks/uipath-review/_shared/check_review_cli_provenance.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Prove the review CLI ran, from the REPORT instead of from command telemetry.
+
+Replaces a `command_executed` criterion on `uip\\s+agent\\s+review`. That form
+asks the harness "did a Bash tool call match this regex", and the answer depends
+on things the agent's actual work does not:
+
+* coder_eval matches the pattern against only the first 2000 chars of the
+  command (`criteria/command_executed.py::_MAX_PATTERN_SEARCH_LEN`, a ReDoS
+  guard). Agents batch many commands into one `bash -lc` script, so a CLI call
+  late in a long script is simply invisible. Whether it lands inside the window
+  is a function of how much unrelated preamble the agent happened to emit.
+* `require_success: true` reads the *wrapper's* exit code
+  (`agents/codex_agent.py`), and a batched script that opens `set +e` and closes
+  `exit 0` always reports success -- even if the CLI inside it failed.
+
+Both failure modes are independent of whether the agent did the work, in both
+directions. So derive ground truth instead: re-run the review CLI on the fixture
+(which the task's gating read-only criteria prove the agent did not modify) and
+require the report to carry the deterministic `RuleId`s it emits.
+
+How strong that evidence is depends on the rule_id, and the checker measures it
+rather than assuming: an id that appears NOWHERE in the agent-readable skill
+tree (e.g. `LOWCODE_EVAL_SET_EMPTY`) can only have come from running the CLI, so
+citing it verbatim proves invocation. An id the skill itself names (e.g.
+`CODED_GUARDRAIL_WRONG_IMPORT`, documented in SKILL.md and
+`references/agents/agents-coded-rules.md`) could in principle be cited by an
+agent that read the source and skipped the CLI -- there the check still verifies
+the CLI genuinely emits that finding and that the report carries it verbatim per
+Step 2.5a, but it is not proof of invocation. A WARN names that case explicitly
+so the criterion detail never overstates what it established.
+
+Exit 0 on PASS; sys.exit(str) on failure.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from report_evidence import cli_identity, declares_unavailable
+
+# Names the report may use for the review CLI, for the shared
+# `declares_unavailable` contract check (SKILL.md Critical Rule 11).
+REVIEW_CLI_SUBJECT = r"review\s+CLI|uip\s+agent\s+review|uip\s+codedagent\s+review"
+
+# Anchors that attribute a nearby grade letter to the CLI rather than to the
+# skill's own judgment grade (the two legitimately differ -- Step 4.5 takes
+# min(G_det, G_jud)).
+CLI_MENTION = re.compile(r"(uip\s+agent\s+review|uip\s+codedagent\s+review|review\s+CLI|deterministic)", re.IGNORECASE)
+GRADE_PROXIMITY = 240
+
+
+def _run_cli(uip: str, verb: list[str], project: str) -> tuple[bool, dict, str]:
+    """Run the review CLI on `project`; return (ok, parsed Data, diagnostic)."""
+    argv = [uip, *verb, project, "--output", "json"]
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=180)
+    except FileNotFoundError:
+        return False, {}, f"{uip} not on PATH"
+    except subprocess.TimeoutExpired:
+        return False, {}, f"{' '.join(argv)} timed out after 180s"
+    if proc.returncode != 0:
+        tail = (proc.stderr or proc.stdout or "").strip()[-400:]
+        return False, {}, f"exit {proc.returncode}: {tail}"
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        return False, {}, f"non-JSON output ({e}): {proc.stdout.strip()[:400]}"
+    if payload.get("Result") != "Success":
+        return False, {}, f"Result={payload.get('Result')}: {payload.get('Message', '')[:400]}"
+    return True, payload.get("Data") or {}, ""
+
+
+def _derivable_from_skill(rule_ids: list[str]) -> list[str] | None:
+    """Which `rule_ids` the agent could have read out of the skill tree.
+
+    Only the agent-READABLE tree counts: `$TASK_DIR` is chmod-000 during the
+    agent turn, and `tests/runs/` is gitignored scratch that does not exist in a
+    clean checkout, so neither is a source the agent could have used.
+    """
+    repo = os.environ.get("SKILLS_REPO_PATH")
+    if not repo:
+        return None
+    skills = Path(repo) / "skills" / "uipath-review"
+    if not skills.is_dir():
+        return None
+    text = ""
+    for f in skills.rglob("*.md"):
+        try:
+            text += f.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+    return [r for r in rule_ids if r in text]
+
+
+def _grade_evidenced(text: str, grade: str) -> bool:
+    """True if `grade` appears as a standalone token near a CLI attribution."""
+    letter = re.compile(rf"(?<![A-Za-z]){re.escape(grade)}(?![A-Za-z])")
+    for m in CLI_MENTION.finditer(text):
+        window = text[max(0, m.start() - GRADE_PROXIMITY) : m.end() + GRADE_PROXIMITY]
+        if letter.search(window):
+            return True
+    return False
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--project", default="ReviewSol/SampleAgent")
+    ap.add_argument("--report", default="_review_report.md")
+    ap.add_argument(
+        "--verb",
+        default="agent review",
+        help="CLI verb: 'agent review' (low-code) or 'codedagent review' (coded).",
+    )
+    args = ap.parse_args()
+
+    report = Path(os.getcwd()) / args.report
+    if not report.is_file():
+        sys.exit(f"FAIL: {report} not found")
+    text = report.read_text(encoding="utf-8", errors="replace")
+
+    uip = os.environ.get("UIP", "uip")
+    print(f"Checker resolved `{uip}` -> {cli_identity(uip)}")
+    ok, data, why = _run_cli(uip, args.verb.split(), args.project)
+
+    if not ok:
+        # Ground truth is unobtainable. Do not silently pass (that is the hole
+        # this check exists to close) and do not hard-fail on infra (that just
+        # trades one flake for another): hold the report to the contract the
+        # skill defines for exactly this case.
+        print(f"WARN: could not establish ground truth -- `{uip} {args.verb}` unavailable ({why})")
+        if declares_unavailable(text, REVIEW_CLI_SUBJECT):
+            print("OK: report declares the review CLI unavailable under 'Rules Skipped'")
+            print("PASS")
+            return
+        sys.exit(
+            f"FAIL: the review CLI could not be run at check time ({why}), and the report does "
+            "not declare it unavailable under 'Rules Skipped'. Either the CLI was skipped, or "
+            "the harness lost CLI access -- both need a human look."
+        )
+
+    grade = str(data.get("Grade") or "")
+    score = data.get("Score")
+    rule_ids = sorted({str(i.get("RuleId")) for i in (data.get("Issues") or []) if i.get("RuleId")})
+    print(f"Ground truth from `{uip} {args.verb} {args.project}`: Grade={grade} Score={score} Issues={rule_ids}")
+
+    if rule_ids:
+        missing = [r for r in rule_ids if r not in text]
+        if missing and declares_unavailable(text, REVIEW_CLI_SUBJECT):
+            # The report claims the CLI was unavailable, but this checker just
+            # ran it. Either the agent resolved a DIFFERENT `uip` (a host with
+            # several installs plus a login shell / per-task HOME will do this),
+            # or the claim is false. Both are real problems and neither may pass
+            # -- accepting the declaration unconditionally would let any agent
+            # skip Step 2.5a by writing one line. Name the likelier cause so the
+            # environment can be checked first.
+            sys.exit(
+                f"FAIL: report declares the review CLI unavailable under 'Rules Skipped', but this "
+                f"checker ran it successfully via {cli_identity(uip)} and got {missing}. Either the "
+                f"agent resolved a different `uip` than the checker (compare `which -a uip`; a login "
+                f"shell or a per-task HOME from sandbox.mock_path_dirs can pick a stale one), or the "
+                f"report's unavailability claim is false. Fix the environment before reading this as "
+                f"a skill regression."
+            )
+        if missing:
+            sys.exit(
+                f"FAIL: report omits deterministic rule_id(s) the review CLI emitted: {missing}. "
+                "These appear in no judgment catalog, so the report cannot have been produced "
+                "from a run that executed the CLI (SKILL.md Critical Rule 9 / Step 2.5a requires "
+                "carrying every CLI finding verbatim)."
+            )
+        print(f"OK: report carries every CLI-emitted rule_id verbatim: {rule_ids}")
+        derivable = _derivable_from_skill(rule_ids)
+        if derivable is None:
+            pass  # no SKILLS_REPO_PATH: cannot judge strength, so claim nothing
+        elif derivable:
+            print(
+                f"WARN: {derivable} also appear(s) in the agent-readable skill tree, so citing them "
+                "does not by itself prove the CLI ran -- this criterion verifies the CLI emits them "
+                "and the report carries them verbatim, not that the agent invoked it."
+            )
+        elif rule_ids:
+            print(f"OK: {rule_ids} appear nowhere in the skill tree -- citation proves the CLI ran")
+    else:
+        # Nothing deterministic to carry, so fall back to the other CLI-only
+        # facts. Keep this branch: sibling fixtures can legitimately be clean.
+        if not (grade and _grade_evidenced(text, grade)) and not (score is not None and str(score) in text):
+            sys.exit(
+                f"FAIL: the review CLI returned no findings, and the report evidences neither its "
+                f"grade ({grade!r}) nor its score ({score!r}) -- no trace that Step 2.5a ran."
+            )
+        print(f"OK: CLI returned no findings; report evidences its grade/score (Grade={grade} Score={score})")
+
+    if grade and not _grade_evidenced(text, grade):
+        # Step 4.5 reads G_det from the CLI; the report format only *requires*
+        # printing it when it differs from the final grade, so this is a signal,
+        # not a gate.
+        print(f"WARN: report does not attribute grade {grade} to the review CLI near a CLI mention")
+
+    print("PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-review/_shared/report_evidence.py
+++ b/tests/tasks/uipath-review/_shared/report_evidence.py
@@ -1,0 +1,60 @@
+"""Shared helpers for report-evidence checkers.
+
+Both the review-CLI and guardrail-catalog checkers ask the same two questions of
+a saved review report, so the regexes live here rather than drifting apart in
+two copies. Imported by sibling `check_*.py` scripts, which coder_eval invokes
+as `python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_*.py` --
+so this directory is already `sys.path[0]` and a plain import works.
+"""
+
+import re
+import shutil
+import subprocess
+
+# SKILL.md Critical Rule 11 / rule-catalog-workflow.md 2.5a: when a required
+# input genuinely cannot be obtained, the report must say so HERE and not just
+# anywhere in prose ("the CLI was unavailable, so I guessed" must not count).
+SKIPPED_HEADING = re.compile(r"^#+\s*Rules Skipped\s*$", re.MULTILINE)
+
+# Phrasing varies a lot between agents; observed forms include "unavailable",
+# "does not provide the `review` command", and "unknown command". Keep this
+# alternation generous -- a missed phrasing turns an honest skip declaration
+# into a confusing failure, while a spurious match only relaxes a branch that
+# already fails on its own.
+_UNAVAILABLE = (
+    r"(unavailable|not\s+available|not\s+installed|could\s+not\s+be\s+(run|fetched|retrieved)|failed"
+    r"|does\s+not\s+(provide|support|have)|unknown\s+command|missing|unsupported)"
+)
+
+
+def declares_unavailable(text: str, subject: str) -> bool:
+    """True if the report's 'Rules Skipped' section calls `subject` unavailable.
+
+    `subject` is an alternation of names for the thing (e.g. the review CLI, the
+    guardrail catalog). Matching is confined to the section body so prose
+    elsewhere cannot satisfy the contract.
+    """
+    heading = SKIPPED_HEADING.search(text)
+    if not heading:
+        return False
+    body = text[heading.end():]
+    return bool(re.search(rf"({subject})[^.\n]*{_UNAVAILABLE}", body, re.IGNORECASE))
+
+
+def cli_identity(uip: str) -> str:
+    """`which` + `--version` of the CLI this checker resolved.
+
+    Printed on every run because agent and checker resolve `uip` through
+    different shells: the agent's is a login shell (and, under
+    `sandbox.mock_path_dirs`, a per-task HOME whose dotfiles never run), so a
+    host with several `uip` installs can hand them different binaries. When that
+    happens the report and the ground truth disagree for environmental reasons,
+    and the criterion detail needs to say which binary it spoke to.
+    """
+    path = shutil.which(uip) or uip
+    try:
+        proc = subprocess.run([uip, "--version"], capture_output=True, text=True, timeout=60)
+        version = (proc.stdout or proc.stderr).strip().splitlines()[-1] if proc.returncode == 0 else "unknown"
+    except (OSError, subprocess.SubprocessError, IndexError):
+        version = "unknown"
+    return f"{path} (v{version})"

--- a/tests/tasks/uipath-review/_shared/test_check_guardrail_catalog_evidence.py
+++ b/tests/tasks/uipath-review/_shared/test_check_guardrail_catalog_evidence.py
@@ -1,0 +1,150 @@
+"""Unit tests for check_guardrail_catalog_evidence.py.
+
+Drives the checker with a stubbed `uip` (via the `UIP` env var it honours) and
+varies the report, covering all four cells of the reachable x declared matrix.
+The point of the criterion is that a batched `set +e ... exit 0` wrapper can no
+longer make a broken catalog look verified, so the "unreachable" cases matter
+as much as the happy path.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CHECKER = HERE / "check_guardrail_catalog_evidence.py"
+
+CATALOG_OK = {
+    "Result": "Success",
+    "Code": "GuardrailCatalog",
+    "Data": {"SchemaVersion": "1.0.0", "Guardrails": [
+        {"ValidatorId": "pii_detection"}, {"ValidatorId": "prompt_injection"}]},
+}
+
+SILENT_REPORT = textwrap.dedent("""\
+    # Review Report
+
+    ## Warning Findings
+
+    | W-D-001 | `LC_GUARDRAIL_MISAPPLIED` | PII block at Llm is misapplied. |
+
+    ## Rules Skipped
+
+    None. The live guardrail catalog was available.
+    """)
+
+DECLARED_REPORT = textwrap.dedent("""\
+    # Review Report
+
+    ## Warning Findings
+
+    None.
+
+    ## Rules Skipped
+
+    | `LC_GUARDRAIL_MISAPPLIED` | the guardrails catalog was unavailable, so the rule was skipped. |
+    """)
+
+
+def _fake_uip(tmp_path: Path, payload, *, exit_code: int = 0) -> Path:
+    script = tmp_path / "fake_uip.py"
+    body = payload if isinstance(payload, str) else json.dumps(payload)
+    script.write_text(
+        "import sys\n"
+        f"a=sys.argv[1:]\n"
+        f"sys.stdout.write('1.202.0' if a==['--version'] else {body!r})\n"
+        f"sys.exit(0 if a==['--version'] else {exit_code})\n",
+        encoding="utf-8",
+    )
+    launcher = tmp_path / "fake_uip"
+    launcher.write_text(f'#!/bin/sh\nexec "{sys.executable}" "{script}" "$@"\n', encoding="utf-8")
+    launcher.chmod(0o755)
+    return launcher
+
+
+def run(tmp_path: Path, report: str | None, uip: Path) -> subprocess.CompletedProcess:
+    if report is not None:
+        (tmp_path / "_review_report.md").write_text(report, encoding="utf-8")
+    return subprocess.run([sys.executable, str(CHECKER)], cwd=tmp_path,
+                          env={**os.environ, "UIP": str(uip)}, capture_output=True, text=True)
+
+
+# --- reachable ---------------------------------------------------------------
+
+def test_reachable_and_report_silent_passes(tmp_path):
+    r = run(tmp_path, SILENT_REPORT, _fake_uip(tmp_path, CATALOG_OK))
+    assert r.returncode == 0, r.stderr
+    assert "catalog is reachable" in r.stdout
+    assert "pii_detection" in r.stdout
+
+
+def test_reachable_but_report_claims_unavailable_fails(tmp_path):
+    r = run(tmp_path, DECLARED_REPORT, _fake_uip(tmp_path, CATALOG_OK))
+    assert r.returncode != 0
+    assert "declares the guardrail catalog unavailable" in r.stderr
+    assert "which -a uip" in r.stderr
+
+
+# --- unreachable: the hole `require_success: true` could not close -----------
+
+def test_unreachable_and_report_silent_fails(tmp_path):
+    """The demonstrated false positive: batched `exit 0` hid `unknown command`."""
+    uip = _fake_uip(tmp_path, {"Result": "ValidationError", "Message": "unknown command 'catalog'"})
+    r = run(tmp_path, SILENT_REPORT, uip)
+    assert r.returncode != 0
+    assert "could not be fetched" in r.stderr
+
+
+def test_unreachable_and_report_declares_it_passes(tmp_path):
+    uip = _fake_uip(tmp_path, {"Result": "ValidationError", "Message": "unknown command 'catalog'"})
+    r = run(tmp_path, DECLARED_REPORT, uip)
+    assert r.returncode == 0, r.stderr
+    assert "report declares the guardrail catalog unavailable" in r.stdout
+
+
+def test_catalog_unavailable_code_is_treated_as_unreachable(tmp_path):
+    """guardrails-review.md Step 0 names this exact payload shape."""
+    uip = _fake_uip(tmp_path, {"Result": "Success", "Code": "GuardrailCatalogUnavailable"})
+    r = run(tmp_path, SILENT_REPORT, uip)
+    assert r.returncode != 0
+    assert "GuardrailCatalogUnavailable" in r.stdout
+
+
+def test_empty_validator_list_is_unreachable(tmp_path):
+    uip = _fake_uip(tmp_path, {"Result": "Success", "Data": {"Guardrails": []}})
+    r = run(tmp_path, SILENT_REPORT, uip)
+    assert r.returncode != 0
+    assert "zero validators" in r.stdout
+
+
+def test_non_json_output_is_unreachable(tmp_path):
+    r = run(tmp_path, SILENT_REPORT, _fake_uip(tmp_path, "not json"))
+    assert r.returncode != 0
+    assert "non-JSON output" in r.stdout
+
+
+def test_missing_binary_is_unreachable(tmp_path):
+    (tmp_path / "_review_report.md").write_text(SILENT_REPORT, encoding="utf-8")
+    r = subprocess.run([sys.executable, str(CHECKER)], cwd=tmp_path,
+                       env={**os.environ, "UIP": "/nonexistent/uip"}, capture_output=True, text=True)
+    assert r.returncode != 0
+    assert "not on PATH" in r.stdout
+
+
+# --- report plumbing ---------------------------------------------------------
+
+def test_missing_report_fails(tmp_path):
+    r = run(tmp_path, None, _fake_uip(tmp_path, CATALOG_OK))
+    assert r.returncode != 0
+    assert "not found" in r.stderr
+
+
+def test_unavailability_prose_outside_rules_skipped_does_not_count(tmp_path):
+    uip = _fake_uip(tmp_path, {"Result": "ValidationError", "Message": "boom"})
+    misplaced = "# R\n\nThe guardrails catalog was unavailable, so I guessed.\n\n## Rules Skipped\n\nNone.\n"
+    r = run(tmp_path, misplaced, uip)
+    assert r.returncode != 0

--- a/tests/tasks/uipath-review/_shared/test_check_review_cli_provenance.py
+++ b/tests/tasks/uipath-review/_shared/test_check_review_cli_provenance.py
@@ -1,0 +1,279 @@
+"""Unit tests for check_review_cli_provenance.py.
+
+The checker's whole point is that its verdict tracks the REPORT's content and
+never the shape of the agent's shell calls, so these tests drive it with a
+stubbed `uip` (via the `UIP` env var the checker honours) and vary only the
+report. A batched-vs-unbatched command trajectory cannot change any outcome
+here — that is the property the criterion swap was made to buy.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+CHECKER = HERE / "check_review_cli_provenance.py"
+
+CLI_RULE_ID = "LOWCODE_EVAL_SET_EMPTY"
+
+GOOD_REPORT = textwrap.dedent(
+    f"""\
+    # Review Report — ReviewSol / SampleAgent
+
+    **Agent grade: B — Good.** The deterministic review grade was A; the judgment
+    score was 71/100, so the final grade is B.
+
+    ## Automated Review Result
+
+    `uip agent review` returned grade **A**, score **99**, and one informational
+    deterministic finding:
+
+    | ID | Rule | Finding |
+    |---|---|---|
+    | I-D-001 | `{CLI_RULE_ID}` | Eval set has no datapoints. Add datapoints. |
+
+    ## Warning Findings
+
+    | ID | Rule | Finding |
+    |---|---|---|
+    | W-D-001 | `LC_GUARDRAIL_MISAPPLIED` | PII block at Llm is misapplied. Remove it. |
+
+    ## Rules Skipped
+
+    None. The agent review CLI completed successfully.
+    """
+)
+
+
+def _fake_uip(tmp_path: Path, payload: object, *, exit_code: int = 0) -> Path:
+    """A stand-in `uip` that prints `payload` and exits `exit_code`."""
+    script = tmp_path / "fake_uip.py"
+    body = payload if isinstance(payload, str) else json.dumps(payload)
+    script.write_text(
+        "import sys\n"
+        f"sys.stdout.write({body!r})\n"
+        f"sys.exit({exit_code})\n",
+        encoding="utf-8",
+    )
+    launcher = tmp_path / "fake_uip"
+    launcher.write_text(f'#!/bin/sh\nexec "{sys.executable}" "{script}" "$@"\n', encoding="utf-8")
+    launcher.chmod(0o755)
+    return launcher
+
+
+def _payload(issues: list[str], *, grade: str = "A", score: int = 99) -> dict:
+    return {
+        "Result": "Success",
+        "Code": "AgentReview",
+        "Data": {
+            "Verdict": "PASS",
+            "Score": score,
+            "Grade": grade,
+            "Issues": [
+                {"RuleId": r, "Severity": "info", "Description": "d", "File": "f", "SuggestedFix": "s"}
+                for r in issues
+            ],
+            "Stats": {"Errors": 0, "Warnings": 0, "Infos": len(issues)},
+        },
+    }
+
+
+def run(tmp_path: Path, report: str | None, uip: Path) -> subprocess.CompletedProcess:
+    if report is not None:
+        (tmp_path / "_review_report.md").write_text(report, encoding="utf-8")
+    env = {**os.environ, "UIP": str(uip)}
+    return subprocess.run(
+        [sys.executable, str(CHECKER)],
+        cwd=tmp_path, env=env, capture_output=True, text=True,
+    )
+
+
+# --- the CLI ran and the report proves it ----------------------------------
+
+def test_passes_when_report_carries_every_cli_rule_id(tmp_path):
+    uip = _fake_uip(tmp_path, _payload([CLI_RULE_ID]))
+    r = run(tmp_path, GOOD_REPORT, uip)
+    assert r.returncode == 0, r.stderr
+    assert "carries every CLI-emitted rule_id" in r.stdout
+
+
+def test_passes_regardless_of_how_the_agent_shelled_out(tmp_path):
+    """No command telemetry is consulted, so batching cannot change the verdict."""
+    uip = _fake_uip(tmp_path, _payload([CLI_RULE_ID]))
+    r = run(tmp_path, GOOD_REPORT, uip)
+    assert r.returncode == 0
+    assert "command" not in r.stderr.lower()
+
+
+# --- the CLI did not run ----------------------------------------------------
+
+def test_fails_when_report_omits_a_cli_rule_id(tmp_path):
+    uip = _fake_uip(tmp_path, _payload([CLI_RULE_ID]))
+    stripped = GOOD_REPORT.replace(f"`{CLI_RULE_ID}`", "`LC_EVAL_COVERAGE_THIN`")
+    r = run(tmp_path, stripped, uip)
+    assert r.returncode != 0
+    assert CLI_RULE_ID in r.stderr
+
+
+def test_fails_when_only_some_cli_rule_ids_are_carried(tmp_path):
+    uip = _fake_uip(tmp_path, _payload([CLI_RULE_ID, "LOWCODE_ENTRY_POINTS_MISSING"]))
+    r = run(tmp_path, GOOD_REPORT, uip)
+    assert r.returncode != 0
+    assert "LOWCODE_ENTRY_POINTS_MISSING" in r.stderr
+    assert CLI_RULE_ID not in r.stderr  # the carried one is not reported missing
+
+
+# --- clean fixture: nothing to carry, fall back to grade/score --------------
+
+def test_passes_on_clean_fixture_when_grade_is_evidenced(tmp_path):
+    uip = _fake_uip(tmp_path, _payload([], grade="A", score=100))
+    r = run(tmp_path, GOOD_REPORT, uip)
+    assert r.returncode == 0, r.stderr
+    assert "no findings" in r.stdout
+
+
+def test_fails_on_clean_fixture_when_report_evidences_nothing(tmp_path):
+    uip = _fake_uip(tmp_path, _payload([], grade="D", score=42))
+    bare = "# Review Report\n\n## Warning Findings\n\nNothing was checked here.\n"
+    r = run(tmp_path, bare, uip)
+    assert r.returncode != 0
+    assert "no trace that Step 2.5a ran" in r.stderr
+
+
+# --- ground truth unobtainable ---------------------------------------------
+
+def test_fails_when_cli_is_down_and_report_is_silent(tmp_path):
+    uip = _fake_uip(tmp_path, "boom", exit_code=3)
+    r = run(tmp_path, GOOD_REPORT, uip)
+    assert r.returncode != 0
+    assert "does not declare it unavailable" in r.stderr
+
+
+def test_passes_when_cli_is_down_and_report_declares_it_skipped(tmp_path):
+    uip = _fake_uip(tmp_path, "boom", exit_code=3)
+    declared = GOOD_REPORT.replace(
+        "None. The agent review CLI completed successfully.",
+        "| Step 2.5a | `uip agent review` | reason: the review CLI was unavailable. |",
+    )
+    r = run(tmp_path, declared, uip)
+    assert r.returncode == 0, r.stderr
+    assert "declares the review CLI unavailable" in r.stdout
+
+
+def test_skip_note_outside_rules_skipped_does_not_count(tmp_path):
+    """The declaration must live under 'Rules Skipped', not anywhere in prose."""
+    uip = _fake_uip(tmp_path, "boom", exit_code=3)
+    misplaced = (
+        "# Review Report\n\nThe review CLI was unavailable, so I guessed.\n\n"
+        "## Rules Skipped\n\nNone.\n"
+    )
+    r = run(tmp_path, misplaced, uip)
+    assert r.returncode != 0
+
+
+def test_cli_capability_divergence_fails_with_an_environment_diagnostic(tmp_path):
+    """Report says the CLI lacks `review`, but the checker's `uip` provides it.
+
+    Observed for real: on a host with three `uip` installs, the Codex agent's
+    login shell (per-task HOME, so no dotfiles) resolved a stale 1.0.0 without
+    `agent review`, while the checker resolved 1.202.0. This must fail -- passing
+    on the declaration alone would let any agent skip Step 2.5a by writing one
+    line -- but the message must point at the environment, not at the skill.
+    """
+    uip = _fake_uip(tmp_path, _payload([CLI_RULE_ID]))
+    declared = GOOD_REPORT.replace(f"`{CLI_RULE_ID}`", "`LC_EVAL_COVERAGE_THIN`").replace(
+        "None. The agent review CLI completed successfully.",
+        "| `uip agent review` | The installed CLI does not provide the `review` command. |",
+    )
+    r = run(tmp_path, declared, uip)
+    assert r.returncode != 0
+    assert "resolved a different `uip`" in r.stderr
+    assert "which -a uip" in r.stderr
+
+
+def test_checker_reports_which_cli_it_resolved(tmp_path):
+    uip = _fake_uip(tmp_path, _payload([CLI_RULE_ID]))
+    r = run(tmp_path, GOOD_REPORT, uip)
+    assert "Checker resolved" in r.stdout
+    assert str(uip) in r.stdout
+
+
+def test_non_success_result_is_treated_as_unavailable(tmp_path):
+    uip = _fake_uip(tmp_path, {"Result": "ValidationError", "Message": "bad project"})
+    r = run(tmp_path, GOOD_REPORT, uip)
+    assert r.returncode != 0
+    assert "ValidationError" in r.stdout or "ValidationError" in r.stderr
+
+
+def test_non_json_output_is_treated_as_unavailable(tmp_path):
+    uip = _fake_uip(tmp_path, "not json at all")
+    r = run(tmp_path, GOOD_REPORT, uip)
+    assert r.returncode != 0
+    assert "non-JSON output" in r.stdout
+
+
+# --- report plumbing --------------------------------------------------------
+
+def test_fails_when_report_missing(tmp_path):
+    uip = _fake_uip(tmp_path, _payload([CLI_RULE_ID]))
+    r = run(tmp_path, None, uip)
+    assert r.returncode != 0
+    assert "not found" in r.stderr
+
+
+def test_unattributed_grade_warns_but_does_not_fail(tmp_path):
+    """Step 4.5 only *requires* printing the CLI grade when it differs."""
+    uip = _fake_uip(tmp_path, _payload([CLI_RULE_ID], grade="F"))
+    r = run(tmp_path, GOOD_REPORT, uip)
+    assert r.returncode == 0, r.stderr
+    assert "does not attribute grade F" in r.stdout
+
+
+# --- how strong is the evidence for THIS rule_id? ---------------------------
+
+def _run_with_repo(tmp_path: Path, report: str, uip: Path, repo: str | None):
+    (tmp_path / "_review_report.md").write_text(report, encoding="utf-8")
+    env = {**os.environ, "UIP": str(uip)}
+    env.pop("SKILLS_REPO_PATH", None)
+    if repo:
+        env["SKILLS_REPO_PATH"] = repo
+    return subprocess.run([sys.executable, str(CHECKER)], cwd=tmp_path, env=env,
+                          capture_output=True, text=True)
+
+
+REAL_REPO = str(Path(__file__).resolve().parents[4])  # .../Projects/skills
+
+
+def test_rule_id_absent_from_skill_tree_is_reported_as_proof(tmp_path):
+    """`LOWCODE_EVAL_SET_EMPTY` is in no skill file, so citing it proves invocation."""
+    uip = _fake_uip(tmp_path, _payload([CLI_RULE_ID]))
+    r = _run_with_repo(tmp_path, GOOD_REPORT, uip, REAL_REPO)
+    assert r.returncode == 0, r.stderr
+    assert "appear nowhere in the skill tree" in r.stdout
+
+
+def test_rule_id_documented_in_the_skill_downgrades_the_claim(tmp_path):
+    """`CODED_GUARDRAIL_WRONG_IMPORT` is named in SKILL.md and agents-coded-rules.md.
+
+    An agent could cite it from the source without running the CLI, so the
+    criterion must say so rather than claim proof of invocation.
+    """
+    rid = "CODED_GUARDRAIL_WRONG_IMPORT"
+    uip = _fake_uip(tmp_path, _payload([rid]))
+    report = GOOD_REPORT.replace(CLI_RULE_ID, rid)
+    r = _run_with_repo(tmp_path, report, uip, REAL_REPO)
+    assert r.returncode == 0, r.stderr
+    assert "does not by itself prove the CLI ran" in r.stdout
+
+
+def test_probe_is_silent_without_skills_repo_path(tmp_path):
+    uip = _fake_uip(tmp_path, _payload([CLI_RULE_ID]))
+    r = _run_with_repo(tmp_path, GOOD_REPORT, uip, None)
+    assert r.returncode == 0, r.stderr
+    assert "skill tree" not in r.stdout

--- a/tests/tasks/uipath-review/agents/coded_review_guardrail_action_ineffective/coded_review_guardrail_action_ineffective.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_guardrail_action_ineffective/coded_review_guardrail_action_ineffective.yaml
@@ -55,10 +55,24 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Fetched the live guardrail catalog (coded-guardrails-review.md Step 0)"
+    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
     min_count: 1
+    weight: 0
+    pass_threshold: 0
+  # Carries the gating weight the advisory check above gave up. That matcher is
+  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
+  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
+  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # 'catalog'`. This establishes whether the catalog was really reachable and holds
+  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
+  # prove the agent fetched it -- no artifact survives that would.
+  - type: run_command
+    description: "Guardrail catalog reachable, and the report's claim about it is consistent"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-review/agents/coded_review_guardrail_action_ineffective/coded_review_guardrail_action_ineffective.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_guardrail_action_ineffective/coded_review_guardrail_action_ineffective.yaml
@@ -54,20 +54,16 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
-    min_count: 1
-    weight: 0
-    pass_threshold: 0
-  # Carries the gating weight the advisory check above gave up. That matcher is
-  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
-  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
-  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # Replaces a `command_executed` check on `uip\s+agent\s+guardrails\s+catalog`.
+  # That matcher was wrapper-blind (coder_eval only searches the first 2000 chars of
+  # a command, so a batched call is invisible), and its `require_success: true` read
+  # the batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in
+  # two live Codex runs while the command actually returned `unknown command
   # 'catalog'`. This establishes whether the catalog was really reachable and holds
-  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
-  # prove the agent fetched it -- no artifact survives that would.
+  # the report to guardrails-review.md Step 0's contract when it was not. It does not
+  # prove the agent fetched the catalog; no artifact survives that would, and a
+  # weight-0 advisory of the old check was dropped rather than kept as decoration --
+  # it renders PASS at every score, and this suite is triaged on pass/fail alone.
   - type: run_command
     description: "Guardrail catalog reachable, and the report's claim about it is consistent"
     command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'

--- a/tests/tasks/uipath-review/agents/coded_review_guardrail_misapplied/coded_review_guardrail_misapplied.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_guardrail_misapplied/coded_review_guardrail_misapplied.yaml
@@ -54,10 +54,24 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Fetched the live guardrail catalog (coded-guardrails-review.md Step 0)"
+    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
     min_count: 1
+    weight: 0
+    pass_threshold: 0
+  # Carries the gating weight the advisory check above gave up. That matcher is
+  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
+  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
+  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # 'catalog'`. This establishes whether the catalog was really reachable and holds
+  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
+  # prove the agent fetched it -- no artifact survives that would.
+  - type: run_command
+    description: "Guardrail catalog reachable, and the report's claim about it is consistent"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-review/agents/coded_review_guardrail_misapplied/coded_review_guardrail_misapplied.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_guardrail_misapplied/coded_review_guardrail_misapplied.yaml
@@ -53,20 +53,16 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
-    min_count: 1
-    weight: 0
-    pass_threshold: 0
-  # Carries the gating weight the advisory check above gave up. That matcher is
-  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
-  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
-  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # Replaces a `command_executed` check on `uip\s+agent\s+guardrails\s+catalog`.
+  # That matcher was wrapper-blind (coder_eval only searches the first 2000 chars of
+  # a command, so a batched call is invisible), and its `require_success: true` read
+  # the batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in
+  # two live Codex runs while the command actually returned `unknown command
   # 'catalog'`. This establishes whether the catalog was really reachable and holds
-  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
-  # prove the agent fetched it -- no artifact survives that would.
+  # the report to guardrails-review.md Step 0's contract when it was not. It does not
+  # prove the agent fetched the catalog; no artifact survives that would, and a
+  # weight-0 advisory of the old check was dropped rather than kept as decoration --
+  # it renders PASS at every score, and this suite is triaged on pass/fail alone.
   - type: run_command
     description: "Guardrail catalog reachable, and the report's claim about it is consistent"
     command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'

--- a/tests/tasks/uipath-review/agents/coded_review_guardrail_recommended/coded_review_guardrail_recommended.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_guardrail_recommended/coded_review_guardrail_recommended.yaml
@@ -54,10 +54,24 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Fetched the live guardrail catalog (coded-guardrails-review.md Step 0)"
+    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
     min_count: 1
+    weight: 0
+    pass_threshold: 0
+  # Carries the gating weight the advisory check above gave up. That matcher is
+  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
+  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
+  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # 'catalog'`. This establishes whether the catalog was really reachable and holds
+  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
+  # prove the agent fetched it -- no artifact survives that would.
+  - type: run_command
+    description: "Guardrail catalog reachable, and the report's claim about it is consistent"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-review/agents/coded_review_guardrail_recommended/coded_review_guardrail_recommended.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_guardrail_recommended/coded_review_guardrail_recommended.yaml
@@ -53,20 +53,16 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
-    min_count: 1
-    weight: 0
-    pass_threshold: 0
-  # Carries the gating weight the advisory check above gave up. That matcher is
-  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
-  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
-  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # Replaces a `command_executed` check on `uip\s+agent\s+guardrails\s+catalog`.
+  # That matcher was wrapper-blind (coder_eval only searches the first 2000 chars of
+  # a command, so a batched call is invisible), and its `require_success: true` read
+  # the batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in
+  # two live Codex runs while the command actually returned `unknown command
   # 'catalog'`. This establishes whether the catalog was really reachable and holds
-  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
-  # prove the agent fetched it -- no artifact survives that would.
+  # the report to guardrails-review.md Step 0's contract when it was not. It does not
+  # prove the agent fetched the catalog; no artifact survives that would, and a
+  # weight-0 advisory of the old check was dropped rather than kept as decoration --
+  # it renders PASS at every score, and this suite is triaged on pass/fail alone.
   - type: run_command
     description: "Guardrail catalog reachable, and the report's claim about it is consistent"
     command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'

--- a/tests/tasks/uipath-review/agents/coded_review_guardrail_wrong_import/coded_review_guardrail_wrong_import.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_guardrail_wrong_import/coded_review_guardrail_wrong_import.yaml
@@ -50,11 +50,18 @@ success_criteria:
   # (Step 2.5a). It's deterministic and offline, so this gate proves the CLI ran,
   # letting the run_command check accept either the verbatim rule_id or a
   # summarized wrong-import finding without letting an eyeballed guess pass.
-  - type: command_executed
-    description: "Ran the coded review CLI (Step 2.5a) — the source of the wrong-import finding"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+codedagent\s+review'
-    min_count: 1
+  # Artifact evidence, not command telemetry. A `command_executed` criterion on the
+  # review CLI scores the shape of the agent's shell call rather than the work:
+  # coder_eval matches the pattern against only the first 2000 chars of a command,
+  # so a CLI call late in a batched `bash -lc` script is invisible, and
+  # `require_success` sees only the wrapper's exit code, which `set +e ... exit 0`
+  # pins to 0. This asserts the same thing from the report instead -- see the
+  # checker's module docstring.
+  - type: run_command
+    description: "Report carries the review CLI's deterministic findings (Step 2.5a ran)"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_cli_provenance.py --project CodedAgent --verb "codedagent review"'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_action_ineffective/lowcode_review_guardrail_action_ineffective.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_action_ineffective/lowcode_review_guardrail_action_ineffective.yaml
@@ -51,23 +51,42 @@ success_criteria:
     command_pattern: '"file_path":\s*"[^"]*ReviewSol'
     weight: 3.0
 
-  - type: command_executed
-    description: "Ran the review CLI first (Step 2.5a) — guardrail is format-clean"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+review'
-    min_count: 1
-    require_success: true
+  # Artifact evidence, not command telemetry. A `command_executed` criterion on the
+  # review CLI scores the shape of the agent's shell call rather than the work:
+  # coder_eval matches the pattern against only the first 2000 chars of a command,
+  # so a CLI call late in a batched `bash -lc` script is invisible, and
+  # `require_success` sees only the wrapper's exit code, which `set +e ... exit 0`
+  # pins to 0. This asserts the same thing from the report instead -- see the
+  # checker's module docstring.
+  - type: run_command
+    description: "Report carries the review CLI's deterministic findings (Step 2.5a ran)"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_cli_provenance.py --project ReviewSol/SampleAgent --verb "agent review"'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   # The forcing function: the action-vs-scope defect lives only in the live
   # catalog's when_not_to_use, so a passing report must have fetched it.
   - type: command_executed
-    description: "Fetched the live guardrail catalog (guardrails-review.md Step 0)"
+    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
     min_count: 1
-    require_success: true
+    weight: 0
+    pass_threshold: 0
+  # Carries the gating weight the advisory check above gave up. That matcher is
+  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
+  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
+  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # 'catalog'`. This establishes whether the catalog was really reachable and holds
+  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
+  # prove the agent fetched it -- no artifact survives that would.
+  - type: run_command
+    description: "Guardrail catalog reachable, and the report's claim about it is consistent"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_action_ineffective/lowcode_review_guardrail_action_ineffective.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_action_ineffective/lowcode_review_guardrail_action_ineffective.yaml
@@ -68,20 +68,16 @@ success_criteria:
 
   # The forcing function: the action-vs-scope defect lives only in the live
   # catalog's when_not_to_use, so a passing report must have fetched it.
-  - type: command_executed
-    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
-    min_count: 1
-    weight: 0
-    pass_threshold: 0
-  # Carries the gating weight the advisory check above gave up. That matcher is
-  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
-  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
-  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # Replaces a `command_executed` check on `uip\s+agent\s+guardrails\s+catalog`.
+  # That matcher was wrapper-blind (coder_eval only searches the first 2000 chars of
+  # a command, so a batched call is invisible), and its `require_success: true` read
+  # the batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in
+  # two live Codex runs while the command actually returned `unknown command
   # 'catalog'`. This establishes whether the catalog was really reachable and holds
-  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
-  # prove the agent fetched it -- no artifact survives that would.
+  # the report to guardrails-review.md Step 0's contract when it was not. It does not
+  # prove the agent fetched the catalog; no artifact survives that would, and a
+  # weight-0 advisory of the old check was dropped rather than kept as decoration --
+  # it renders PASS at every score, and this suite is triaged on pass/fail alone.
   - type: run_command
     description: "Guardrail catalog reachable, and the report's claim about it is consistent"
     command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
@@ -62,20 +62,16 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
-    min_count: 1
-    weight: 0
-    pass_threshold: 0
-  # Carries the gating weight the advisory check above gave up. That matcher is
-  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
-  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
-  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # Replaces a `command_executed` check on `uip\s+agent\s+guardrails\s+catalog`.
+  # That matcher was wrapper-blind (coder_eval only searches the first 2000 chars of
+  # a command, so a batched call is invisible), and its `require_success: true` read
+  # the batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in
+  # two live Codex runs while the command actually returned `unknown command
   # 'catalog'`. This establishes whether the catalog was really reachable and holds
-  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
-  # prove the agent fetched it -- no artifact survives that would.
+  # the report to guardrails-review.md Step 0's contract when it was not. It does not
+  # prove the agent fetched the catalog; no artifact survives that would, and a
+  # weight-0 advisory of the old check was dropped rather than kept as decoration --
+  # it renders PASS at every score, and this suite is triaged on pass/fail alone.
   - type: run_command
     description: "Guardrail catalog reachable, and the report's claim about it is consistent"
     command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
@@ -47,21 +47,40 @@ success_criteria:
     command_pattern: '"file_path":\s*"[^"]*ReviewSol'
     weight: 3.0
 
-  - type: command_executed
-    description: "Ran the review CLI first (Step 2.5a)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+review'
-    min_count: 1
-    require_success: true
+  # Artifact evidence, not command telemetry. A `command_executed` criterion on the
+  # review CLI scores the shape of the agent's shell call rather than the work:
+  # coder_eval matches the pattern against only the first 2000 chars of a command,
+  # so a CLI call late in a batched `bash -lc` script is invisible, and
+  # `require_success` sees only the wrapper's exit code, which `set +e ... exit 0`
+  # pins to 0. This asserts the same thing from the report instead -- see the
+  # checker's module docstring.
+  - type: run_command
+    description: "Report carries the review CLI's deterministic findings (Step 2.5a ran)"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_cli_provenance.py --project ReviewSol/SampleAgent --verb "agent review"'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Fetched the live guardrail catalog (guardrails-review.md Step 0)"
+    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
     min_count: 1
-    require_success: true
+    weight: 0
+    pass_threshold: 0
+  # Carries the gating weight the advisory check above gave up. That matcher is
+  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
+  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
+  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # 'catalog'`. This establishes whether the catalog was really reachable and holds
+  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
+  # prove the agent fetched it -- no artifact survives that would.
+  - type: run_command
+    description: "Guardrail catalog reachable, and the report's claim about it is consistent"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
@@ -61,20 +61,16 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
-    min_count: 1
-    weight: 0
-    pass_threshold: 0
-  # Carries the gating weight the advisory check above gave up. That matcher is
-  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
-  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
-  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # Replaces a `command_executed` check on `uip\s+agent\s+guardrails\s+catalog`.
+  # That matcher was wrapper-blind (coder_eval only searches the first 2000 chars of
+  # a command, so a batched call is invisible), and its `require_success: true` read
+  # the batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in
+  # two live Codex runs while the command actually returned `unknown command
   # 'catalog'`. This establishes whether the catalog was really reachable and holds
-  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
-  # prove the agent fetched it -- no artifact survives that would.
+  # the report to guardrails-review.md Step 0's contract when it was not. It does not
+  # prove the agent fetched the catalog; no artifact survives that would, and a
+  # weight-0 advisory of the old check was dropped rather than kept as decoration --
+  # it renders PASS at every score, and this suite is triaged on pass/fail alone.
   - type: run_command
     description: "Guardrail catalog reachable, and the report's claim about it is consistent"
     command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
@@ -46,21 +46,40 @@ success_criteria:
     command_pattern: '"file_path":\s*"[^"]*ReviewSol'
     weight: 3.0
 
-  - type: command_executed
-    description: "Ran the review CLI first (Step 2.5a)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+review'
-    min_count: 1
-    require_success: true
+  # Artifact evidence, not command telemetry. A `command_executed` criterion on the
+  # review CLI scores the shape of the agent's shell call rather than the work:
+  # coder_eval matches the pattern against only the first 2000 chars of a command,
+  # so a CLI call late in a batched `bash -lc` script is invisible, and
+  # `require_success` sees only the wrapper's exit code, which `set +e ... exit 0`
+  # pins to 0. This asserts the same thing from the report instead -- see the
+  # checker's module docstring.
+  - type: run_command
+    description: "Report carries the review CLI's deterministic findings (Step 2.5a ran)"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_cli_provenance.py --project ReviewSol/SampleAgent --verb "agent review"'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Fetched the live guardrail catalog (guardrails-review.md Step 0)"
+    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
     min_count: 1
-    require_success: true
+    weight: 0
+    pass_threshold: 0
+  # Carries the gating weight the advisory check above gave up. That matcher is
+  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
+  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
+  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # 'catalog'`. This establishes whether the catalog was really reachable and holds
+  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
+  # prove the agent fetched it -- no artifact survives that would.
+  - type: run_command
+    description: "Guardrail catalog reachable, and the report's claim about it is consistent"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
@@ -48,21 +48,40 @@ success_criteria:
     command_pattern: '"file_path":\s*"[^"]*ReviewSol'
     weight: 3.0
 
-  - type: command_executed
-    description: "Ran the review CLI first (Step 2.5a)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+review'
-    min_count: 1
-    require_success: true
+  # Artifact evidence, not command telemetry. A `command_executed` criterion on
+  # `uip\s+agent\s+review` scores the shape of the agent's shell call rather than
+  # the work: coder_eval matches the pattern against only the first 2000 chars of
+  # a command, so a CLI call late in a batched `bash -lc` script is invisible, and
+  # `require_success` sees only the wrapper's exit code, which `set +e ... exit 0`
+  # pins to 0. This asserts the same thing from the report instead -- see the
+  # checker's module docstring.
+  - type: run_command
+    description: "Report carries the review CLI's deterministic findings (Step 2.5a ran)"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_cli_provenance.py'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Fetched the live guardrail catalog (guardrails-review.md Step 0)"
+    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
     min_count: 1
-    require_success: true
+    weight: 0
+    pass_threshold: 0
+  # Carries the gating weight the advisory check above gave up. That matcher is
+  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
+  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
+  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # 'catalog'`. This establishes whether the catalog was really reachable and holds
+  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
+  # prove the agent fetched it -- no artifact survives that would.
+  - type: run_command
+    description: "Guardrail catalog reachable, and the report's claim about it is consistent"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
@@ -63,20 +63,16 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent fetched the live guardrail catalog visibly in Bash (not gated — the matcher only sees the first 2000 chars of a command, so a batched call is invisible)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
-    min_count: 1
-    weight: 0
-    pass_threshold: 0
-  # Carries the gating weight the advisory check above gave up. That matcher is
-  # wrapper-blind, and its `require_success: true` (now dropped) reads only the
-  # batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in two
-  # live Codex runs while `guardrails catalog` actually returned `unknown command
+  # Replaces a `command_executed` check on `uip\s+agent\s+guardrails\s+catalog`.
+  # That matcher was wrapper-blind (coder_eval only searches the first 2000 chars of
+  # a command, so a batched call is invisible), and its `require_success: true` read
+  # the batch wrapper's exit code -- a `set +e ... exit 0` script scored it 1.00 in
+  # two live Codex runs while the command actually returned `unknown command
   # 'catalog'`. This establishes whether the catalog was really reachable and holds
-  # the report to guardrails-review.md Step 0's contract when it was not. It cannot
-  # prove the agent fetched it -- no artifact survives that would.
+  # the report to guardrails-review.md Step 0's contract when it was not. It does not
+  # prove the agent fetched the catalog; no artifact survives that would, and a
+  # weight-0 advisory of the old check was dropped rather than kept as decoration --
+  # it renders PASS at every score, and this suite is triaged on pass/fail alone.
   - type: run_command
     description: "Guardrail catalog reachable, and the report's claim about it is consistent"
     command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_guardrail_catalog_evidence.py'

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_unknown_validator/lowcode_review_guardrail_unknown_validator.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_unknown_validator/lowcode_review_guardrail_unknown_validator.yaml
@@ -56,12 +56,18 @@ success_criteria:
   # letting an eyeballed guess pass. (Previously the check required the rule_id
   # transcribed verbatim into the saved report, which flaked on Bedrock when the
   # agent ran the review but summarized the finding instead of copying the id.)
-  - type: command_executed
-    description: "Ran the catalog-backed review CLI (Step 2.5a) — the only source of the unknown-validator finding"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+review'
-    min_count: 1
-    require_success: true
+  # Artifact evidence, not command telemetry. A `command_executed` criterion on the
+  # review CLI scores the shape of the agent's shell call rather than the work:
+  # coder_eval matches the pattern against only the first 2000 chars of a command,
+  # so a CLI call late in a batched `bash -lc` script is invisible, and
+  # `require_success` sees only the wrapper's exit code, which `set +e ... exit 0`
+  # pins to 0. This asserts the same thing from the report instead -- see the
+  # checker's module docstring.
+  - type: run_command
+    description: "Report carries the review CLI's deterministic findings (Step 2.5a ran)"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_cli_provenance.py --project ReviewSol/SampleAgent --verb "agent review"'
+    timeout: 240
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Problem

The `uipath-review` guardrail tasks gated on `command_executed` patterns for the review CLI and the guardrail catalog. That matcher scores the *shape of the agent's shell call* rather than the work, and it fails in both directions.

**False negative — the run that prompted this.** In the 2026-08-31 codereval run, [`skill-review-agents-lowcode-guardrail-misapplied`](https://coder-evalboard.uipath-dev.com/runs/2026-08-31_04-17-25/skill-review-agents-lowcode-guardrail-misapplied) scored 0.889 with one failing criterion. coder_eval matches `command_pattern` against only the first 2000 chars of a command (`criteria/command_executed.py::_MAX_PATTERN_SEARCH_LEN`, a ReDoS guard). The agent batched four CLI calls into one 2293-char `bash -lc` script:

| command | offset | matched? |
|---|---|---|
| `uip agent guardrails catalog` | 1262 | yes — 738 bytes of headroom |
| `uip agent review` | **2063** | **no — 63 bytes past the cap** |

Both in the same tool call. The agent *had* run the CLI successfully — its report records grade A, score 99. Whether the criterion passes depends on how much unrelated preamble the agent happened to emit, so these criteria are flaky by construction.

**False positive.** `require_success: true` reads the *wrapper's* exit code (`agents/codex_agent.py`), and a batched script that opens `set +e` and closes `exit 0` always reports success. Two live Codex runs scored the catalog criterion **1.00 while the command returned `unknown command 'catalog'`** — the eval reported catalog-grounded findings as verified when the catalog was never read.

## Change

**Review CLI → artifact evidence.** `check_review_cli_provenance.py` re-runs the review CLI on the (contractually unmodified) fixture and requires the report to carry the deterministic `RuleId`s it emits. Evidence strength varies by rule_id, so the checker *measures* it rather than assuming:

- `LOWCODE_EVAL_SET_EMPTY` appears nowhere in the agent-readable skill tree → citing it proves invocation.
- `CODED_GUARDRAIL_WRONG_IMPORT` is documented in `SKILL.md` and `agents-coded-rules.md` → a WARN states the check verifies carry-through per Step 2.5a, **not** invocation. The criterion detail never overstates what it established.

**Catalog → reachability cross-check.** There is no equivalent artifact, and I checked: the catalog's unique fields (`DetectionMethod`, `Examples[].Name`) are never required in a report; the mandated "matched catalog clause" is paraphrased in practice; and the `.guardrails-catalog-cache.json` from Step 0 was absent from the final sandbox in **10 of 10** measured runs. So the wrapper-blind matcher is **removed** and a new criterion takes the gating weight:

| catalog reachable | report says unavailable | verdict |
|---|---|---|
| yes | no | PASS |
| yes | yes | **FAIL** — contradiction |
| no | yes | PASS — Critical Rule 11 honoured |
| no | no | **FAIL** — ungrounded findings, undisclosed |

I first demoted that matcher to advisory (weight 0, pass_threshold 0) following #2927, then removed it in the second commit. With `min_count: 1` the score is `match_count / min_count`, so "nobody fetched the catalog" scores 0.00 and "everybody did" scores 1.00 — but **both render PASS** at threshold 0. The distinction survives only in the score column, and this suite is triaged on pass/fail status, so it was decoration that read as coverage the eval does not have. What is genuinely lost is the only probe of whether the agent *invoked* the fetch; the criterion comment records that rather than leaving a reader to assume the `run_command` covers it. (The pre-existing advisories in `uipath-agents/{coded,lowcode}/guardrails/validate` have the same property, but are out of scope here.)

Shared checkers live in `_shared/` behind `$SKILLS_REPO_PATH` — the pattern #2927 established for sandbox reachability.

## Deliberately not converted

`coded_review_guardrail_{action_ineffective,misapplied,recommended}`. Their fixtures return **zero CLI findings** (Grade A+, Score 100), so no artifact can prove the CLI ran. The fallback would key on `100`, which collides with the evaluator rubric text ("Score 0-100…") present in those very reports — trading this PR's false negative for a false positive. The durable fix is a deterministic, CLI-detectable defect in those fixtures; happy to file that separately.

## Validation

Codex Terra (`gpt-5.6-terra`) and Claude Sonnet 5, `--driver tempdir`:

| run | result |
|---|---|
| **13 live task runs** across `lowcode_*_misapplied`, `lowcode_*_unknown_validator`, `coded_*_wrong_import`, `coded_*_misapplied` | **1.000** on both models |
| Shipped config re-validated after the advisory was removed — `lowcode_*_misapplied`, both models | **1.000**, 6 criteria, advisory absent |
| Negative controls (prompt forbidding the CLI), run on the provenance-only config | correctly **FAIL** at 0.500 / 0.778, each exercising a different failure path |
| Original failing nightly report, replayed | old criterion FAIL → **new PASS** |
| The two false-positive runs, replayed | old criterion 1.00 → **new FAIL** with an actionable diagnostic |
| Offline dry-run of every converted task's exact command line against its real fixture | PASS on a compliant report, FAIL on one missing the rule_ids |
| Unit tests | **28 passed** |
| All 1282 tracked task YAMLs | parse clean |

One environment caveat surfaced during validation: agent and checker resolve `uip` through different shells (the agent's is a login shell, and under `sandbox.mock_path_dirs` a per-task HOME whose dotfiles never run), so a host with several `uip` installs can hand them different binaries. Both checkers print which binary they resolved and name that possibility first in the contradiction branch, so it reads as an environment problem rather than a skill regression.

## Residual

The truncation false negative is only fully fixable in coder_eval — the 2000-char cap is undocumented in `TASK_DEFINITION_GUIDE.md`, and 177 `command_not_executed` Bash assertions repo-wide can silently pass the same way. Worth a follow-up there; this PR removes the exposure for the gating criteria it touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvsV9jFqaJm8yv6BvvaCqC


