### PR TITLE
fix(traces): stop the segment guard zeroing multi-line commands

### DIFF
--- a/.github/workflows/test-helpers.yml
+++ b/.github/workflows/test-helpers.yml
@@ -8,6 +8,7 @@ on:
       - 'tests/tasks/uipath-planner/**'
       - 'tests/tasks/uipath-agents/**'
       - 'tests/tasks/uipath-admin/**'
+      - 'tests/tasks/uipath-platform/**'
       - 'tests/scripts/**'
       - 'scripts/**'  # guarded scripts (e.g. build-uip-catalog.py) must trigger their tests
       - 'hooks/**'    # telemetry hook has a contract guard in tests/scripts/
@@ -139,6 +140,26 @@ jobs:
       # (see #1203).
       - name: Run catalog guard tests
         run: pytest tests/scripts/test_catalog_build_guards.py -v
+
+  command-pattern-guard:
+    runs-on: uipath-ubuntu-latest
+    name: command_pattern segment-guard controls
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.13'
+
+      - name: Install pytest
+        run: pip install pytest pyyaml
+
+      # Replays a 7-control matrix through a copy of coder_eval's haystack
+      # matching. Fails red if a segment guard stops at a newline again — that
+      # zeroes every backslash-continued command, which is how most agents
+      # write a long `uip` call (see #2836).
+      - name: Run segment-guard controls
+        run: pytest tests/scripts/test_command_pattern_segment_guard.py -v
 
   telemetry-hook-tests:
     runs-on: uipath-ubuntu-latest

--- a/tests/README.md
+++ b/tests/README.md
@@ -438,12 +438,14 @@ Verify the agent ran a specific CLI command (matched by regex). From `init_valid
   pass_threshold: 1.0   # fraction of min_count required to pass
 ```
 
-**Scope lookaheads and excludes to ONE command segment.** The grader runs one `pattern.search()` per Bash tool call (`re.DOTALL`) and also matches a normalized haystack with newlines collapsed to spaces — so `(?=[\s\S]*--flag)` and `exclude_pattern` see every command batched into that call (codex chains `a && b` or stacks lines; a call-wide exclude then vetoes a correct command). Use the segment idiom `S = (?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*` ("rest of THIS command", stops at newline, `&&`, `||`, `;`, `|`, or the next `uip`) and inline negatives instead of `exclude_pattern`:
+**Scope lookaheads and excludes to ONE command segment.** The grader runs one `pattern.search()` per Bash tool call (`re.DOTALL`) and also matches a shlex-normalized haystack — so `(?=[\s\S]*--flag)` and `exclude_pattern` see every command batched into that call (codex chains `a && b` or stacks lines; a call-wide exclude then vetoes a correct command). Use the segment idiom `S = (?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*` ("rest of THIS command", stops at `&&`, `||`, `;`, `|`, or the next `uip`) and inline negatives instead of `exclude_pattern`:
 
 ```yaml
 # S expanded inline — YAML single quotes, no escaping needed
-command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--span-id)(?!(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--agent-id)'
+command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?=(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--span-id)(?!(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--agent-id)'
 ```
