### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@b570962

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 122da6a. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ b570962. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 122da6a. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ b570962. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 122da6a. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ b570962. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -51,9 +51,10 @@ Prepared connector modules live at `connectors-local/<key>.ts`; their descriptor
 If the request mentions `loadByDefault`, dependent dropdowns, preselected
 reference values, `customFieldsRequestDetails`, or other connection-specific
 fields, the static library descriptor is not sufficient. Before authoring the
-connector call, resolve the real parent values, run `uip maestro registry
-prepare <connector-key> <action> --connection-id <id>` with every required
+connector call, resolve the real parent values, run
+`npx flow-sdk registry prepare <connector-key> <action>` with every required
 `-f NAME=VALUE`, and import the generated `connectors-local/<key>.ts` descriptor.
+It finds the connection itself and writes `bindings.json`.
 
 Do not substitute manual `resources run list` lookups plus a static
 `connectors/<key>.ts` import: the lookups choose values but do not create the

--- a/preview/uipath-maestro-flow/references/api.md
+++ b/preview/uipath-maestro-flow/references/api.md
@@ -29,7 +29,7 @@ generated from the built types; longer tutorials stay in the node references.
 
 **Expressions and types** — [lit](#lit-function) · [v](#v-function) · [DEFAULT_TRIGGER_ID](#defaulttriggerid-const) · [input](#input-function) · [entryInput](#entryinput-function) · [out](#out-function) · [ran](#ran-function) · [err](#err-function) · [js](#js-function) · [tmpl](#tmpl-function) · [types](#types-const)
 
-**Generated descriptors** — [ConnectorValue](#connectorvalue-type) · [ConnectorLookupValue](#connectorlookupvalue-type) · [ConnectorMeta](#connectormeta-interface) · [ConnectorDescriptor](#connectordescriptor-type) · [descriptor](#descriptor-function) · [TriggerMeta](#triggermeta-interface) · [TriggerDescriptor](#triggerdescriptor-type) · [triggerDescriptor](#triggerdescriptor-function) · [LookupStrategy](#lookupstrategy-type) · [LookupSpec](#lookupspec-interface) · [LookupToken](#lookuptoken-interface) · [isLookupToken](#islookuptoken-function) · [lookupKey](#lookupkey-function) · [LookupBuilder](#lookupbuilder-type) · [lookup](#lookup-function) · [LookupResolution](#lookupresolution-interface) · [LookupResolutions](#lookupresolutions-type) · [resolvedValue](#resolvedvalue-function) · [unresolvedLookupMessage](#unresolvedlookupmessage-function) · [lookupSpecOf](#lookupspecof-function)
+**Generated descriptors** — [ConnectorValue](#connectorvalue-type) · [ConnectorLookupValue](#connectorlookupvalue-type) · [ConnectorMeta](#connectormeta-interface) · [ConnectorDescriptor](#connectordescriptor-type) · [descriptor](#descriptor-function) · [TriggerMeta](#triggermeta-interface) · [TriggerDescriptor](#triggerdescriptor-type) · [triggerDescriptor](#triggerdescriptor-function) · [LookupStrategy](#lookupstrategy-type) · [LookupSpec](#lookupspec-interface) · [LookupToken](#lookuptoken-interface) · [isLookupToken](#islookuptoken-function) · [lookupKey](#lookupkey-function) · [LookupBuilder](#lookupbuilder-type) · [lookup](#lookup-function) · [LookupResolution](#lookupresolution-interface) · [LookupResolutions](#lookupresolutions-type) · [resolvedValue](#resolvedvalue-function) · [unresolvedLookupMessage](#unresolvedlookupmessage-function) · [lookupSpecOf](#lookupspecof-function) · [refuseLookupToken](#refuselookuptoken-function)
 
 **Builders** — [FlowBuilder](#flowbuilder-class) · [StepList](#steplist-class) · [ArmBuilder](#armbuilder-class)
 
@@ -865,6 +865,13 @@ export declare function unresolvedLookupMessage(token: LookupToken): string;
 ````ts
 /** The `LookupSpec` for one field, or `undefined` when it earns no helper. */
 export declare function lookupSpecOf(reference: RawReference, invariant?: ReadonlySet<string>): LookupSpec | undefined;
+````
+
+## refuseLookupToken (function)
+
+````ts
+/** Refuse a lookup token where the family cannot resolve one. */
+export declare function refuseLookupToken(value: unknown, family: string, field: string): void;
 ````
 
 ## FlowBuilder (class)

--- a/preview/uipath-maestro-flow/references/bindings.md
+++ b/preview/uipath-maestro-flow/references/bindings.md
@@ -42,8 +42,46 @@ the resource kind and emitted binding purpose explicit.
 | `default` | one of `resourceKey` / `default` | Fallback when `resourceKey` is absent. Shipped examples repeat the resource key here. |
 | `propertyAttribute` | no | `"ConnectionId"` for a connection or `"FolderKey"` for a folder. |
 
+## Where both values come from
+
+**Usually you do not fill these in at all.**
+`npx flow-sdk registry prepare <connector-key> <action>` discovers the connection and writes both entries into `bindings.json` for you — see [connector-params.md](connector-params.md#resolving-connection-scoped-reference-values).
+Reach for the manual route below only when you are authoring bindings without
+running `prepare`.
+
+If you are doing it by hand: `uip is connections list` returns the connection id
+**and its folder key** on the same record, so one call answers both:
+
+```bash
+uip is connections list --output json
+```
+
+```text
+{
+  "Name": "dustin.metzgar",
+  "Id": "c03a1967-f702-47d2-9ede-917aed159805",
+  "Folder": "dustin.metzgar@uipath.com's workspace",
+  "FolderKey": "b53217ce-25b2-46cd-a6b0-b73c6ba5894c",
+  "ConnectorKey": "uipath-salesforce-slack",
+  "State": "Enabled"
+}
+```
+
+`Id` is the connection binding's `resourceKey`; **`FolderKey` is the folder
+binding's**. Add `--all-folders` if the connection you want is not in the
+default listing.
+
+**Do not go looking in Orchestrator for the folder.** `uip or folders list` is a
+different resource with different keys, and a folder binding wants the one the
+CONNECTION lives in — which you already have. Measured on the eval corpus: an
+agent that had already listed the connection went on to spend three to four
+further calls on `uip or --help`, `uip or folders --help` and `folders list`,
+searching for a folder matching the symbolic name in its prompt. The symbolic
+name (`slack`, `shared`) is just the label you pass to `connector()`; it is never
+something to search the tenant for.
+
 Copy this two-connector, one-folder example and replace all three placeholders
-with values from the live connection listing:
+with values from the connection listing above:
 
 ```json
 {

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -90,16 +90,22 @@ the tenant, so it needs a live Integration Service connection and a logged-in
 `uip`; without one, fall back to the curated operation in the markdown library.
 
 ```bash
-npx flow-sdk registry prepare <connector-key> <action> \
-  --connection-id <connection-id>
+npx flow-sdk registry prepare <connector-key> <action>
 # Generic operation: materialize the one connected object the task uses.
-npx flow-sdk registry prepare <connector-key> <action> \
-  --connection-id <connection-id> --object <api-object-name>
+npx flow-sdk registry prepare <connector-key> <action> --object <api-object-name>
 # Use --all-objects only when the task truly needs the full connected catalog.
 ```
 
 The result lands in `./connectors-local/`, which the compilers union over the
 library. Calls accumulate, so preparing a second operation keeps the first.
+
+`prepare` picks the connection itself (see below). Pass `--connection-id <id>`
+only to pin a specific one, and expect it to be checked: a connection whose
+`State` is not `Enabled` is refused, naming the enabled alternatives. A `Failed`
+connection answers field discovery with an empty schema, so preparing through
+it would write an overlay with no fields and the next compile would still
+reject every input as unknown — the refusal is the only signal that says
+"connection", not "field".
 
 Descriptors from either tree are imported with their real `.ts` extension — a
 `.js` specifier does not resolve, because these are sources rather than compiled
@@ -291,7 +297,7 @@ For Jira, `/project/{key}/issuetypes` has no object of its own; `project_statuse
 **3. Prepare with every parent.** Pass them all as `-f NAME=VALUE`:
 
 ```bash
-npx flow-sdk registry prepare <connector-key> <action> --connection-id <connection-id> \
+npx flow-sdk registry prepare <connector-key> <action> \
   -f fields.project.key=IN -f fields.issuetype.id=10620
 ```
 
@@ -359,8 +365,16 @@ channel: lookup(SendMessageToUser, 'channel').byEmail('dustin@example.com')
 
 ```bash
 npx flow-sdk registry prepare uipath-salesforce-slack send-message-to-user \
-  --connection-id <id> --resolve channel:profile.email=dustin@example.com
+  --resolve channel:profile.email=dustin@example.com
 ```
+
+**You do not need to find the connection first.** `prepare` discovers it from
+`uip is connections list` — your own folder first, the tenant second — and writes
+both the connection id AND its folder key into `bindings.json`. So one command
+covers the lookup, the connection binding and the folder binding. Pass
+`--connection <name>` only when several connections match the same connector;
+it reports the candidates rather than guessing, because connections for one
+connector are not interchangeable.
 
 `check` names the exact command when a lookup is unresolved, and warns when a
 lookup field is given a literal id. Run it before compiling: it finds everything


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `122da6a` to current `UiPath/flow-builder-sdk@main` (`b570962`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)