### PR TITLE
fix(flow-check): name an unconfigured connector node instead of "no create-entity-record"

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_file_activities.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_file_activities.py
@@ -90,9 +90,19 @@ def main() -> int:
         upload_node = None
         delete_node = None
         create_node = None
+        # Connector nodes that carry no `inputs.detail` at all. The platform reads
+        # a connector's entity/body/connection from `detail`, so such a node can
+        # never run — it is an unconfigured node (SDK `rawNode`, a hand-written
+        # node, or `node add` without `node configure`), not a missing one.
+        # Naming it keeps "no create-entity-record" from being read as "the
+        # agent forgot the step" (2026-09-01 v2: the step was there, raw).
+        unconfigured = []
         for n in doc.get("nodes", []):
             t = n.get("type", "")
             detail = n.get("inputs", {}).get("detail", {})
+            if t.startswith("uipath.connector.") and (not isinstance(detail, dict) or not detail):
+                unconfigured.append(f"{n.get('id')} ({t.rsplit('.', 1)[-1]})")
+                detail = {}
             pp = detail.get("pathParameters") or {}
             query = detail.get("queryParameters") or {}
             body = detail.get("bodyParameters") or {}
@@ -111,6 +121,11 @@ def main() -> int:
                         delete_node = n
         if not REQUIRED.issubset(seen.keys()):
             continue
+        unconfigured_note = (
+            f" Unconfigured connector node(s) with no inputs.detail: {unconfigured} — "
+            f"the platform reads entity, body and connection from detail, so these can never run."
+            if unconfigured else ""
+        )
         resolved = {s: resolve_field(v, globals_by_id) for s, v in seen.items()}
         wrong = [(s, seen[s], resolved[s]) for s in REQUIRED if resolved[s] != FIELD]
         if wrong:
@@ -135,7 +150,7 @@ def main() -> int:
 
         # create-entity-record on ENTITY must exist and upload+delete recordId must reference its output
         if not create_node:
