### PR TITLE
chore(uipath-insights): own the insights skill paths as a team [IN-13526]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -190,8 +190,8 @@
 /tests/tasks/uipath-mcp-servers/ @cristipufu @UiPath/team-coded-agents
 
 # Insights skill (job monitoring and analytics)
-/skills/uipath-insights/ @suranabhavya @rliuup
-/tests/tasks/uipath-insights/ @suranabhavya @rliuup
+/skills/uipath-insights/ @UiPath/insights
+/tests/tasks/uipath-insights/ @UiPath/insights
 
 # Automation Discovery skill
 /skills/uipath-automation-discovery/ @uisherif


### PR DESCRIPTION
Related to [IN-13526](https://uipath.atlassian.net/browse/IN-13526).

## What

Replaces the two named owners on the insights CODEOWNERS lines (`/skills/uipath-insights/` and `/tests/tasks/uipath-insights/`) with the `@UiPath/insights` team.

## Why

The insights paths listed two individual handles, and reviews bottleneck when either is unavailable. The team has 9 members including both current owners, so ownership now tracks team membership instead of individual handles.

Ownership change only, no skill content touched. Companion cli PR does the same for the insights packages there.

[IN-13526]: https://uipath.atlassian.net/browse/IN-13526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