### PR TITLE
feat(uipath-maestro-flow): add child simulation docs and skill test

### DIFF
--- a/skills/uipath-maestro-flow/references/evaluate/CAPABILITY.md
+++ b/skills/uipath-maestro-flow/references/evaluate/CAPABILITY.md
@@ -12,6 +12,7 @@ Capability index for `uip maestro flow eval` — evaluator CRUD (7 types), eval 
 - Create evaluators (`exact-match`, `json-similarity`, `contains`, `llm-judge-*` types) for a Flow project
 - Create or remove eval sets, link them to evaluators, pin entry points
 - Add, list, or remove simulations on data points (`uip maestro flow eval simulation`)
+- Add, list, or remove child tool simulations on agent nodes (`--parent` flag)
 - Start an eval run on Studio Web, poll its status, fetch detailed results
 - Compare two eval runs to verify a change improved scores without regressions
 
@@ -95,6 +96,7 @@ uip maestro flow eval run results <eval_set_run_id> \
 | **Add a data point with file attachments** | [eval-sets-guide.md — `--input-file`](eval-sets-guide.md#--input-file-keypath) |
 | **Set per-data-point criteria for trajectory evaluators** | [eval-sets-guide.md — `--criteria`](eval-sets-guide.md#--criteria) |
 | **Add a simulation to a data point** | [eval-sets-guide.md — Simulations](eval-sets-guide.md#simulations-on-data-points) + [commands-reference.md — Simulations](commands-reference.md#simulations) |
+| **Add a child tool simulation to an agent node** | [eval-sets-guide.md — Child Simulations](eval-sets-guide.md#child-simulations-agent-tool-simulation) + [commands-reference.md — Simulations](commands-reference.md#simulations) |
 | **Start a Studio Web eval run** | [running-guide.md — Start a Run](running-guide.md#start-a-run) |
 | **Poll run status without `--wait`** | [running-guide.md — Check Status](running-guide.md#check-status) |
 | **Inspect only failed data points** | [running-guide.md — Detailed Results](running-guide.md#detailed-results) (`--only-failed --verbose`) |

--- a/skills/uipath-maestro-flow/references/evaluate/commands-reference.md
+++ b/skills/uipath-maestro-flow/references/evaluate/commands-reference.md
@@ -141,11 +141,12 @@ Add or replace a simulation on a data point. If a simulation for `<component-id>
 | `--set <name>` | Yes | Eval set name or ID |
 | `--data-point <id>` | Yes | Data point name or ID |
 | `--strategy <strategy>` | Yes | `Llm` or `Static` |
-| `--component-type <type>` | Yes | Component type (e.g. `connector`, `agent`, `subflow`) |
+| `--component-type <type>` | No | Component type (e.g. `connector`, `agent`, `subflow`). Required unless `--parent` is used (defaults to `Node`). |
 | `--component-description <text>` | No | Human-readable label for the component |
 | `--simulation-instructions <text>` | No | LLM prompt describing what the component should return (for `Llm` strategy) |
 | `--mock-value <json>` | No | Static JSON output (for `Static` strategy) |
-| `--output-schema <json>` | No | JSON Schema describing the expected output shape; passed to the LLM to constrain its response. **Auto-resolved from the `.flow` file when omitted for `Llm` strategy** — fails if the node is not found or has no outputs. Pass explicitly to override. |
+| `--output-schema <json>` | No | JSON Schema describing the expected output shape; passed to the LLM to constrain its response. **Auto-resolved from the `.flow` file when omitted for `Llm` strategy** (top-level simulations only; required when using `--parent`). |
+| `--parent <component-id>` | No | Parent agent node component ID. When set, the simulation is added as a child tool simulation nested inside the parent agent node's simulation. If no parent simulation exists yet, one is auto-created (type `agent`, strategy `Llm`). `--component-type` defaults to `Node`. |
 | `--path <path>` | No | (see Common Options) |
 
 **Strategy guide:**
@@ -185,6 +186,22 @@ uip maestro flow eval simulation add agent-lookup \
   --path ./MySolution/MyFlow --output json
 ```
 
+Example — Child simulation (tool inside an agent node):
+
+```bash
+# Add a child tool simulation. No separate parent simulation step needed —
+# --parent auto-creates the parent if it does not exist.
+uip maestro flow eval simulation add Web_Search \
+  --parent agent-lookup \
+  --set "Smoke Tests" \
+  --data-point "hello-test" \
+  --strategy Static \
+  --mock-value '{"results": [{"title": "Example", "url": "https://example.com"}]}' \
+  --path ./MySolution/MyFlow --output json
+```
+
+The child's `<component-id>` is the tool's **runtime name** (e.g. `Web_Search`, `Send_Email`), not a `.flow` node ID. Child simulations are stored in the parent's `childSimulations` array.
+
 ### `uip maestro flow eval simulation list`
 
 List all simulations configured on a data point.
@@ -193,10 +210,19 @@ List all simulations configured on a data point.
 |------|----------|-------------|
 | `--set <name>` | Yes | Eval set name or ID |
 | `--data-point <id>` | Yes | Data point name or ID |
+| `--parent <component-id>` | No | Parent agent component ID. When set, lists child tool simulations on that parent instead of top-level simulations. |
 | `--path <path>` | No | (see Common Options) |
 
 ```bash
+# List top-level simulations
 uip maestro flow eval simulation list \
+  --set "Smoke Tests" \
+  --data-point "hello-test" \
+  --path ./MySolution/MyFlow --output json
+
+# List child simulations on an agent node
+uip maestro flow eval simulation list \
+  --parent agent-lookup \
   --set "Smoke Tests" \
   --data-point "hello-test" \
   --path ./MySolution/MyFlow --output json
@@ -210,10 +236,19 @@ Remove a simulation from a data point. Returns an error if no simulation with th
 |------|----------|-------------|
 | `--set <name>` | Yes | Eval set name or ID |
 | `--data-point <id>` | Yes | Data point name or ID |
+| `--parent <component-id>` | No | Parent agent component ID. When set, removes a child tool simulation from the parent instead of a top-level simulation. |
 | `--path <path>` | No | (see Common Options) |
 
 ```bash
+# Remove a top-level simulation
 uip maestro flow eval simulation remove connector-send-email \
+  --set "Smoke Tests" \
+  --data-point "hello-test" \
+  --path ./MySolution/MyFlow --output json
+
+# Remove a child simulation from an agent node
+uip maestro flow eval simulation remove Web_Search \
+  --parent agent-lookup \
   --set "Smoke Tests" \
   --data-point "hello-test" \
   --path ./MySolution/MyFlow --output json
@@ -298,6 +333,7 @@ The CLI emits a `Code` field on every JSON response. Useful when filtering or sc
 | `eval set add` / `list` / `remove` | `FlowEvalSetAdd` / `FlowEvalSetList` / `FlowEvalSetRemove` |
 | `eval evaluator add` / `list` / `remove` | `FlowEvalEvaluatorAdd` / `FlowEvalEvaluatorList` / `FlowEvalEvaluatorRemove` |
 | `eval simulation add` / `list` / `remove` | `FlowEvalSimulationAdd` / `FlowEvalSimulationList` / `FlowEvalSimulationRemove` |
+| `eval simulation add --parent` / `list --parent` / `remove --parent` | `FlowEvalChildSimulationAdd` / `FlowEvalChildSimulationList` / `FlowEvalChildSimulationRemove` |
 | `eval run start` (no `--wait`) | `FlowEvalRunStarted` |
 | `eval run start --wait` (summary) | `FlowEvalRunCompleted` |
 | `eval run status` | `FlowEvalRunStatus` |

--- a/skills/uipath-maestro-flow/references/evaluate/eval-sets-guide.md
+++ b/skills/uipath-maestro-flow/references/evaluate/eval-sets-guide.md
@@ -217,6 +217,53 @@ For `Llm` simulations, `--output-schema` is **auto-resolved from the `.flow` fil
 
 Simulations are stored inline in the data point's `simulations` array within the eval set JSON. Running `simulation add` twice for the same `<component-id>` on the same data point replaces the existing simulation.
 
+### Child Simulations (Agent Tool Simulation)
+
+When a flow has an agent node, you can simulate individual tools inside that agent instead of mocking the whole agent as one unit. Use `--parent <agent-component-id>` to target a child tool. The child's `<component-id>` is the tool's runtime name (e.g. `Web_Search`, `Send_Email`), not a workflow node ID.
+
+```bash
+# Add a child tool simulation (Static — fixed output).
+# If no parent simulation exists for <agent-node-id>, one is auto-created
+# (type: agent, strategy: Llm).
+uip maestro flow eval simulation add Web_Search \
+  --parent <agent-node-id> \
+  --set "<set_name>" \
+  --data-point "<data_point_name>" \
+  --strategy Static \
+  --mock-value '{"results": [{"title": "Example", "url": "https://example.com"}]}' \
+  --path <flow_project> --output json
+
+# Add a child tool simulation (Llm — prompt-guided)
+uip maestro flow eval simulation add Send_Email \
+  --parent <agent-node-id> \
+  --set "<set_name>" \
+  --data-point "<data_point_name>" \
+  --strategy Llm \
+  --simulation-instructions "Return a success status with a generated messageId." \
+  --output-schema '{"type":"object","properties":{"status":{"type":"string"},"messageId":{"type":"string"}}}' \
+  --path <flow_project> --output json
+
+# List child simulations on an agent node
+uip maestro flow eval simulation list \
+  --parent <agent-node-id> \
+  --set "<set_name>" \
+  --data-point "<data_point_name>" \
+  --path <flow_project> --output json
+
+# Remove a child simulation
+uip maestro flow eval simulation remove Web_Search \
+  --parent <agent-node-id> \
+  --set "<set_name>" \
+  --data-point "<data_point_name>" \
+  --path <flow_project> --output json
+```
+
+No separate parent simulation step is needed — passing `--parent` auto-creates the parent simulation (type `agent`, strategy `Llm`) if it does not exist yet. This means a single command is enough to add a child tool simulation.
+
+When `--parent` is used, `--component-type` defaults to `Node` (the convention for child tool simulations). You can override it if needed.
+
+Child simulations are stored in the parent's `childSimulations` array in the eval set JSON. Running `simulation add` with `--parent` twice for the same child `<component-id>` replaces the existing child simulation.
+
 ## Anti-patterns
 
 - **Don't hand-write `id` UUIDs on data points.** Use `uip maestro flow eval add` so the CLI generates fresh UUIDs and keeps `evalSetId` consistent with the parent set.

--- a/tests/tasks/uipath-maestro-flow/evaluate/child_simulation/check_child_simulation_crud.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/child_simulation/check_child_simulation_crud.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Verify child simulation CRUD produced real artifacts on disk.
+
+Beyond the `command_executed` matchers (which only prove the agent ran the
+right shell command), confirm that:
+
+  1. An eval-set JSON exists under ChildSimEval/ with name == "Agent Tools"
+     carrying a data point named "search-test" in `evaluations[]`.
+  2. That data point has a `simulations` array with a parent entry whose
+     componentId is "agent-1" (auto-created by --parent).
+  3. The parent has a `childSimulations` array.
+  4. The Static child simulation "Web_Search" is present (add worked).
+  5. The Llm child simulation "Send_Email" is gone (remove worked).
+  6. The parent simulation's componentType is "agent" and simulationStrategy
+     is "Llm" (auto-creation defaults).
+
+Fails if the agent ran the commands but they errored, or fabricated stdout
+without producing/mutating real files.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT = Path("ChildSimEval")
+KEPT_CHILD = "Web_Search"
+REMOVED_CHILD = "Send_Email"
+PARENT_ID = "agent-1"
+
+
+def _load_jsons(root: Path) -> list[tuple[Path, dict]]:
+    out: list[tuple[Path, dict]] = []
+    for p in root.rglob("*.json"):
+        try:
+            out.append((p, json.loads(p.read_text(encoding="utf-8"))))
+        except (OSError, json.JSONDecodeError):
+            continue
+    return out
+
+
+def _component_ids(sims: list) -> list[str]:
+    """Extract componentId from a list of simulation dicts."""
+    ids: list[str] = []
+    for s in sims:
+        if isinstance(s, dict):
+            cid = s.get("componentId") or s.get("component_id") or s.get("id")
+            if isinstance(cid, str):
+                ids.append(cid)
+    return ids
+
+
+def main() -> None:
+    if not PROJECT.is_dir():
+        sys.exit(f"FAIL: project directory {PROJECT} does not exist")
+
+    docs = _load_jsons(PROJECT)
+    if not docs:
+        sys.exit(f"FAIL: no JSON files found under {PROJECT}")
+
+    # 1. Find eval set "Agent Tools"
+    set_match = next(
+        (
+            (p, d)
+            for p, d in docs
+            if isinstance(d, dict)
+            and d.get("name") == "Agent Tools"
+            and isinstance(d.get("evaluations"), list)
+        ),
+        None,
+    )
+    if not set_match:
+        names = [d.get("name") for _, d in docs if isinstance(d, dict) and d.get("name")]
+        sys.exit(
+            f'FAIL: no eval-set JSON under {PROJECT}/ has name="Agent Tools". '
+            f"Found names: {names}"
+        )
+
+    # 2. Find data point "search-test"
+    cases = set_match[1].get("evaluations") or []
+    dp = next(
+        (c for c in cases if isinstance(c, dict) and c.get("name") == "search-test"),
+        None,
+    )
+    if not dp:
+        sys.exit(
+            f'FAIL: eval set "Agent Tools" ({set_match[0]}) has no data point '
+            f'named "search-test". Got: {[c.get("name") for c in cases if isinstance(c, dict)]}'
+        )
+
+    # 3. Find parent simulation "agent-1"
+    sims = dp.get("simulations")
+    if not isinstance(sims, list) or not sims:
+        sys.exit(
+            f'FAIL: data point "search-test" has no simulations array. Got: {sims!r}'
+        )
+
+    parent_ids = _component_ids(sims)
+    parent = next(
+        (s for s in sims if isinstance(s, dict) and s.get("componentId") == PARENT_ID),
+        None,
+    )
+    if not parent:
+        sys.exit(
+            f'FAIL: no parent simulation with componentId="{PARENT_ID}" found. '
+            f"Component ids present: {parent_ids}"
+        )
+
+    # 4. Verify auto-creation defaults
+    parent_type = parent.get("componentType")
+    parent_strategy = parent.get("simulationStrategy")
+    if parent_type != "agent":
+        sys.exit(
+            f'FAIL: parent simulation componentType should be "agent", '
+            f'got "{parent_type}"'
+        )
+    if parent_strategy != "Llm":
+        sys.exit(
+            f'FAIL: auto-created parent simulationStrategy should be "Llm", '
+            f'got "{parent_strategy}"'
+        )
+    print(f"OK: parent simulation {PARENT_ID} auto-created (type=agent, strategy=Llm)")
+
+    # 5. Check child simulations
+    children = parent.get("childSimulations")
+    if not isinstance(children, list):
+        sys.exit(
+            f'FAIL: parent "{PARENT_ID}" has no childSimulations array. '
+            f"Got: {children!r}"
+        )
+
+    child_ids = _component_ids(children)
+
+    if KEPT_CHILD not in child_ids:
+        sys.exit(
+            f'FAIL: child simulation "{KEPT_CHILD}" not found in parent '
+            f'"{PARENT_ID}" childSimulations (add did not persist). '
+            f"Child ids present: {child_ids}"
+        )
+
+    if REMOVED_CHILD in child_ids:
+        sys.exit(
+            f'FAIL: child simulation "{REMOVED_CHILD}" is still present — '
+            f"`simulation remove --parent` did not mutate the eval-set JSON. "
+            f"Child ids present: {child_ids}"
+        )
+
+    print(
+        f"OK: parent '{PARENT_ID}' keeps child '{KEPT_CHILD}' and "
+        f"dropped child '{REMOVED_CHILD}' (child simulation add + remove persisted)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/evaluate/child_simulation/child_simulation_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/child_simulation/child_simulation_crud.yaml
@@ -1,0 +1,146 @@
+task_id: skill-flow-eval-child-simulation-crud
+description: >
+  Skill-guided child simulation CRUD: agent uses the uipath-maestro-flow
+  skill's evaluate capability to scaffold a Flow project, build an eval set +
+  data point, then add child tool simulations on an agent node using
+  `--parent`, list them, and remove one — all in a single pass, no separate
+  parent simulation step. Covers Static and Llm child strategies. Purely
+  local, no login, no upload, no run. Tests whether the skill teaches the
+  `--parent` flag and child simulation lifecycle, and verifies the child
+  simulations persist in the eval-set JSON nested inside the auto-created
+  parent.
+tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, feature:eval, feature:child-simulation]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 60
+
+initial_prompt: |
+  Use the `uipath-maestro-flow` skill's evaluate capability to scaffold a Flow
+  project, build an eval set with one data point, then add **child tool
+  simulations** on an agent node — purely local, no Studio Web round-trip.
+
+  Steps:
+  1. Create a solution `ChildSimEval` and a Flow project `ChildSimEval`. The
+     flow file MUST live at `ChildSimEval/ChildSimEval/ChildSimEval.flow`
+     (double-nested layout) and be linked via `uip solution project add`.
+
+  2. Declare a string input variable named `query` on
+     `ChildSimEval/ChildSimEval/ChildSimEval.flow` before adding the data point.
+
+  3. Create an eval set named `Agent Tools` in the Flow project at
+     `ChildSimEval/ChildSimEval`. (No `--entry-point`, no `--evaluators` —
+     defaults are fine.)
+
+  4. Add one data point named `search-test` to that eval set with inputs
+     `{"query":"weather in NYC"}` and expected
+     `{"answer":"Sunny, 72°F in New York City."}`.
+
+  5. Add a `Static` child simulation on the `search-test` data point targeting
+     child tool `Web_Search` on parent agent node `agent-1`. Use
+     `--mock-value '{"results":[{"title":"NYC Weather","snippet":"Sunny, 72°F"}]}'`.
+     Do NOT add a parent simulation first — `--parent` auto-creates it.
+
+  6. Add an `Llm` child simulation on the `search-test` data point targeting
+     child tool `Send_Email` on the same parent `agent-1`. Supply
+     `--simulation-instructions "Return a success status with a message ID."`,
+     and pass `--output-schema '{"type":"object","properties":{"status":{"type":"string"},"messageId":{"type":"string"}}}'`
+     explicitly.
+
+  7. List the child simulations on `agent-1` to confirm both are present.
+
+  8. Remove the `Send_Email` child simulation from `agent-1`.
+
+  Important:
+  - Use `--output json` on every `uip maestro flow eval ...` command.
+  - Use `--parent agent-1` on every child simulation command (add/list/remove).
+  - Do NOT call `uip login`. Do NOT call `uip solution upload`. Do NOT call
+    `uip maestro flow eval run *` — this task tests local CRUD only.
+  - Do NOT add a separate parent simulation for `agent-1` before adding children.
+    The `--parent` flag auto-creates the parent.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created a solution"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+solution\s+(new|init)'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent initialized a Flow project"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+init'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Flow file was created at the double-nested path"
+    path: "ChildSimEval/ChildSimEval/ChildSimEval.flow"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created an eval set"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+set\s+add'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added a data point with --inputs and --expected"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+add\s+.*(--inputs.*--expected|--expected.*--inputs)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added a Static child simulation with --parent and --mock-value"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+.*--parent\s+.*--strategy\s+Static\b.*--mock-value|--parent\s+.*--mock-value.*--strategy\s+Static|--strategy\s+Static.*--parent\s+.*--mock-value|--mock-value.*--parent\s+.*--strategy\s+Static'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added an Llm child simulation with --parent, --strategy Llm, and --output-schema"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+.*--parent\s+.*--strategy\s+Llm|--strategy\s+Llm.*--parent'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed child simulations with --parent"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+list\s+.*--parent'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent removed a child simulation with --parent"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+remove\s+.*--parent|--parent.*simulation\s+remove'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did NOT add a parent simulation without --parent before adding children"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+agent-1\s+(?!.*--parent)'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Eval-set JSON shows the auto-created parent with child simulations persisted correctly"
+    command: "python3 $TASK_DIR/check_child_simulation_crud.py"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/evaluate/child_simulation/child_simulation_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/child_simulation/child_simulation_crud.yaml
@@ -39,7 +39,7 @@ initial_prompt: |
   5. Add a `Static` child simulation on the `search-test` data point targeting
      child tool `Web_Search` on parent agent node `agent-1`. Use
      `--mock-value '{"results":[{"title":"NYC Weather","snippet":"Sunny, 72°F"}]}'`.
-     Do NOT add a parent simulation first — `--parent` auto-creates it.
+     Do NOT add a separate parent simulation first.
 
   6. Add an `Llm` child simulation on the `search-test` data point targeting
      child tool `Send_Email` on the same parent `agent-1`. Supply
@@ -56,8 +56,8 @@ initial_prompt: |
   - Use `--parent agent-1` on every child simulation command (add/list/remove).
   - Do NOT call `uip login`. Do NOT call `uip solution upload`. Do NOT call
     `uip maestro flow eval run *` — this task tests local CRUD only.
-  - Do NOT add a separate parent simulation for `agent-1` before adding children.
-    The `--parent` flag auto-creates the parent.
+  - Do NOT add a separate parent simulation for `agent-1` before adding children —
+    use the child simulation workflow from the skill.
 
 success_criteria:
   - type: command_executed


### PR DESCRIPTION
## Summary

- Add `--parent` flag docs to the evaluate capability for simulating individual tools inside agent nodes
- Child simulations let you mock individual tools (e.g. `Web_Search`, `Send_Email`) inside an agent node instead of the whole agent
- A single command is enough — the parent simulation is auto-created if it does not exist
- Companion PR for CLI: UiPath/cli#3923

## Changes

- **CAPABILITY.md**: add child simulation to "When to use" and "Common tasks"
- **commands-reference.md**: add `--parent` to simulation add/list/remove flag tables, examples, and output codes (`FlowEvalChildSimulationAdd/List/Remove`)
- **eval-sets-guide.md**: add "Child Simulations (Agent Tool Simulation)" section

## Skill test

- **child_simulation_crud.yaml**: full lifecycle — add Static + Llm child, list, remove — with auto-created parent, 11 success criteria
- **check_child_simulation_crud.py**: verifier reads eval-set JSON and checks parent auto-creation, child persistence, and removal

## Test plan

- [x] Skill test passes: `child_simulation_crud` task runs end-to-end
- [ ] Existing simulation_crud task still passes (no breaking changes to docs)

> Ran `skill-flow-eval-child-simulation-crud` locally and it passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)