-            print(f"FAIL: {path} — no create-entity-record on {ENTITY}", file=sys.stderr)
+            print(f"FAIL: {path} — no create-entity-record on {ENTITY} with inputs.detail.pathParameters.entityName={ENTITY!r}.{unconfigured_note}", file=sys.stderr)
             return 1
         create_body = (create_node.get("inputs", {}).get("detail", {}).get("bodyParameters") or {})
         required_body = {"title", "description", "score"}

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_file_activities.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_smoke_file_activities.py
@@ -122,7 +122,7 @@ def main() -> int:
         if not REQUIRED.issubset(seen.keys()):
             continue
         unconfigured_note = (
-            f" Unconfigured connector node(s) with no inputs.detail: {unconfigured} — "
+            f" Unconfigured connector node(s) with no inputs.detail: {', '.join(unconfigured)} — "
             f"the platform reads entity, body and connection from detail, so these can never run."
             if unconfigured else ""
         )

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/test_check_smoke_file_activities.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/test_check_smoke_file_activities.py
@@ -1,0 +1,100 @@
+"""Unit tests for check_smoke_file_activities.py — purely structural, no CLI.
+
+Run with ``pytest tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/test_check_smoke_file_activities.py``.
+
+The shapes come from real eval artifacts of ``skill-flow-datafabric-smoke-file-activities``:
+the v1 arm's configured connector nodes (pass), and the 2026-09-01 SDK arm, whose
+``create-entity-record`` node was placed through ``rawNode`` and so carried its inputs
+flat with no ``inputs.detail`` (fail — and the message must say the node is unconfigured,
+not absent).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+CHECKER = Path(__file__).resolve().parent / "check_smoke_file_activities.py"
+ENTITY = "FlowCodeEvalEntity"
+DS = "uipath.connector.uipath-uipath-dataservice."
+
+
+def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(CHECKER)], cwd=str(cwd), capture_output=True, text=True)
+
+
+def _configured(node_id: str, action: str, *, path: dict[str, Any] | None = None,
+                query: dict[str, Any] | None = None, body: dict[str, Any] | None = None,
+                multipart: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    detail: dict[str, Any] = {
+        "connector": "uipath-uipath-dataservice",
+        "connectionId": "d61e5d0e-04af-4f93-95cc-151d81fa08dc",
+        "connectionFolderKey": "c4359cde-55f0-4f0e-9322-c6cdce74ab4c",
+        "pathParameters": path or {"entityName": ENTITY},
+    }
+    if query is not None:
+        detail["queryParameters"] = query
+    if body is not None:
+        detail["bodyParameters"] = body
+    if multipart is not None:
+        detail["multipartParameters"] = multipart
+    return {"id": node_id, "type": DS + action, "typeVersion": "1.0.0", "inputs": {"detail": detail}}
+
+
+def _file_nodes(create_node: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {"id": "start", "type": "core.trigger.manual"},
+        _configured("downloadFile", "download-file-from-record-field",
+                    query={"recordId": "11111111-1111-4111-8111-111111111111", "_fieldName": "file1"}),
+        create_node,
+        _configured("uploadFile", "upload-file-to-record-field",
+                    query={"recordId": "=js:$vars.createRecord.output.Id", "_fieldName": "file1"},
+                    multipart=[{"name": "file", "dataType": "file", "value": "=js:$vars.downloadedFile"}]),
+        _configured("deleteFile", "delete-file-from-record-field",
+                    query={"recordId": "=js:$vars.createRecord.output.Id", "_fieldName": "file1"}),
+        {"id": "end", "type": "core.control.end"},
+    ]
+
+
+def _write(tmp_path: Path, nodes: list[dict[str, Any]]) -> None:
+    doc = {
+        "id": "t", "version": "1.0.0", "name": "T", "nodes": nodes, "edges": [],
+        "variables": {"globals": [{"id": "downloadedFile", "name": "downloadedFile",
+                                   "direction": "inout", "type": "file"}],
+                      "variableUpdates": {}},
+    }
+    (tmp_path / "TransferFile.flow").write_text(json.dumps(doc))
+
+
+def test_configured_create_with_flat_body_passes(tmp_path: Path) -> None:
+    create = _configured("createRecord", "create-entity-record",
+                         body={"title": "t", "description": "d", "score": 42.5})
+    _write(tmp_path, _file_nodes(create))
+    r = _run(tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "OK:" in r.stdout
+
+
+def test_raw_unconfigured_create_fails_and_is_named_as_unconfigured(tmp_path: Path) -> None:
+    # The 2026-09-01 SDK artifact: inputs flat, no `detail` — an unconfigured node.
+    raw_create = {"id": "createRecord", "type": DS + "create-entity-record", "typeVersion": "1.0.0",
+                  "inputs": {"entityName": ENTITY, "body": {"title": "t", "description": "d", "score": 42.5}}}
+    _write(tmp_path, _file_nodes(raw_create))
+    r = _run(tmp_path)
+    assert r.returncode == 1
+    assert "no create-entity-record" in r.stderr
+    assert "Unconfigured connector node(s) with no inputs.detail" in r.stderr
+    assert "createRecord (create-entity-record)" in r.stderr
+
+
+def test_nested_body_object_still_fails_on_required_fields(tmp_path: Path) -> None:
+    # The 2026-08-31 22:43 SDK artifact: a forged overlay nested the body under `body`.
+    create = _configured("createRecord", "create-entity-record",
+                         body={"body": {"title": "t", "description": "d", "score": 42.5}})
+    _write(tmp_path, _file_nodes(create))
+    r = _run(tmp_path)
+    assert r.returncode == 1
+    assert "create body missing required fields" in r.stderr


### PR DESCRIPTION
## Why

`skill-flow-datafabric-smoke-file-activities`, SDK arm, adhoc `2026-09-01_06-35-33`: the agent placed `create-entity-record` through the SDK's `rawNode`, so the node **existed** but carried its inputs flat with no `inputs.detail`. The checker reads entity/body/connection from `detail` (what the platform reads), skipped the node, and reported `no create-entity-record on FlowCodeEvalEntity` — which reads as "the agent forgot step 2". It did not; the node can never run.

The enabling defect is fixed in the SDK ([flow-builder-sdk#663](https://github.com/UiPath/flow-builder-sdk/pull/663): `rawNode` refuses connector types; `prepare` names the parent input; bindings help points at `prepare` / `--all-folders`). This PR only makes the checker's failure text land on that defect.

## What

- The FAIL line now says where `entityName` is expected (`inputs.detail.pathParameters.entityName`) and lists connector nodes with no `inputs.detail` — "Unconfigured connector node(s) … the platform reads entity, body and connection from detail, so these can never run."
- Verdicts unchanged. Verified on the real artifacts: 09-01 v1 → `OK`, 09-01 v2 → `FAIL` (now naming `createRecord (create-entity-record)`), 08-31 22:43 v2 → same `create body missing required fields`.

## Tests

- `test_check_smoke_file_activities.py` (new, 3): configured flat body passes; raw unconfigured create fails and is named; nested `body` object still fails on required fields.
- `uv run --with pytest --with pyyaml python -m pytest tests/tasks/uipath-maestro-flow/` → 343 passed; `scripts/check-task-driver.py tests/tasks` → OK.

## Measurement contract (plan §2.5 / D-1)

No prompt, criterion, weight, threshold or `run_limits` change; message text only.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMAwQ1iQQSUUPi3oatMqgG
