### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@c30ff64

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ b570962. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ c30ff64. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ b570962. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ c30ff64. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ b570962. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ c30ff64. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -630,6 +630,14 @@ Signature: `rawNode({ nodeType, version, manifest, inputs?, outputs? })`.
 wrote. Prefer a typed factory when one exists: it carries the family's checks,
 defaults and output contract. `decompile` emits this for a node type it cannot
 name, so an unknown node keeps its type and version through a round trip.
+
+**Never for a connector.** `check` and `compile` refuse a `uipath.connector.*`
+node type here: a raw node keeps its inputs verbatim, so the emitted node has no
+`inputs.detail` and no connection binding — `validate` only warns and the run
+never reaches Integration Service. When `compile` refuses a connector input as
+unknown, the answer is `npx flow-sdk registry prepare <key> <action>` (see
+[connector-params.md](references/connector-params.md#schema-dynamic-operations-the-parent-field-loop)),
+not `rawNode`.
 
 **Reference: [`references/placeholder.md`](references/placeholder.md#unknown-node-types)**
 

--- a/preview/uipath-maestro-flow/references/bindings.md
+++ b/preview/uipath-maestro-flow/references/bindings.md
@@ -49,11 +49,15 @@ the resource kind and emitted binding purpose explicit.
 Reach for the manual route below only when you are authoring bindings without
 running `prepare`.
 
-If you are doing it by hand: `uip is connections list` returns the connection id
-**and its folder key** on the same record, so one call answers both:
+If you are doing it by hand: `uip is connections list --all-folders` returns the
+connection id **and its folder key** on the same record, so one call answers both.
+Always pass `--all-folders`: the default listing is your own folder only, and a
+connection shared from another folder (the usual case on a team tenant) is
+invisible without it — an empty or unrelated default listing is not evidence
+that the connection does not exist.
 
 ```bash
-uip is connections list --output json
+uip is connections list --all-folders --output json
 ```
 
 ```text
@@ -68,8 +72,9 @@ uip is connections list --output json
 ```
 
 `Id` is the connection binding's `resourceKey`; **`FolderKey` is the folder
-binding's**. Add `--all-folders` if the connection you want is not in the
-default listing.
+binding's**. Never fill either with a made-up GUID or with the binding's own
+name: `compile` refuses a binding whose `resourceKey` is its own name, and a
+plausible GUID compiles and then faults at run time.
 
 **Do not go looking in Orchestrator for the folder.** `uip or folders list` is a
 different resource with different keys, and a folder binding wants the one the

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -273,6 +273,25 @@ uip is resources describe <connector-key> <object> \
 That placeholder is also the **ordering**: resolve `fields.project.key` before
 you can resolve `fields.issuetype.id`.
 
+**A second declaration shape has no placeholder.** Data Service
+(`uipath-uipath-dataservice`) operations such as `create-entity-record`,
+`update-entity-record` and the file-record-field operations declare their parent
+through the registry's schema action (`GenerateSchema` over `entityName`), not
+through a reference path. Their describe with no values returns only the static
+inputs (`entityName`, `expansionLevel`) — not one field of the entity — so
+`compile` refuses `title`, `description`, … as unknown. `prepare` names the
+parent when you omit it; the fix is always the entity name:
+
+```bash
+npx flow-sdk registry prepare uipath-uipath-dataservice create-entity-record \
+  -f entityName=FlowCodeEvalEntity
+# → 8 input field(s): entityName, expansionLevel + the entity's own fields
+```
+
+Do not work around the refusal — not with `rawNode`, not by editing the emitted
+`.flow`, not by hand-writing a `connectors-local/` overlay. Each produces a node
+the platform cannot run.
+
 Parent-field names are operation-specific. Copy each `Name` exactly from this
 operation's describe response; do not reuse the dotted names from the
 `create-issue` example for another action (for example, Jira `get-issue` uses

--- a/preview/uipath-maestro-flow/references/placeholder.md
+++ b/preview/uipath-maestro-flow/references/placeholder.md
@@ -44,6 +44,18 @@ against its own catalog. **Prefer a typed factory** whenever one exists: it
 carries the family's check rules, its defaults and its output contract, none of
 which a raw node can know.
 
+**Never for a connector.** A `uipath.connector.*` node type is refused by
+`check` (`RAW_NODE_CONNECTOR`) and by `compile`. A raw node keeps its inputs
+verbatim, so the emitted connector node has no `inputs.detail` and no
+connection binding: `uip maestro flow validate` only warns ("Connector is not
+configured") and the run can never reach Integration Service. Measured on the
+eval archive, every Data Fabric flow authored this way failed its checker. The
+situation that tempts it — `compile` refusing a body field as `unknown input`
+because the static library does not carry it — is what
+`npx flow-sdk registry prepare <key> <action>` exists for (add
+`-f entityName=<Entity>` for a Data Service operation); see the
+[parent-field loop](connector-params.md#schema-dynamic-operations-the-parent-field-loop).
+
 `decompile` emits `rawNode(...)` for any node type it cannot name, hoisting the
 manifest to a `const` beside the flow. So `mock()` in decompiled source means
 the flow really contains a placeholder.


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `b570962` to current `UiPath/flow-builder-sdk@main` (`c30ff64`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)