### PR TITLE
fix(tests): point the three RPA-backed tasks at an offline fixture

### DIFF
--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/check_expense_runnable_structure.py
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/check_expense_runnable_structure.py
@@ -54,7 +54,7 @@ REQUIRED_EXTERNAL_BINDINGS = {
     "Shared/uipath-agents/WeatherAPI.WeatherAPI": "WeatherAPI",
     "Shared/uipath-maestro-flow/CountLetters CodedAgent.CountLetters": "CountLetters",
     "Shared/uipath-agents/ProcurementProcess.ProcurementProcess": "ProcurementProcess",
-    "Shared/uipath-maestro-flow/ProjectEuler RPA.RPA Workflow": "RPA Workflow",
+    "Shared/uipath-maestro-flow/HelpDeskLookup RPA.HelpDeskLookup": "HelpDeskLookup",
     "Shared/uipath-maestro-case/CaseTest.Maestro Case": "Maestro Case",
 }
 

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
@@ -10,7 +10,7 @@ description: >
   harness runs uip maestro case debug to prove the case executes to
   finalStatus=Completed across the Submission -> Manager Approval -> Finance
   Approval -> Payment -> Approved happy path, binding real deployed resources
-  (WeatherAPI, CountLetters, ProcurementProcess, ProjectEuler, CaseTest).
+  (WeatherAPI, CountLetters, ProcurementProcess, HelpDeskLookup, CaseTest).
 tags:
   - uipath-maestro-case
   - e2e
@@ -57,8 +57,8 @@ initial_prompt: |
     with "Node already added to the graph" in this eval environment.
   - The SDD resource labels are aliases for deployed resource NAMES. Map alias →
     deployed name exactly: `WeatherAPI` → `WeatherAPI`, `CountLetters` →
-    `CountLetters`, `ProcurementProcess` → `ProcurementProcess`, `ProjectEuler` →
-    `RPA Workflow`, and `CaseTest` → `Maestro Case`. Do not substitute an SDD
+    `CountLetters`, `ProcurementProcess` → `ProcurementProcess`, `HelpDeskLookup`
+    → `HelpDeskLookup`, and `CaseTest` → `Maestro Case`. Do not substitute an SDD
     alias for a deployed name. The alias on the left is NOT a resource key: keep
     every `resourceKey` — and the matching `bindings_v2.json` `key` — as the
     composite `<folderPath>.<deployed name>` (e.g.

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/fixtures/sdd.md
@@ -10,7 +10,7 @@
 > giving a deterministic linear happy path) so `uip maestro case debug` can run
 > the case to completion without human input; escalation timers use seconds; a manual
 > trigger starts the case so `uip maestro case debug` can run it headlessly. Task payloads are generic (bound to
-> `WeatherAPI`, `CountLetters`, `ProcurementProcess`, `ProjectEuler`,
+> `WeatherAPI`, `CountLetters`, `ProcurementProcess`, `HelpDeskLookup`,
 > `CaseTest`). The 7-stage topology, stage chaining, child case, and the
 > Rejected / Withdrawn terminal lanes are preserved; the reject / withdraw lanes
 > stay dormant at runtime (gated off by the default-`Approve` decision vars) but
@@ -465,9 +465,9 @@
 
 ###### Process / Agent / RPA / API Workflow Task Detail
 
-**Resolved Resource:** ProjectEuler
-**Folder Path:** Shared/uipath-maestro-flow/ProjectEuler RPA
-**Resource Identity:** 486edc26-0658-4ac1-92c9-1ef953927151
+**Resolved Resource:** HelpDeskLookup
+**Folder Path:** Shared/uipath-maestro-flow/HelpDeskLookup RPA
+**Resource Identity:** 4d5c6aa7-a1a6-4dd9-aa4d-6304a22014e8
 **Binding Sub-Type:** —
 **Dispatch / Operation:** —
 
@@ -475,7 +475,7 @@
 
 | Field | Type | Binding |
 |-------|------|---------|
-| problemId | integer | 1 |
+| ticketId | integer | 123 |
 
 **Outputs:**
 
@@ -704,9 +704,9 @@
 
 ###### Process / Agent / RPA / API Workflow Task Detail
 