+
+**Do NOT put `\n` in that stop list.** Normalization does not collapse a backslash line continuation: `shlex.split` re-emits `\` + newline as a literal `'\n'` token, and the join puts it back as a bare newline. So both haystacks keep the line break, a guard that stops at any newline dies there, and every backslash-continued command scores 0 — which is how most agents write a long `uip` call. `\s(?:uip|\$UIP)\s` is what actually separates stacked commands; the newline term adds no scoping and only breaks continuations. `tests/scripts/test_command_pattern_segment_guard.py` replays a 7-control matrix through a copy of the grader and fails red if the term comes back.
 
 ### `file_exists`
 

--- a/tests/scripts/test_command_pattern_segment_guard.py
+++ b/tests/scripts/test_command_pattern_segment_guard.py
@@ -1,0 +1,211 @@
+"""Control matrix for the `command_executed` segment-scoping guard.
+
+The guard restricts a lookahead to "the rest of THIS command" so a Bash call
+that batches two commands grades per command. It must do that WITHOUT dying at
+a backslash line continuation — coder_eval's shlex normalization re-emits
+`\\` + newline as a bare `'\\n'` token, so a guard that stops at any newline
+zeroes every multi-line command in both haystacks.
+
+Each control is graded in a single-line AND a multi-line shape through a copy
+of coder_eval's haystack matching, then compared against the outcome the task
+author intended.
+
+Run from repo root:
+    pytest tests/scripts/test_command_pattern_segment_guard.py
+"""
+
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRACES_TASKS = REPO_ROOT / "tests" / "tasks" / "uipath-platform" / "traces"
+FILTERS_TASK = TRACES_TASKS / "traces_feedback_list_filters_smoke.yaml"
+DETAILED_TASK = TRACES_TASKS / "traces_feedback_list_detailed_smoke.yaml"
+
+
+# --- Faithful copy of coder_eval's matching surface -------------------------
+# Mirrors coder_eval 0.11.5 `criteria/command_executed.py` (`_normalize_shell`,
+# `_match_haystacks`, and the `re.DOTALL` compile). Copied rather than imported
+# because coder_eval is not a dependency of this pytest job.
+
+_MAX_PATTERN_SEARCH_LEN = 2000
+
+
+def _is_shell_program(arg0: str) -> bool:
+    return arg0.rsplit("/", 1)[-1].endswith("sh")
+
+
+def _is_command_flag(tok: str) -> bool:
+    return len(tok) >= 2 and tok[0] == "-" and tok[1] != "-" and tok[1:].isalpha() and "c" in tok[1:]
+
+
+def _normalize_shell(cmd_text: str) -> str | None:
+    try:
+        tokens = shlex.split(cmd_text, posix=True)
+    except ValueError:
+        return None
+    if not tokens:
+        return None
+    if _is_shell_program(tokens[0]):
+        for i in range(1, len(tokens) - 1):
+            tok = tokens[i]
+            if _is_command_flag(tok):
+                rest = tokens[i + 1 :]
+                if len(rest) == 1:
+                    try:
+                        tokens = shlex.split(rest[0], posix=True)
+                    except ValueError:
+                        return None
+                else:
+                    tokens = rest
+                break
+            if not tok.startswith("-"):
+                break
+    return " ".join(tokens)
+
+
+def _match_haystacks(cmd_text: str) -> list[str]:
+    window = cmd_text[:_MAX_PATTERN_SEARCH_LEN]
+    haystacks = [window]
+    normalized = _normalize_shell(window)
+    if normalized is not None and normalized != window:
+        haystacks.append(normalized)
+    return haystacks
+
+
+# --- Guards under test ------------------------------------------------------
+
+GUARD_SHIPPED = r"(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*"
+GUARD_NEWLINE_STOP = r"(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*"
+GUARD_ESCAPED_NEWLINE_STOP = r"(?:(?!(?<!\\)\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*"
+
+# The three `command_pattern` regexes of skill-platform-traces-feedback-list-filters,
+# with the segment guard left as `{S}` so the same criteria can be replayed
+# against any candidate guard.
+CRITERIA = {
+    "c1": r"(uip|\$UIP)\s+traces\s+feedback\s+list(?!\s+detailed)(?={S}--span-id)(?!{S}--agent-id)",
+    "c2": (
+        r"(uip|\$UIP)\s+traces\s+feedback\s+list(?:\s+detailed)?"
+        r"(?={S}--negative)(?={S}--agent-id)(?={S}--agent-version)"
+    ),
+    "c3": (
+        r"(uip|\$UIP)\s+traces\s+feedback\s+list(?:\s+detailed)?"
+        r"(?={S}--negative)(?={S}--limit[\s=]5(?:\s|$))(?={S}--offset[\s=]5(?:\s|$))"
+    ),
+}
+
+
+# --- Control matrix ---------------------------------------------------------
+# `{B}` marks a place the agent may break the line. The single-line shape
+# renders it as a space, the multi-line shape as a backslash continuation.
+
+FOLDER = "2f6c8a41-93bd-4d17-8e55-6a0b7c19d3e2"
+TRACE = "7d3a91e0f5c24b8ea0c6d219bb47f0a3"
+SPAN = "b7e41c93a05d2f68"
+AGENT = "c41d7b62-05ae-4f39-9a18-73e2b6d4c08f"
+
+SPAN_READ = f"uip traces feedback list --folder-key {FOLDER}{{B}}--trace-id {TRACE}{{B}}--span-id {SPAN}"
+SPAN_READ_DETAILED = (
+    f"uip traces feedback list detailed --folder-key {FOLDER}{{B}}--trace-id {TRACE}{{B}}--span-id {SPAN}"
+)
+
+
+def _paged_read(offset: int) -> str:
+    return (
+        f"uip traces feedback list --folder-key {FOLDER}{{B}}--agent-id {AGENT}"
+        f"{{B}}--agent-version 2.4.0{{B}}--negative{{B}}--limit 5{{B}}--offset {offset}"
+    )
+
+
+MERGED = (
+    f"uip traces feedback list --folder-key {FOLDER}{{B}}--trace-id {TRACE}{{B}}--span-id {SPAN}"
+    f"{{B}}--agent-id {AGENT}{{B}}--agent-version 2.4.0{{B}}--negative{{B}}--limit 5{{B}}--offset 5"
+)
+# Same merged command, but the only break sits between the two flags c1 plays
+# off against each other — the shape a `(?<!\\)\n` guard mis-splits.
+MERGED_BREAK_BETWEEN_FLAGS = (
+    f"uip traces feedback list --folder-key {FOLDER} --trace-id {TRACE} --span-id {SPAN}"
+    f"{{B}}--agent-id {AGENT} --agent-version 2.4.0 --negative --limit 5 --offset 5"
+)
+
+CONTROLS = {
+    "A-correct-two-calls": ([SPAN_READ, _paged_read(5)], {"c1": True, "c2": True, "c3": True}),
+    "B-merged-one-command": ([MERGED], {"c1": False, "c2": True, "c3": True}),
+    "B2-merged-break-between-flags": ([MERGED_BREAK_BETWEEN_FLAGS], {"c1": False, "c2": True, "c3": True}),
+    "C-offset-as-page-number": ([SPAN_READ, _paged_read(10)], {"c1": True, "c2": True, "c3": False}),
+    "D-span-read-via-list-detailed": ([SPAN_READ_DETAILED, _paged_read(5)], {"c1": False, "c2": True, "c3": True}),
+    "E-two-reads-chained-with-and": ([f"{SPAN_READ} && {_paged_read(5)}"], {"c1": True, "c2": True, "c3": True}),
+    "F-two-reads-stacked-on-lines": ([f"{SPAN_READ}\n{_paged_read(5)}"], {"c1": True, "c2": True, "c3": True}),
+}
+
+SHAPES = {"single-line": " ", "multi-line": " \\\n  "}
+
+
+def _render(calls: list[str], shape: str) -> list[str]:
+    return [call.replace("{B}", SHAPES[shape]) for call in calls]
+
+
+def _grade(calls: list[str], guard: str) -> dict[str, bool]:
+    graded = {}
+    for name, template in CRITERIA.items():
+        pattern = re.compile(template.format(S=guard), re.DOTALL)
+        graded[name] = any(pattern.search(hay) for call in calls for hay in _match_haystacks(call))
+    return graded
+
+
+def _mismatching_cells(guard: str) -> list[str]:
+    bad = []
+    for shape in SHAPES:
+        for control, (calls, expected) in CONTROLS.items():
+            if _grade(_render(calls, shape), guard) != expected:
+                bad.append(f"{control}/{shape}")
+    return bad
+
+
+# --- The shipped patterns are the ones under test ---------------------------
+
+
+def _command_patterns(task_path: Path) -> list[str]:
+    task = yaml.safe_load(task_path.read_text())
+    return [c["command_pattern"] for c in task["success_criteria"] if c["type"] == "command_executed"]
+
+
+@pytest.mark.parametrize("task_path", [FILTERS_TASK, DETAILED_TASK], ids=lambda p: p.name)
+def test_shipped_guard_never_stops_at_a_newline(task_path):
+    """Every segment guard in the traces tasks uses the continuation-safe form."""
+    for pattern in _command_patterns(task_path):
+        assert GUARD_NEWLINE_STOP not in pattern, (
+            f"{task_path.name} re-introduced the newline-terminated segment guard. "
+            "It zeroes every backslash-continued command — see tests/README.md."
+        )
+        assert GUARD_ESCAPED_NEWLINE_STOP not in pattern, (
+            f"{task_path.name} uses the `(?<!\\\\)\\n` guard variant. It repairs the raw "
+            "haystack but mis-splits the shlex-normalized one (control B2)."
+        )
+
+
+def test_filters_criteria_match_the_replayed_templates():
+    """The replay templates are the shipped regexes, not a drifted copy."""
+    expected = [template.format(S=GUARD_SHIPPED) for template in CRITERIA.values()]
+    assert _command_patterns(FILTERS_TASK) == expected
+
+
+@pytest.mark.parametrize("shape", list(SHAPES))
+@pytest.mark.parametrize("control", list(CONTROLS))
+def test_shipped_guard_grades_control_as_intended(control, shape):
+    calls, expected = CONTROLS[control]
+    assert _grade(_render(calls, shape), GUARD_SHIPPED) == expected
+
+
+def test_newline_stop_guard_zeroes_every_multi_line_shape():
+    """Regression record: the guard PR #2836 shipped fails all 7 multi-line controls."""
+    assert _mismatching_cells(GUARD_NEWLINE_STOP) == [f"{control}/multi-line" for control in CONTROLS]
+
+
+def test_escaped_newline_guard_still_mis_splits_a_merged_command():
+    r"""Regression record: `(?<!\\)\n` is not enough — the normalized haystack has a bare newline."""
+    assert _mismatching_cells(GUARD_ESCAPED_NEWLINE_STOP) == ["B2-merged-break-between-flags/multi-line"]

--- a/tests/tasks/uipath-platform/traces/traces_feedback_list_detailed_smoke.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_list_detailed_smoke.yaml
@@ -35,7 +35,7 @@ success_criteria:
   - type: command_executed
     description: "Last-24-hours pass used the relative lookback (--since 24h)"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list\s+detailed(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--since[\s=]["'']?24h)(?!(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--before)'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list\s+detailed(?=(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--since[\s=]["'']?24h)(?!(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--before)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -43,7 +43,7 @@ success_criteria:
   - type: command_executed
     description: "Second pass bounded by the requested explicit --after/--before window"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list\s+detailed(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--after[\s=]["'']?2026-07-01)(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--before[\s=]["'']?2026-07-08)(?!(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--since)'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list\s+detailed(?=(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--after[\s=]["'']?2026-07-01)(?=(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--before[\s=]["'']?2026-07-08)(?!(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--since)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -51,7 +51,7 @@ success_criteria:
   - type: command_executed
     description: "Second pass filtered to the requested category and not explicitly re-ordered oldest-first (`desc` is the CLI default)"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list\s+detailed(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--category-id[\s=]["'']?3f9a2b71)(?!(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--sort-order[\s=]["'']?asc)'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list\s+detailed(?=(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--category-id[\s=]["'']?3f9a2b71)(?!(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--sort-order[\s=]["'']?asc)'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/traces/traces_feedback_list_filters_smoke.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_list_filters_smoke.yaml
@@ -7,7 +7,7 @@ description: >
   are exercised anywhere. The paging assertion is the sharp one: the second page
   of a five-per-page walk is `--limit 5 --offset 5`, so an agent that treats
   `--offset` as a page number rather than a zero-based item offset fails it.
-  Graders are segment-scoped (a lookahead stops at newline, `&&`, `;`, `|`, or the
+  Graders are segment-scoped (a lookahead stops at `&&`, `||`, `;`, `|`, or the
   next `uip`) so batched calls grade per command, and `list detailed` is accepted
   for the paged cross-trace read — same filters, same data; the span read must
   stay plain `list`.
@@ -35,7 +35,7 @@ success_criteria:
   - type: command_executed
     description: "Agent scoped the first read to a single span with --span-id"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?!\s+detailed)(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--span-id)(?!(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--agent-id)'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?!\s+detailed)(?=(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--span-id)(?!(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--agent-id)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -43,7 +43,7 @@ success_criteria:
   - type: command_executed
     description: "Cross-trace read filtered by sentiment and agent attribution"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?:\s+detailed)?(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--negative)(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--agent-id)(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--agent-version)'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?:\s+detailed)?(?=(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--negative)(?=(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--agent-id)(?=(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--agent-version)'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
@@ -51,7 +51,7 @@ success_criteria:
   - type: command_executed
     description: "Second page of that same filtered walk is --limit 5 --offset 5 (zero-based offset)"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?:\s+detailed)?(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--negative)(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--limit[\s=]5(?:\s|$))(?=(?:(?!\n|&&|\|\||;|\||\s(?:uip|\$UIP)\s).)*--offset[\s=]5(?:\s|$))'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+list(?:\s+detailed)?(?=(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--negative)(?=(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--limit[\s=]5(?:\s|$))(?=(?:(?!&&|\|\||;|\||\s(?:uip|\$UIP)\s)[\s\S])*--offset[\s=]5(?:\s|$))'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Motivation

[PR #2836](https://github.com/UiPath/skills/pull/2836)'s segment guard stops at any newline, so every backslash-continued command scores 0 — `skill-platform-traces-feedback-list-filters` fell from 1.00 to 0.00 on Claude with identical agent behavior. Dropping the `\n` term restores multi-line matching without giving back the batched-call fix #2836 was written for.

## Summary

The `command_executed` segment guard scopes a lookahead to "the rest of THIS command":

```
OLD:  (?:(?!\n|&&|\|\||;|\||\s(?:uip|$UIP)\s).)*
NEW:  (?:(?!&&|\|\||;|\||\s(?:uip|$UIP)\s)[\s\S])*
```

The safety net assumed in the #2836 review does not exist. coder_eval matches a raw haystack **and** a shlex-normalized one, but normalization does **not** collapse a backslash line continuation:

```python
>>> shlex.split("a \\\n b", posix=True)
['a', '\n', 'b']
```

The escaped newline survives as a literal `'\n'` token and `" ".join(tokens)` puts it straight back — now as a *bare* newline. Both haystacks keep the line break, so every lookahead dies at the first continuation.

### Run evidence

| Run | Task | Command shape | Score |
|---|---|---|---|
| `2026-08-27_04-13-44` (last pre-#2836) | `skill-platform-traces-feedback-list-filters` | 2/2 multi-line | **1.00** |
| `2026-08-31_04-15-47` (post-#2836) | same task | same 2/2 multi-line | **0.00 / 3** |

Identical agent behavior; #2836 alone flipped it. All three commands in the 08-31 run were correct — just backslash-continued. The sibling task `skill-platform-traces-feedback-list-detailed` scored 1.00 in the same run only because its commands happened to be single-line; it carries the same latent bug, so both files are fixed here.

Codex is unaffected and keeps the fix it needed: it writes single-line commands and went 6-fail/9 pre-#2836 to 3/3 pass post-#2836.

### Why `(?<!\\)\n` is not enough

A lookbehind that skips only *escaped* newlines repairs the raw haystack but not the normalized one, where `\` + newline has already become a bare newline. That mis-splits one merged command into two fake segments and opens a **false positive**: control B2 below is a single merged command carrying both `--span-id` and `--agent-id`, and the criterion that must reject it starts passing. The `\n` term buys no scoping that `\s(?:uip|$UIP)\s` does not already provide, so the fix is to remove it rather than narrow it.

### File-by-file

- **`tests/tasks/uipath-platform/traces/traces_feedback_list_filters_smoke.yaml`** — all 3 `command_pattern` regexes moved to the new guard (8 guard occurrences). The task `description` no longer claims the lookahead stops at a newline.
- **`tests/tasks/uipath-platform/traces/traces_feedback_list_detailed_smoke.yaml`** — same, all 3 `command_pattern` regexes (7 guard occurrences). No behavior change today (its commands were single-line), but it removes the latent zero.
- **`tests/scripts/test_command_pattern_segment_guard.py`** (new) — replays a 7-control matrix in single-line **and** multi-line shape through a faithful copy of coder_eval 0.11.5 `_match_haystacks` / `_normalize_shell` (raw + shlex-normalized haystacks, `re.DOTALL`). It reads the shipped regexes out of the task YAML, so it fails red if the `\n` term ever comes back, and it pins both rejected alternatives.
- **`tests/README.md`** — corrects the segment-scoping rule: it claimed the grader "also matches a normalized haystack with newlines collapsed to spaces", which is what made the #2836 review look sound. Now states the corrected guard and that continuations are **not** collapsed.
- **`.github/workflows/test-helpers.yml`** — new `command-pattern-guard` job running the matrix, plus `tests/tasks/uipath-platform/**` added to the trigger paths so editing the guarded YAMLs re-runs it.

### Control matrix

Every control runs in both a single-line and a multi-line (backslash-continued) shape — 14 cells, 42 criterion outcomes.

| # | Control | Expected |
|---|---|---|
| A | correct 2-call trajectory | PASS |
| B | both filters merged into ONE command | FAIL c1 only |
| B2 | merged, line break between `--span-id` and `--agent-id` | FAIL c1 only |
| C | `--offset 10` (page number, not zero-based offset) | FAIL c3 only |
| D | span read done via `list detailed` | FAIL c1 only |
| E | two reads chained with `&&` in one call | PASS |
| F | two reads stacked on separate newlines in one call | PASS |

| Guard | Mismatching cells |
|---|---|
| OLD (currently on `main`) | **7** — every multi-line shape wrongly zeroed (18 of 42 criterion outcomes wrong) |
| `(?<!\\)\n` variant | **1** — B2 multi-line, where c1 wrongly *passes* a merged command |
| **proposed (no `\n` term)** | **0** |

E and F stay green, so #2836's batched-call fix is preserved.

> The plan for this change predicted 2 mismatches for the `(?<!\\)\n` variant; the measured matrix produces 1. The hole is the same one (the merged-command false positive) — only the cell count differs, because the single-line rendering of B2 is identical to B and grades correctly.

## Tests performed

```
$ python3 -m pytest tests/scripts/test_command_pattern_segment_guard.py -q
19 passed in 0.03s

$ python3 -m pytest tests/scripts/ -q
122 passed in 29.29s

$ python3 scripts/check-task-driver.py tests/tasks
OK — no task pins `sandbox.driver: tempdir`.

$ python3 scripts/check-cli-verbs.py \
    tests/tasks/uipath-platform/traces/traces_feedback_list_filters_smoke.yaml \
    tests/tasks/uipath-platform/traces/traces_feedback_list_detailed_smoke.yaml
OK — no CLI-verb issues (catalog: uip 1.202.0-dev.8414, 1555 verbs).
```

Plus a YAML parse and `re.compile(..., re.DOTALL)` over every `command_pattern` in `tests/tasks/uipath-platform/traces/` (11 files, 30 patterns — all compile), and a YAML parse of the edited workflow.

`scripts/check-skill-verbs.py` was not run: it takes a skill directory and this PR changes no skill under `skills/` or `preview/`.

The two graded tasks were **not** re-run end to end against a tenant — a live run needs credentials this change does not affect. The change is to the grader regex only, and the control matrix replays the exact scoring path (`_match_haystacks` + `re.DOTALL` search) that a live run would take, including the two real command shapes recorded in runs `2026-08-27_04-13-44` and `2026-08-31_04-15-47`.

## Test plan

- [x] All 6 `command_pattern` regexes in both traces task YAMLs use the continuation-safe guard
- [x] `git grep -F '(?!\n|&&' -- tests/tasks/` returns nothing
- [x] 7-control matrix passes in single-line and multi-line shape under the shipped guard
- [x] Old guard and the `(?<!\\)\n` variant are pinned as failing, so neither can quietly return
- [x] Batched-call controls (E `&&`, F stacked lines) still grade per command
- [x] Existing `tests/scripts/` suite unchanged and green
- [ ] Next nightly Claude run scores `skill-platform-traces-feedback-list-filters` above 0

LLMOPS-3152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
