### PR TITLE
chore: gitignore the .local scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,10 @@ tests/tasks/uipath-maestro-flow/canary/Canary/Canary.uipx
 # Git worktrees
 .worktrees/
 
+# Local scratch projects and probe artifacts. Untracked by design: these hold
+# real tenant identifiers (connection IDs, folder keys, account names).
+.local/
+
 # Node (package.json lives at the repo root for the @uipath/skills package)
 node_modules/
 package-lock.json


### PR DESCRIPTION
## Problem

`.local/` is a documented convention in this repo — the `uipath-troubleshoot` skill writes investigation artifacts there, including `raw/`, which holds **verbatim CLI responses** from a live tenant:

```
tests/tasks/uipath-troubleshoot/CLAUDE.md:238
  The skill writes investigation artifacts to `.local/investigations/` — NOT `.investigations/`.
```

It isn't ignored, so anyone who runs that skill is one `git add .` from committing tenant data:

```
$ git check-ignore .local/     # no match
```

## Fix

Ignore `.local/`, with a comment naming why. Nothing tracked is affected — `.local/` has never been committed.
