### PR TITLE
Add licensing owners and @biftime to the platform CODEOWNERS section

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,12 +31,13 @@
 /tests/tasks/uipath-rpa/ @DragosUnguru @RaduAna-Maria @gabrielavaduva @AlvinStanescu @Mihaiii
 
 # Platform skill
-/skills/uipath-platform/ @gabrielavaduva @alexenica @andreiopr @vlad-voinea-uipath @emanueldejanu @gcoman @puscasu-ion-daniel @razvalex @aeremencu @alinahornet @DinuDanNicolae @florin-munteanu-uipath @StefanPopaUi @razvanpotcoveanu @vladbucur-8 @busesorin94 @dmorosanu @MarinRzv @vladimir-cozma @UiPath/team-merlot @UiPath/team-orange @UiPath/DatafabricCodingAgent
+/skills/uipath-platform/ @gabrielavaduva @alexenica @andreiopr @vlad-voinea-uipath @emanueldejanu @gcoman @puscasu-ion-daniel @razvalex @aeremencu @alinahornet @DinuDanNicolae @florin-munteanu-uipath @StefanPopaUi @razvanpotcoveanu @vladbucur-8 @busesorin94 @dmorosanu @MarinRzv @vladimir-cozma @UiPath/team-merlot @UiPath/team-orange @UiPath/DatafabricCodingAgent @biftime
 /skills/uipath-platform/references/traces/ @UiPath/llmops-team
 /skills/uipath-platform/references/integration-service/ @chandusailella @baishalighosh
 /skills/uipath-platform/references/data-fabric/ @UiPath/DatafabricCodingAgent
 /skills/uipath-platform/references/llmgateway/ @denispetre @vstoleru-uipath @dragosvelcea
-/tests/tasks/uipath-platform/ @gabrielavaduva @alexenica @andreiopr @vlad-voinea-uipath @emanueldejanu @gcoman @puscasu-ion-daniel @razvalex @aeremencu @alinahornet @DinuDanNicolae @florin-munteanu-uipath @StefanPopaUi @razvanpotcoveanu @vladbucur-8 @busesorin94 @dmorosanu @MarinRzv @vladimir-cozma @UiPath/team-merlot @UiPath/team-orange @UiPath/DatafabricCodingAgent
+/skills/uipath-platform/references/licensing/ @biftime @mihai-stef-uipath @dinud-uipath @bogdan-alexandru-uipath @raresgrm @cristiansinescu7-uipath
+/tests/tasks/uipath-platform/ @gabrielavaduva @alexenica @andreiopr @vlad-voinea-uipath @emanueldejanu @gcoman @puscasu-ion-daniel @razvalex @aeremencu @alinahornet @DinuDanNicolae @florin-munteanu-uipath @StefanPopaUi @razvanpotcoveanu @vladbucur-8 @busesorin94 @dmorosanu @MarinRzv @vladimir-cozma @UiPath/team-merlot @UiPath/team-orange @UiPath/DatafabricCodingAgent @biftime
 /tests/tasks/uipath-platform/orchestrator/ @gabrielavaduva @alexenica @andreiopr @vlad-voinea-uipath @emanueldejanu @gcoman @puscasu-ion-daniel @razvalex @aeremencu @alinahornet @DinuDanNicolae @florin-munteanu-uipath @StefanPopaUi @razvanpotcoveanu @vladbucur-8 @busesorin94 @dmorosanu @MarinRzv @vladimir-cozma @UiPath/team-merlot @UiPath/team-orange
 /tests/tasks/uipath-platform/resources/ @gabrielavaduva @alexenica @andreiopr @vlad-voinea-uipath @emanueldejanu @gcoman @puscasu-ion-daniel @razvalex @aeremencu @alinahornet @DinuDanNicolae @florin-munteanu-uipath @StefanPopaUi @razvanpotcoveanu @vladbucur-8 @busesorin94 @dmorosanu @MarinRzv @vladimir-cozma @UiPath/team-merlot @UiPath/team-orange
 /tests/tasks/uipath-platform/integration-service/ @chandusailella @baishalighosh
@@ -44,6 +45,7 @@
 /tests/tasks/uipath-platform/traces/ @UiPath/llmops-team
 /tests/fixtures/ @gabrielavaduva @alexenica @andreiopr @vlad-voinea-uipath @emanueldejanu @gcoman @puscasu-ion-daniel @razvalex @aeremencu @alinahornet @DinuDanNicolae @florin-munteanu-uipath @StefanPopaUi @razvanpotcoveanu @vladbucur-8 @busesorin94 @dmorosanu @MarinRzv @vladimir-cozma @UiPath/team-merlot @UiPath/team-orange
 /tests/tasks/uipath-platform/data-fabric/ @UiPath/DatafabricCodingAgent
+/tests/tasks/uipath-platform/licensing/ @biftime @mihai-stef-uipath @dinud-uipath @bogdan-alexandru-uipath @raresgrm @cristiansinescu7-uipath
 
 # Agents skill (coded + low-code)
 /skills/uipath-agents/ @UiPath/team-coded-agents @AlexandruCGhimisi @andreibalas-uipath @al3xanndru @andreitava-uip


### PR DESCRIPTION
## What

Two changes in the `# Platform skill` section of CODEOWNERS.

**1. Licensing sub-area entries**, placed alongside the existing `traces` / `integration-service` / `data-fabric` / `llmgateway` entries:

```
/skills/uipath-platform/references/licensing/ @biftime @mihai-stef-uipath @dinud-uipath @bogdan-alexandru-uipath @raresgrm @cristiansinescu7-uipath
/tests/tasks/uipath-platform/licensing/       @biftime @mihai-stef-uipath @dinud-uipath @bogdan-alexandru-uipath @raresgrm @cristiansinescu7-uipath
```

**2. `@biftime` appended** to the two folder-wide platform entries: `/skills/uipath-platform/` and `/tests/tasks/uipath-platform/`.

Four lines changed, no other edits.

## Verification

All six handles resolve on GitHub: `biftime` (Bianca Iftime), `mihai-stef-uipath` (Mihai Stefanescu), `dinud-uipath` (Dinu Dragomirescu), `bogdan-alexandru-uipath` (Andrei-Bogdan Alexandru), `raresgrm` (Rares Gramescu), `cristiansinescu7-uipath`. Both licensing paths exist in the repo.

Simulated last-match-wins resolution across the whole file:

| Path | Owner | `@biftime`? |
|---|---|---|
| `skills/uipath-platform/SKILL.md` | platform team | yes |
| `skills/uipath-platform/references/licensing/` | licensing list | yes |
| `tests/tasks/uipath-platform/licensing/` | licensing list | yes |
| `tests/tasks/uipath-platform/orchestrator/` | platform team | no |
| `skills/uipath-platform/references/traces/` | llmops-team | no |
| `skills/uipath-platform/references/llmgateway/` | llmgateway owners | no |
| `tests/tasks/uipath-platform/data-fabric/` | DatafabricCodingAgent | no |

## Two things to confirm before merge

**Sub-area folders are not covered by the folder-wide `@biftime`.** CODEOWNERS is last-match-wins, so the more specific sub-area entries fully replace the broad platform lines. `@biftime` therefore covers the platform root and anything not carved out, but not `traces`, `llmgateway`, `data-fabric`, `integration-service`, `context-grounding`, `orchestrator`, or `resources`. Extending to those means appending `@biftime` to each of those lines — several are owned by other teams, so I have not done it.

**Write access is unverified.** GitHub silently ignores CODEOWNERS entries for users without write access to the repo, so an entry can look correct and do nothing. Worth confirming all six are org members with write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)