### PR TITLE
docs(uipath-platform): say what processes resources actually returns

### DIFF
--- a/skills/uipath-platform/references/orchestrator/run-jobs.md
+++ b/skills/uipath-platform/references/orchestrator/run-jobs.md
@@ -107,8 +107,9 @@ Key options:
 # Get one process by key (cross-folder; resolved through the release lookup)
 uip or processes get <process-key-guid> --output json
 
-# Validation report — what does the runtime see when it tries to start this process?
-# Returns missing tools, missing assets, missing connections, schema mismatches.
+# Validation report — is everything this process needs actually present in its folder?
+# One row per resource the package declares (Queue, Asset, Bucket, Connection, Process,
+# EventTrigger, HttpTrigger, Entity, MCPServer, IXP, ProcessExecutionSettings, ...).
 uip or processes resources <process-key-guid> --output json
 
 # Edit fields after creation. Same flag set as `processes create` minus name/package-key/package-version,
@@ -134,6 +135,14 @@ uip or processes rollback <process-key-guid> --output json
 # Delete the process (release). Package itself stays in the feed.
 uip or processes delete <process-key-guid> --yes --output json
 ```
+
+> `processes resources` is the pre-flight check before `jobs start`. Read `ValidationResult` per row:
+> `Success` = the resource exists in the folder (`ResourceId` names it), `NotFound` = it is missing and
+> `ValidationError` says which one ("This queue cannot be found in the folder"), `Unknown` = not
+> folder-validated (connections, execution settings). Filter for the broken ones with
+> `--output-filter "[?ValidationResult=='NotFound']"`. The answer is release-specific: resource
+> overwrites configured on that process are applied first, so a resource pointed at a different
+> target than the package default still reports `Success`.
 
 `processes update` uses `Mapper.Map<ReleaseDto, UiRelease>(dto)` server-side, which means missing fields on the request body are nulled. The CLI works around this by spreading `currentRelease` as the baseline before applying overrides — but if you build the body yourself by hand, `tags`, `arguments`, `videoRecordingSettings`, `targetFramework`, `robotSize`, `resourceOverwrites`, `remoteControlAccess`, `targetRuntime`, `publisherLicense`, etc. will silently get nulled.
 


### PR DESCRIPTION
`run-jobs.md` described `uip or processes resources` as returning "missing tools, missing assets, missing connections, schema mismatches". It returns one row per resource the package declares, each carrying a `ValidationResult` verdict — which is more useful, and nothing in the docs said how to read it.

Adds what an agent needs to act on the output: what `Success` / `NotFound` / `Unknown` mean, that `ValidationError` carries the human-readable reason, the `--output-filter` for pulling just the broken rows, and that release-level resource overwrites are applied (so a resource redirected away from the package default still reports `Success`).

Every claim was run against a live tenant rather than read off the DTO, including the `--output-filter` expression.

One caveat worth knowing while reviewing: the command is broken in shipped builds — it sends the bare process key where the API wants `packageId:version` and gets an opaque HTTP 500. This doc describes the behavior that lands with UiPath/cli#3921. Merging it earlier is harmless (the current text is wrong either way), but the output it documents is not reachable until that ships.

`npm run skills:validate` passes (26 skills, both flavors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)