### PR TITLE
fix(flow-check): classify a Completed debug with unreadable outputs as INFRA, keep the CLI stderr

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -53,6 +53,7 @@ from typing import Any, Iterable, Sequence
 # the exact payload (finalStatus, elementExecutions, globals, incidents) that the
 # checker saw — which is otherwise ephemeral and unrecoverable post-run.
 _LAST_DEBUG_RAW: str | None = None
+_LAST_DEBUG_STDERR: str | None = None
 
 # Variable ids the most recent :func:`run_debug` bound as INPUTS (via ``--inputs``
 # / ``--attachment``). Stashed because the runtime returns every global — `in` and
@@ -90,6 +91,20 @@ _DEBUG_POLL_TIMEOUT_MARKER = "debug polling timed out"
 # Each attempt costs the full subprocess budget, so cap below `retries`:
 # 3 x 300s would exceed the 600s criterion budget in the task YAMLs.
 _POLL_TIMEOUT_ATTEMPTS = 2
+
+# A run that reports ``finalStatus: Completed`` but whose ``Data`` carries no
+# ``variables`` key at all did NOT produce "no outputs": the CLI's
+# post-completion GET of ``/debug-instances/{id}/variables`` failed and (before
+# UiPath/cli fixed it) the failure was reduced to a stderr warning. A flow that
+# genuinely declares no outputs still returns ``variables`` (with an empty
+# ``globals`` map), so "key absent" is exact, not heuristic. Newer CLIs keep the
+# key absent and add ``variablesError`` explaining why. Both shapes mean
+# "outputs UNREADABLE" — an infrastructure failure to retry, never a flow
+# result to grade. Observed live on coder-eval ``skill-flow-move-node`` (v2,
+# 2026-08-31 and 2026-09-01): every element Completed, ``Outputs: []``, task
+# graded as a flow defect.
+_VARIABLES_UNREADABLE_ATTEMPTS = 2
+_STDERR_CAPTURE_TAIL_CHARS = 4000
 
 # A `uip maestro flow debug` run can die on a transient server-side error — a
 # gateway timeout / 5xx while polling the debug instance, which the CLI reports
@@ -134,6 +149,36 @@ def _is_poll_timeout(result: subprocess.CompletedProcess) -> bool:
     return result.returncode != 0 and (
         _DEBUG_POLL_TIMEOUT_MARKER in _output_blob(result)
     )
+
+
+def _variables_unreadable(data: dict | None) -> str | None:
+    """Return a reason when a *completed* debug payload's outputs could not be
+    read (see :data:`_VARIABLES_UNREADABLE_ATTEMPTS`), else ``None``.
+
+    Exact by construction: only the ``variables`` key being absent from ``Data``
+    (or an explicit ``variablesError``) counts. A present-but-empty
+    ``variables`` is a real result and is returned to the caller as-is."""
+    payload = _get_ci(data or {}, "Data") or {}
+    if not isinstance(payload, dict):
+        return None
+    status = _get_ci(payload, "finalStatus", "FinalStatus")
+    if status != "Completed":
+        return None
+    err = _get_ci(payload, "variablesError", "VariablesError")
+    if isinstance(err, dict):
+        attempts = _get_ci(err, "attempts", "Attempts")
+        message = _get_ci(err, "message", "Message") or "unknown error"
+        return (
+            f"the CLI could not read the output variables (variablesError after "
+            f"{attempts} attempt(s): {message})"
+        )
+    has_key = any(str(k).lower() == "variables" for k in payload)
+    if not has_key:
+        return (
+            "the CLI returned no `variables` key at all — the post-completion "
+            "fetch of /debug-instances/{id}/variables failed and was dropped"
+        )
+    return None
 
 
 def _as_text(raw: bytes | str | None) -> str:
