### PR TITLE
test(maestro-flow): reach the shared checker via SKILLS_REPO_PATH

### DIFF
--- a/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
@@ -72,7 +72,7 @@ success_criteria:
   # _shared is its sibling.
   - type: run_command
     description: "Inline agent.json: model overridden, real system prompt, typed outputSchema"
-    command: 'python3 "$TASK_DIR/../_shared/check_inline_agent.py" "EmailTriage/EmailTriage/*/agent.json"'
+    command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/check_inline_agent.py" "EmailTriage/EmailTriage/*/agent.json"'
     timeout: 15
     expected_exit_code: 0
     weight: 3.0


### PR DESCRIPTION
One line: the `inline_agent_robust` checker criterion reached `_shared/check_inline_agent.py` via `$TASK_DIR/../` — the only relative escape in the repo. The runner's sandbox isolation (between the 08-20 and 08-31 nightlies) mounts the task directory alone, so the escape fails with `[Errno 2]` and the task has scored 0.714 every night since (1.0 through 08-20). Switched to the `$SKILLS_REPO_PATH` absolute form used by every other task.

Passing run: local run `2026-09-01_14-57-45` under the current runner — 1.0, all six criteria, checker output `OK (...)`.