-**Resolved Resource:** ProjectEuler
-**Folder Path:** Shared/uipath-maestro-flow/ProjectEuler RPA
-**Resource Identity:** 486edc26-0658-4ac1-92c9-1ef953927151
+**Resolved Resource:** HelpDeskLookup
+**Folder Path:** Shared/uipath-maestro-flow/HelpDeskLookup RPA
+**Resource Identity:** 4d5c6aa7-a1a6-4dd9-aa4d-6304a22014e8
 **Binding Sub-Type:** —
 **Dispatch / Operation:** —
 
@@ -714,7 +714,7 @@
 
 | Field | Type | Binding |
 |-------|------|---------|
-| problemId | integer | 1 |
+| ticketId | integer | 123 |
 
 **Outputs:**
 
@@ -862,7 +862,7 @@
 | Resource | Type | Folder | Resource ID (+version) | Used By Tasks |
 |----------|------|--------|------------------------|---------------|
 | ProcurementProcess | process | Shared/uipath-agents/ProcurementProcess | 4fc450ab-89be-4462-8fc8-21ac4c1d6fb9 | Budget & GL Reconciliation, Update GL Records |
-| ProjectEuler | rpa | Shared/uipath-maestro-flow/ProjectEuler RPA | 486edc26-0658-4ac1-92c9-1ef953927151 | Process Reimbursement, Send Rejection Notification |
+| HelpDeskLookup | rpa | Shared/uipath-maestro-flow/HelpDeskLookup RPA | 4d5c6aa7-a1a6-4dd9-aa4d-6304a22014e8 | Process Reimbursement, Send Rejection Notification |
 
 ### Child Cases
 

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/test_check_expense_runnable_structure.py
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/test_check_expense_runnable_structure.py
@@ -94,8 +94,8 @@ def _valid_resources() -> list[dict]:
             "value": {"name": {"defaultValue": "ProcurementProcess"}},
         },
         {
-            "key": "Shared/uipath-maestro-flow/ProjectEuler RPA.RPA Workflow",
-            "value": {"name": {"defaultValue": "RPA Workflow"}},
+            "key": "Shared/uipath-maestro-flow/HelpDeskLookup RPA.HelpDeskLookup",
+            "value": {"name": {"defaultValue": "HelpDeskLookup"}},
         },
         {
             "key": "Shared/uipath-maestro-case/CaseTest.Maestro Case",
@@ -109,8 +109,8 @@ class ResourceBindingTests(unittest.TestCase):
         _assert_required_external_bindings({"resources": _valid_resources()})
 
     def test_rejects_resource_alias_in_place_of_display_name(self) -> None:
-        # The SDD alias "ProjectEuler" is not the deployed name "RPA Workflow".
+        # The SDD alias "CaseTest" is not the deployed name "Maestro Case".
         resources = _valid_resources()
-        resources[3]["value"]["name"]["defaultValue"] = "ProjectEuler"
-        with self.assertRaisesRegex(SystemExit, "RPA Workflow"):
+        resources[4]["value"]["name"]["defaultValue"] = "CaseTest"
+        with self.assertRaisesRegex(SystemExit, "Maestro Case"):
             _assert_required_external_bindings({"resources": resources})

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/check_rpa_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/check_rpa_case.py
@@ -17,7 +17,7 @@ def main():
     if task_is_skeleton(task):
         sys.exit(
             "FAIL: rpa task is a skeleton — debug requires a resolved "
-            "ProjectEuler registry entry with a real taskTypeId"
+            "HelpDeskLookup registry entry with a real taskTypeId"
         )
     run_debug(timeout=720)
     print(

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -30,7 +30,7 @@ initial_prompt: |
   | Property | Value |
   |---|---|
   | Case Name | RpaSingleCase |
-  | Case Description | Single-node case that runs the ProjectEuler RPA workflow on a fixed problem number. |
+  | Case Description | Single-node case that runs the HelpDeskLookup RPA workflow on a fixed ticket id. |
   | Case Identifier | Prefix: RSC, Type: constant |
   | Case-Level SLA | 1 d |
   | SLA Type | Static |
@@ -48,14 +48,14 @@ initial_prompt: |
   ### 1.5 Case Variables
   | Name | Category | Type | sourceTriggers | sourceFields | Default | Description |
   |---|---|---|---|---|---|---|
-  | in_ProblemNumber | In | number | | | 123 | Project Euler problem number to solve. |
-  | problemTitle | Variable | string | | | | Problem title returned by the ProjectEuler RPA workflow; populated by Run RPA. |
+  | in_TicketId | In | number | | | 123 | Help desk ticket id to look up. |
+  | ticketTitle | Variable | string | | | | Ticket title returned by the HelpDeskLookup RPA workflow; populated by Run RPA. |
 
   ## Section 2: Stages & Tasks
 
   ### Stage 1: Run RPA (`runRpa`)
   **Type:** Stage
-  **Description:** Execute the ProjectEuler RPA workflow on the input problem number.
+  **Description:** Execute the HelpDeskLookup RPA workflow on the input ticket id.
   **Required for Case Completion:** Yes
 
   #### Stage Entry Conditions
@@ -71,12 +71,12 @@ initial_prompt: |
   #### Tasks
   | # | Task ID | Task Name | Type | Required | Run Only Once | Persona | SLA |
   |---|---------|-----------|------|----------|---------------|---------|-----|
-  | 1 | `runRpa.runProjectEuler` | Run ProjectEuler RPA workflow | rpa | Yes | No | system | — |
+  | 1 | `runRpa.runHelpDeskLookup` | Run HelpDeskLookup RPA workflow | rpa | Yes | No | system | — |
 
-  ##### Task 1.1: Run ProjectEuler RPA workflow (`runRpa.runProjectEuler`)
+  ##### Task 1.1: Run HelpDeskLookup RPA workflow (`runRpa.runHelpDeskLookup`)
 
   **Type:** rpa
-  **Description:** Run the ProjectEuler RPA workflow to fetch the problem title for the given problem number.
+  **Description:** Run the HelpDeskLookup RPA workflow to fetch the ticket title for the given ticket id.
 
   **Entry Condition**
 
@@ -86,18 +86,18 @@ initial_prompt: |
 
   | Field | Value |
   |---|---|
-  | Process Reference | Name "RPA Workflow", Folder "Shared/uipath-maestro-flow/ProjectEuler RPA" |
+  | Process Reference | Name "RPA Workflow", Folder "Shared/uipath-maestro-case/HelpDeskLookup RPA" |
   | Component Type | RPA |
 
   **Inputs**
   | Variable | Type | Binding |
   |---|---|---|
-  | in_ProblemNumber | number | 123 |
+  | in_TicketId | number | 123 |
 
   **Outputs**
   | Variable | Type | Binding |
   |---|---|---|
-  | problemTitle | string | -> problemTitle |
+  | ticketTitle | string | -> ticketTitle |
   ```
 
   Treat the generated tasks.md plan as pre-approved — do NOT block on the

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -86,7 +86,7 @@ initial_prompt: |
 
   | Field | Value |
   |---|---|
-  | Process Reference | Name "RPA Workflow", Folder "Shared/uipath-maestro-case/HelpDeskLookup RPA" |
+  | Process Reference | Name "HelpDeskLookup", Folder "Shared/uipath-maestro-case/HelpDeskLookup RPA" |
   | Component Type | RPA |
 
   **Inputs**

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""ProjectEulerTitle: an RPA-workflow node executes; output holds the title."""
+"""HelpDeskTicketTitle: an RPA-workflow node executes; output holds the title."""
 
 import os
 import sys
@@ -14,11 +14,11 @@ from _shared.flow_check import (  # noqa: E402
 
 def main():
     assert_flow_has_node_type(["uipath.core.rpa-workflow"])
-    # RPA workflows are slow: spin up robot, launch Chrome, scrape. 4 min
-    # is routinely not enough on this tenant.
+    # The workflow itself is a fixed in-process lookup, but the run still has
+    # to provision and start a robot, so keep a generous budget.
     payload = run_debug(timeout=540)
-    assert_outputs_contain(payload, "prime square remainders")
-    print("OK: RPA node present; output contains 'prime square remainders'")
+    assert_outputs_contain(payload, "password reset loop")
+    print("OK: RPA node present; output contains 'password reset loop'")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
@@ -1,8 +1,8 @@
 task_id: skill-flow-rpa
 description: >
-  Create a UiPath Flow that uses the ProjectEuler RPA workflow to retrieve the
-  title for problem 123. Exercises RPA resource node discovery, registry get,
-  and node wiring.
+  Create a UiPath Flow that uses the HelpDeskLookup RPA workflow to retrieve
+  the title for ticket 123. Exercises RPA resource node discovery, registry
+  get, and node wiring.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
 
 run_limits:
@@ -11,8 +11,8 @@ run_limits:
   task_timeout: 2700  # 1380s grading + a turn; inherited 1200 could not fit grading
 
 initial_prompt: |
-  Create a UiPath Flow project named "ProjectEulerTitle" that uses the
-  ProjectEuler RPA workflow to retrieve the title for problem 123 and
+  Create a UiPath Flow project named "HelpDeskTicketTitle" that uses the
+  HelpDeskLookup RPA workflow to retrieve the title for ticket 123 and
   return it as an output.
 
   Validate the flow.
@@ -30,7 +30,7 @@ success_criteria:
 
   # ── Execution checks ──────────────────────────────────────────────────
   - type: run_command
-    description: "Flow has an RPA node and debug returns the problem title"
+    description: "Flow has an RPA node and debug returns the ticket title"
     command: "python3 $TASK_DIR/check_rpa_flow.py"
     timeout: 1200
     expected_exit_code: 0


### PR DESCRIPTION
`skill-flow-rpa` and `skill-case-single-rpa` both drove the ProjectEuler RPA workflow, which scraped projecteuler.net. That host now returns a hard 403 to datacenter IPs while still serving a normal page from a residential address, so every run failed in the browser step. Nothing about the tasks was wrong: the fixture they drove had simply stopped being reachable from the eval tenant.

Both tasks now drive a HelpDeskLookup RPA workflow that resolves a ticket title from a fixed in-process lookup. The argument shape is unchanged, one numeric input and one string output, so the tasks still exercise RPA resource node discovery, registry resolution and node wiring. What goes away is the entire network failure class, and a run that used to need minutes of browser work now finishes in seconds.

The case task also stops reaching into the flow suite's Orchestrator folder and resolves its process from its own `uipath-maestro-case` folder instead.

`skill-case-e2e-expense-runnable` carried the same breakage and moves across too. Its Payment stage holds a required `rpa` task on the graded happy path, so `uip maestro case debug` dispatched a real ProjectEuler job on every run, and that debug criterion is weight 6 of 15. It now binds HelpDeskLookup on ticket 123. The Rejected lane's RPA task moves with it, though that lane stays dormant at runtime.

Both releases are named `HelpDeskLookup` rather than after their inner project. `uip maestro flow registry search` returns only a node type, display name and description: no folder path, no resource key. Seven tenant releases already answered to the display name `RPA Workflow`, so a fixture carrying that name is indistinguishable from the rest, and an agent asked for it binds one of the others at random. A first paired run confirmed exactly that, drawing ProjectEuler's alias and faulting on the same 403 this change exists to remove. ProjectEuler was only ever discoverable because its own release carries a distinctive name.

The fixture itself, its provisioning recipe entries and its readiness pins live in `coder_eval_uipath`; this change is the task side only.

## Verification

Paired codex / `gpt-5.6-luna` run on the eval VM, tempdir driver, Bedrock backend, against this branch at `7a5888af6` with `uip 1.201.0-dev.8272`.

| Task | Status | Score | Duration |
|---|---|---|---|
| `skill-flow-rpa` | SUCCESS | 1.000 | 156.8s |
| `skill-case-single-rpa` | SUCCESS | 1.000 | 194.9s |
| `skill-case-e2e-expense-runnable` | SUCCESS | 1.000 | 442.7s |

3/3 passed, every criterion green, one iteration each.

One environment note for whoever provisions this: renaming an Orchestrator release leaves `~/.uip/case-resources/process-index.json` stale on the eval host, and `uip maestro case registry pull` honors the cache rather than refreshing it. A case task then binds the old release name and the run fails at dispatch with `[170007] Failure to start the Orchestrator job`, which points nowhere near the cache. `uip maestro case registry pull --force` clears it.