@@ -197,13 +242,16 @@ def run_debug(
         cmd.extend(["--attachment", f"{var_id}={local_path}"])
     env = dict(os.environ)
     env.setdefault("UIP_LOG_LEVEL", _DEBUG_LOG_LEVEL)
-    global _LAST_DEBUG_RAW, _LAST_DEBUG_INPUT_IDS, _LAST_DEBUG_PROJECT_DIR
+    global _LAST_DEBUG_RAW, _LAST_DEBUG_STDERR, _LAST_DEBUG_INPUT_IDS
+    global _LAST_DEBUG_PROJECT_DIR
     # Record what we bound as input, and where the project lives, so output
     # assertions can discount echoes of our own inputs.
     _LAST_DEBUG_INPUT_IDS = {str(k) for k in (inputs or {})} | {
         str(k) for k in (attachments or {})
     }
     _LAST_DEBUG_PROJECT_DIR = project_dir
+    unreadable: str | None = None
+    unreadable_attempts = 0
     for attempt in range(retries):
         try:
             r = subprocess.run(
@@ -213,6 +261,7 @@ def run_debug(
             # The CLI's own --timeout never fired, so the stall is upstream of
             # polling. Keep the partial output rather than dying on a traceback.
             _LAST_DEBUG_RAW = _as_text(exc.stdout)
+            _LAST_DEBUG_STDERR = _as_text(exc.stderr)
             _fail_with_capture(
                 f"flow debug exceeded the {timeout}s subprocess cap without returning "
                 f"(CLI --timeout was {cli_timeout}s, so the stall is upstream of "
@@ -221,9 +270,20 @@ def run_debug(
                 f"stdout: {_as_text(exc.stdout)}\nstderr: {_as_text(exc.stderr)}"
             )
         _LAST_DEBUG_RAW = r.stdout
-        if r.returncode == 0 or not _is_transient_debug_error(r):
+        # Keep the CLI's stderr too: it is where `flow debug` reports what it
+        # could not do (e.g. the output-variables fetch). Dropping it on a zero
+        # exit is how the 2026-08-31/09-01 move-node failures lost their cause.
+        _LAST_DEBUG_STDERR = r.stderr
+        if r.returncode == 0:
+            unreadable = _variables_unreadable(_parse_json(r.stdout))
+            if unreadable is None:
+                break
+            unreadable_attempts += 1
+            if unreadable_attempts >= _VARIABLES_UNREADABLE_ATTEMPTS:
+                break
+        elif not _is_transient_debug_error(r):
             break
-        if _is_poll_timeout(r) and attempt + 1 >= _POLL_TIMEOUT_ATTEMPTS:
+        elif _is_poll_timeout(r) and attempt + 1 >= _POLL_TIMEOUT_ATTEMPTS:
             break
         if attempt + 1 < retries:
             time.sleep(backoff_seconds)
@@ -236,6 +296,16 @@ def run_debug(
     status = _get_ci(payload, "finalStatus", "FinalStatus")
     if status != "Completed":
         _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout}")
+    if unreadable is not None:
+        # Every attempt completed, and every attempt's outputs were unreadable.
+        # This is an infrastructure failure (INFRA), not a verdict on the flow:
+        # the run reached its End node, we just never saw what it returned.
+        _fail_with_capture(
+            f"flow debug completed but its outputs could not be read on "
+            f"{unreadable_attempts} attempt(s): {unreadable}. "
+            "Classify as INFRA (outputs unknown), not as a flow defect; the "
+            "elements all ran. See the captured STDERR for the CLI's own account."
+        )
     return payload
 
 
@@ -687,6 +757,11 @@ def assert_outputs_contain(
             f"Outputs missing {mode} {list(needles)}; present={present}; "
             f"missing={missing}\nOutputs: {haystack[:1000]}{detail}"
         )
+
+
+def get_last_debug_stderr() -> str | None:
+    """Return the stderr of the most recent ``run_debug`` call, or ``None``."""
+    return _LAST_DEBUG_STDERR
 
 
 def get_last_debug_raw() -> str | None:
@@ -1800,6 +1875,11 @@ def _dump_debug_capture(context: str = "") -> None:
     except Exception as exc:  # noqa: BLE001 — diagnostics must never mask the real failure
         lines.append(f"SUMMARY: <unparsable: {exc!r}>")
     lines.append("RAW: " + raw.strip())
+    stderr = (_LAST_DEBUG_STDERR or "").strip()
+    if stderr:
+        # The CLI's own account of the run (progress, warnings such as a failed
+        # output-variables fetch). Tail only: the head is login/upload noise.
+        lines.append("STDERR (tail): " + stderr[-_STDERR_CAPTURE_TAIL_CHARS:])
     lines.append("=== FLOW_DEBUG_RAW_CAPTURE END ===")
     print("\n".join(lines), file=sys.stderr)
 

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -870,6 +870,131 @@ def test_is_transient_debug_error(cp, expected):
     assert flow_check._is_transient_debug_error(cp) is expected
 
 
+# ── run_debug: completed but outputs unreadable (variables fetch failed) ─────
+
+# Verbatim shape of the 2026-09-01 move-node/v2 payload: every element
+# Completed, no `variables` key anywhere in Data.
+_COMPLETED_NO_VARIABLES = (
+    '{\n  "Result": "Success",\n  "Code": "FlowDebug",\n'
+    '  "Data": {"jobKey": "j", "instanceId": "609c57fa", "finalStatus": "Completed",\n'
+    '           "elementExecutions": [{"elementId": "end", "status": "Completed"}]},\n'
+    '  "Instructions": "Debug completed with status: Completed"\n}'
+)
+# Shape emitted by the fixed CLI: still no `variables`, plus the structured reason.
+_COMPLETED_VARIABLES_ERROR = (
+    '{\n  "Result": "Success",\n  "Code": "FlowDebug",\n'
+    '  "Data": {"instanceId": "609c57fa", "finalStatus": "Completed", "elementExecutions": [],\n'
+    '           "variablesError": {"message": "pims API request failed: 403 Forbidden", '
+    '"httpStatus": 403, "attempts": 4, "traceIds": ["t1"], '
+    '"endpoint": "/api/v1/debug-instances/609c57fa/variables"}}\n}'
+)
+# A run whose flow declares no outputs: `variables` is PRESENT and empty. Real result.
+_COMPLETED_EMPTY_VARIABLES = (
+    '{\n  "Result": "Success",\n'
+    '  "Data": {"finalStatus": "Completed", "variables": {"globals": {}, "elements": []}}\n}'
+)
+_CLI_STDERR = (
+    "Polling for completion...\nStatus: Completed (9/9 elements completed)\n"
+    "Fetching output variables...\n"
+    "[WARN] Could not fetch variables: pims API request failed: 403 Forbidden on GET "
+    "/api/v1/debug-instances/609c57fa/variables\n"
+)
+
+
+def test_run_debug_retries_completed_without_variables_then_returns_outputs(monkeypatch):
+    """A Completed payload with no `variables` key is a failed fetch, not a
+    result — retry the debug once; the second run's outputs are graded."""
+    calls = _stub_debug(
+        monkeypatch,
+        [_cp(0, _COMPLETED_NO_VARIABLES, _CLI_STDERR), _cp(0, _COMPLETED)],
+    )
+    payload = run_debug()
+    assert calls["n"] == 2
+    assert flow_check.collect_outputs(payload) == ["Sev1"]
+
+
+def test_run_debug_retries_variables_error_payload(monkeypatch):
+    calls = _stub_debug(
+        monkeypatch, [_cp(0, _COMPLETED_VARIABLES_ERROR), _cp(0, _COMPLETED)]
+    )
+    payload = run_debug()
+    assert calls["n"] == 2
+    assert flow_check.collect_outputs(payload) == ["Sev1"]
+
+
+def test_run_debug_persistent_unreadable_outputs_fails_as_infra(monkeypatch, capsys):
+    """Both attempts complete with unreadable outputs: fail with an INFRA
+    message and the capture (RAW + the CLI's STDERR), never as
+    'Outputs missing' — that verdict would blame the flow."""
+    calls = _stub_debug(
+        monkeypatch,
+        [
+            _cp(0, _COMPLETED_NO_VARIABLES, _CLI_STDERR),
+            _cp(0, _COMPLETED_NO_VARIABLES, _CLI_STDERR),
+        ],
+    )
+    with pytest.raises(SystemExit) as exc:
+        run_debug()
+    assert calls["n"] == flow_check._VARIABLES_UNREADABLE_ATTEMPTS == 2
+    msg = str(exc.value)
+    assert "could not be read" in msg
+    assert "INFRA" in msg
+    assert "Outputs missing" not in msg
+    err = capsys.readouterr().err
+    assert "FLOW_DEBUG_RAW_CAPTURE BEGIN" in err
+    assert "STDERR (tail):" in err
+    assert "Could not fetch variables" in err
+
+
+def test_run_debug_does_not_retry_present_but_empty_variables(monkeypatch):
+    """`variables` present and empty is a genuine 'no outputs' result — return
+    it on the first attempt so the caller's assertion grades it."""
+    calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED_EMPTY_VARIABLES)])
+    payload = run_debug()
+    assert calls["n"] == 1
+    assert flow_check.collect_outputs(payload) == []
+
+
+def test_run_debug_unreadable_retry_does_not_burn_the_transient_budget(monkeypatch):
+    """The unreadable-outputs retry is its own budget (2), independent of the
+    3 attempts reserved for 5xx/RetryLater."""
+    calls = _stub_debug(
+        monkeypatch,
+        [_cp(1, _TRANSIENT_504), _cp(0, _COMPLETED_NO_VARIABLES), _cp(0, _COMPLETED)],
+    )
+    payload = run_debug()
+    assert calls["n"] == 3
+    assert flow_check.collect_outputs(payload) == ["Sev1"]
+
+
+@pytest.mark.parametrize(
+    "stdout,expected",
+    [
+        (_COMPLETED, None),
+        (_COMPLETED_EMPTY_VARIABLES, None),
+        ('{"Result": "Success", "Data": {"finalStatus": "Faulted"}}', None),  # not Completed: other path
+        (_COMPLETED_NO_VARIABLES, "no `variables` key"),
+        (_COMPLETED_VARIABLES_ERROR, "variablesError after 4 attempt(s)"),
+    ],
+)
+def test_variables_unreadable_classifier(stdout, expected):
+    reason = flow_check._variables_unreadable(flow_check._parse_json(stdout))
+    if expected is None:
+        assert reason is None
+    else:
+        assert expected in reason
+
+
+def test_capture_includes_cli_stderr_tail(capsys, _reset_debug_raw, monkeypatch):
+    monkeypatch.setattr(flow_check, "_LAST_DEBUG_STDERR", _CLI_STDERR)
+    flow_check._LAST_DEBUG_RAW = _COMPLETED_NO_VARIABLES
+    with pytest.raises(SystemExit):
+        flow_check._fail_with_capture("boom")
+    err = capsys.readouterr().err
+    assert "STDERR (tail): Polling for completion..." in err
+    assert "Could not fetch variables" in err
+
+
 # ── run_debug timeout budget + diagnostics ───────────────────────────────────
 #
 # Regression cover for skill-flow-wiki-pageviews: the subprocess cap fired below


### PR DESCRIPTION
## Short version

When `uip maestro flow debug` finishes a run but cannot read its output variables, the CLI (before UiPath/cli#3929) printed `Result: Success` with **no `variables` key** and put the reason only on stderr. `run_debug` discarded stderr on exit 0 and `assert_outputs_contain` then reported `Outputs missing …; present=[]` — grading an **infrastructure** failure as a **flow** defect.

Seen on `skill-flow-move-node` v2 on 2026-08-31 and 2026-09-01 (every element `Completed`, `Outputs: []`, score 0.375). The same `.flow` debugged 7/7 with outputs from a host and from inside the eval image.

## Changes (test layer, classification + diagnostics — no prompt or criteria change)

- **Classify, then retry.** A `Completed` payload whose `Data` has no `variables` key at all, or carries the new `variablesError` (UiPath/cli#3929), is "outputs UNREADABLE": the debug is retried once (own 2-attempt budget, independent of the 3 attempts reserved for 5xx/RetryLater). If it persists the check fails with an explicit INFRA message, never "Outputs missing". The condition is **key absent**, not empty — a flow that declares no outputs still returns `variables` with an empty `globals` map, so real "no outputs" results are graded as before.
- **Keep the CLI's stderr.** Captured on every attempt and printed (tail, 4000 chars) in the `FLOW_DEBUG_RAW_CAPTURE` dump, so the next occurrence carries its own cause in `task.json`.

Example of the new failure text on the 09-01 shape:

```
FAIL: flow debug completed but its outputs could not be read on 2 attempt(s): the CLI returned no `variables` key at all — the post-completion fetch of /debug-instances/{id}/variables failed and was dropped. Classify as INFRA (outputs unknown), not as a flow defect; the elements all ran. See the captured STDERR for the CLI's own account.
```

## Tests

`_shared/test_flow_check.py`: +7 (retry-then-grade, `variablesError` payload, persistent → INFRA with RAW + STDERR capture, present-but-empty not retried, budgets independent, classifier table, stderr tail in capture). `pytest tests/tasks/uipath-maestro-flow/` → **340 passed**; `scripts/check-task-driver.py` OK.

Measurement contract (plan §2.5 / D-1): no task prompt, criterion, weight or `run_limits` changes; `_shared/flow_check.py` only. RCA: `workspaces/reports/2026-09-01-maestro-flow-failed-tests/rca-move-node.md`.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193r8XwXyqZqZwbBXXuwiHA
