### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@965313a

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ c30ff64. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 965313a. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ c30ff64. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 965313a. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-case/references/api.md
+++ b/preview/uipath-maestro-case/references/api.md
@@ -29,7 +29,7 @@ generated from the built types; longer tutorials stay in the node references.
 
 **Option shapes** — [RuleOpts](#ruleopts-interface) · [EscalationOpts](#escalationopts-interface) · [ManualTriggerOpts](#manualtriggeropts-interface) · [TimerTriggerOpts](#timertriggeropts-interface) · [ResolvedEventTriggerOpts](#resolvedeventtriggeropts-interface) · [EventTriggerOpts](#eventtriggeropts-interface) · [EventSubscription](#eventsubscription-interface) · [TriggerOptions](#triggeroptions-interface) · [SlaOpts](#slaopts-interface) · [EntryOpts](#entryopts-interface) · [ExitOpts](#exitopts-interface) · [ExternalTaskOptions](#externaltaskoptions-interface) · [ConnectorOpts](#connectoropts-interface)
 
-**Supporting types** — [CaseRuleType](#caseruletype-type) · [CaseRule](#caserule-interface) · [WhenExpression](#whenexpression-interface) · [BuiltEscalation](#builtescalation-interface) · [EscalationRecipient](#escalationrecipient-interface) · [BuiltTrigger](#builttrigger-interface) · [TriggerDescriptor](#triggerdescriptor-type) · [JsonSchemaType](#jsonschematype-interface) · [WaitConnectorSpec](#waitconnectorspec-type) · [EscalationTrigger](#escalationtrigger-type) · [CaseTriggerKind](#casetriggerkind-type) · [TaskOutputBinding](#taskoutputbinding-interface) · [TriggerMeta](#triggermeta-interface) · [TypeDesc](#typedesc-type) · [CaseAppConfig](#caseappconfig-interface) · [CaseLayout](#caselayout-interface) · [CaseRuleGrid](#caserulegrid-type) · [BuiltCase](#builtcase-interface) · [WaitConnectorPlaceholderSpec](#waitconnectorplaceholderspec-interface) · [EventFilter](#eventfilter-interface) · [CaseAppSection](#caseappsection-interface) · [CaseNodeLayout](#casenodelayout-interface) · [BuiltStage](#builtstage-interface) · [CaseRuleInput](#caseruleinput-type) · [SlaUnit](#slaunit-type) · [CaseVarDecl](#casevardecl-interface) · [BuiltCaseExitCondition](#builtcaseexitcondition-interface) · [BuiltSla](#builtsla-interface) · [CaseAppDetailValue](#caseappdetailvalue-type) · [UnresolvedReferenceTaskKind](#unresolvedreferencetaskkind-type) · [ConnectorDescriptor](#connectordescriptor-type) · [RecipientType](#recipienttype-type) · [ActionField](#actionfield-interface) · [TimerSpecData](#timerspecdata-type) · [BuiltTask](#builttask-interface) · [StageExitType](#stageexittype-type) · [SelectNextStageSpec](#selectnextstagespec-interface) · [BuiltEntryCondition](#builtentrycondition-interface) · [BuiltExitCondition](#builtexitcondition-interface) · [ConnectorMeta](#connectormeta-interface) · [ExternalExecutionMode](#externalexecutionmode-type) · [TaskKind](#taskkind-type) · [TaskRef](#taskref-interface) · [ActionSpecData](#actionspecdata-interface) · [ConnectorSpecData](#connectorspecdata-type) · [ExternalTaskSpecData](#externaltaskspecdata-interface) · [TaskInputBinding](#taskinputbinding-interface) · [BuiltTaskEntryCondition](#builttaskentrycondition-interface) · [LookupSpec](#lookupspec-interface) · [LookupStrategy](#lookupstrategy-type)
+**Supporting types** — [CaseRuleType](#caseruletype-type) · [CaseRule](#caserule-interface) · [WhenExpression](#whenexpression-interface) · [BuiltEscalation](#builtescalation-interface) · [EscalationRecipient](#escalationrecipient-interface) · [BuiltTrigger](#builttrigger-interface) · [TriggerDescriptor](#triggerdescriptor-type) · [JsonSchemaType](#jsonschematype-interface) · [WaitConnectorSpec](#waitconnectorspec-type) · [EscalationTrigger](#escalationtrigger-type) · [CaseTriggerKind](#casetriggerkind-type) · [TaskOutputBinding](#taskoutputbinding-interface) · [TriggerMeta](#triggermeta-interface) · [TypeDesc](#typedesc-type) · [CaseAppConfig](#caseappconfig-interface) · [CaseLayout](#caselayout-interface) · [CaseRuleGrid](#caserulegrid-type) · [BuiltCase](#builtcase-interface) · [WaitConnectorPlaceholderSpec](#waitconnectorplaceholderspec-interface) · [EventFilter](#eventfilter-type) · [CaseAppSection](#caseappsection-interface) · [CaseNodeLayout](#casenodelayout-interface) · [BuiltStage](#builtstage-interface) · [CaseRuleInput](#caseruleinput-type) · [SlaUnit](#slaunit-type) · [CaseVarDecl](#casevardecl-interface) · [BuiltCaseExitCondition](#builtcaseexitcondition-interface) · [BuiltSla](#builtsla-interface) · [CaseAppDetailValue](#caseappdetailvalue-type) · [UnresolvedReferenceTaskKind](#unresolvedreferencetaskkind-type) · [ConnectorDescriptor](#connectordescriptor-type) · [RecipientType](#recipienttype-type) · [ActionField](#actionfield-interface) · [TimerSpecData](#timerspecdata-type) · [BuiltTask](#builttask-interface) · [StageExitType](#stageexittype-type) · [SelectNextStageSpec](#selectnextstagespec-interface) · [BuiltEntryCondition](#builtentrycondition-interface) · [BuiltExitCondition](#builtexitcondition-interface) · [ConnectorMeta](#connectormeta-interface) · [ExternalExecutionMode](#externalexecutionmode-type) · [TaskKind](#taskkind-type) · [TaskRef](#taskref-interface) · [ActionSpecData](#actionspecdata-interface) · [ConnectorSpecData](#connectorspecdata-type) · [ExternalTaskSpecData](#externaltaskspecdata-interface) · [TaskInputBinding](#taskinputbinding-interface) · [BuiltTaskEntryCondition](#builttaskentrycondition-interface) · [LookupSpec](#lookupspec-interface) · [LookupStrategy](#lookupstrategy-type)
 
 ## rule (function)
 
@@ -492,6 +492,12 @@ export interface EventSubscription {
      * --connection-id <id>`).
      */
     where?: Record<string, string>;
+    /**
+     * The OBJECT a GENERIC event watches (a Data Fabric entity, a Salesforce or
+     * ServiceNow object, a Jira record type). Required for such an event, refused
+     * for a curated one; see `TriggerOptions.object`.
+     */
+    object?: string;
     /** Optional filters on the payload. Omit to take every event in scope. */
     filters?: EventFilter[];
     /** bindings.json id for the connection (defaults to the flow's single binding). */
@@ -518,6 +524,17 @@ export interface TriggerOptions<W = Record<string, string>> {
      * `{ parentFolderId: '<mail folder id>' }`.
      */
     where?: W;
+    /**
+     * The OBJECT a GENERIC event watches — the one thing its node type does not
+     * say. `record-created` / `record-updated` on Data Fabric, Salesforce,
+     * ServiceNow, Jira and some sixty other connectors fire for ONE object of the
+     * connection (an entity, a table, a custom object), and the library carries no
+     * default for it: `uip is triggers objects <key> <EVENT> --connection-id <id>`
+     * lists the choices. REQUIRED for such an event, refused for a curated one whose
+     * object is built in (Outlook `email-received` is always `Message`). It is not
+     * an event parameter, so it does not go in `where`.
+     */
+    object?: string;
     /** Optional filters on the payload. Omit to take every event in scope. */
     filters?: EventFilter[];
     /** bindings.json id for the connection (defaults to the flow's single binding). */
@@ -811,13 +828,30 @@ export interface WaitConnectorPlaceholderSpec {
 }
 ````
 
-## EventFilter (interface)
+## EventFilter (type)
 
 ````ts
-export interface EventFilter {
+export type EventFilter = {
     field: string;
+} & ({
     contains: string;
-}
+} | {
+    startsWith: string;
+} | {
+    endsWith: string;
+} | {
+    equals: string | number | boolean;
+} | {
+    notEquals: string | number | boolean;
+} | {
+    lessThan: string | number;
+} | {
+    lessThanOrEqual: string | number;
+} | {
+    greaterThan: string | number;
+} | {
+    greaterThanOrEqual: string | number;
+});
 ````
 
 ## CaseAppSection (interface)

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ c30ff64. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 965313a. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -296,6 +296,7 @@ export default flow('mail').trigger(onEvent(mail))
 ```
 
 Resolve scope names and ids from the bound connection; preserve filter casing.
+A generic event (`record-created`/`record-updated`) needs `object: '<Entity>'` — never put it in `where`.
 Use the reference's completion contract before debugging: an injected start
 payload can exercise downstream wiring, but it is not a subscription witness.
 

--- a/preview/uipath-maestro-flow/references/api.md
+++ b/preview/uipath-maestro-flow/references/api.md
@@ -35,7 +35,7 @@ generated from the built types; longer tutorials stay in the node references.
 
 **Option shapes** — [TriggerOptions](#triggeroptions-interface) · [EventSubscription](#eventsubscription-interface) · [ScheduledInputs](#scheduledinputs-interface) · [HttpInputs](#httpinputs-type) · [ScriptInputs](#scriptinputs-interface) · [TransformInputs](#transforminputs-interface) · [HitlInputs](#hitlinputs-interface) · [SummarizeInputs](#summarizeinputs-interface) · [BatchTransformInputs](#batchtransforminputs-interface) · [IxpExtractInputs](#ixpextractinputs-interface) · [DelayInputs](#delayinputs-type) · [RpaWorkflowInputs](#rpaworkflowinputs-interface) · [ApiWorkflowInputs](#apiworkflowinputs-interface) · [PublishedFunctionInputs](#publishedfunctioninputs-interface) · [SendMessageInputs](#sendmessageinputs-interface) · [WaitForMessageInputs](#waitformessageinputs-interface) · [ConversationContextInputs](#conversationcontextinputs-interface) · [CreateOutgoingCallInputs](#createoutgoingcallinputs-interface) · [EndCallInputs](#endcallinputs-interface) · [VoiceAgentInputs](#voiceagentinputs-interface) · [ConversationalAgentInputs](#conversationalagentinputs-interface) · [AgenticProcessInputs](#agenticprocessinputs-type) · [AgentInputs](#agentinputs-interface) · [InlineAgentInputs](#inlineagentinputs-interface) · [DocumentClassifyInputs](#documentclassifyinputs-interface) · [DynamicExtractInputs](#dynamicextractinputs-interface) · [DataFabricReadInputs](#datafabricreadinputs-interface) · [DataFabricUpdateInputs](#datafabricupdateinputs-interface) · [QueueItemInputs](#queueiteminputs-interface) · [ConnectorOpts](#connectoropts-interface) · [NodeOptions](#nodeoptions-interface) · [HttpInputsBase](#httpinputsbase-interface) · [DocValidationInputs](#docvalidationinputs-interface) · [AgenticProcessInputsBase](#agenticprocessinputsbase-interface) · [LoopOptions](#loopoptions-interface) · [DoWhileOptions](#dowhileoptions-interface)
 
-**Supporting types** — [ContributionDiagnostic](#contributiondiagnostic-interface) · [DefinitionReference](#definitionreference-type) · [ContributionContext](#contributioncontext-interface) · [BindingContribution](#bindingcontribution-interface) · [NodeContribution](#nodecontribution-interface) · [FlowNode](#flownode-class) · [FlowAction](#flowaction-class) · [FlowTrigger](#flowtrigger-class) · [FlowResource](#flowresource-class) · [rawNode](#rawnode-function) · [TriggerSpec](#triggerspec-type) · [ChildFlow](#childflow-type) · [Expr](#expr-class) · [SubflowSpec](#subflowspec-interface) · [ActionSpec](#actionspec-type) · [ErrorEnvelopeField](#errorenvelopefield-type) · [RawReference](#rawreference-type) · [EventFilter](#eventfilter-interface) · [ScheduleEvery](#scheduleevery-type) · [FlowLayout](#flowlayout-interface) · [StickyNote](#stickynote-interface) · [TypeDesc](#typedesc-type) · [VarSpec](#varspec-interface) · [BuiltFlow](#builtflow-interface) · [ScriptReturns](#scriptreturns-type) · [TransformVariant](#transformvariant-type) · [TransformOperation](#transformoperation-type) · [HitlVariant](#hitlvariant-type) · [AppRef](#appref-interface) · [FormField](#formfield-type) · [Outcome](#outcome-type) · [HitlRecipient](#hitlrecipient-interface) · [OutputColumn](#outputcolumn-interface) · [ReturnFieldType](#returnfieldtype-type) · [VoiceSettings](#voicesettings-interface) · [ConversationalAgentSettings](#conversationalagentsettings-interface) · [AgentGuardrail](#agentguardrail-type) · [AgenticProcessCompletion](#agenticprocesscompletion-type) · [AgentLocation](#agentlocation-type) · [AgentFlavour](#agentflavour-type) · [InlineAgentFieldType](#inlineagentfieldtype-type) · [AgentMemoryRef](#agentmemoryref-interface) · [ContextIndexRef](#contextindexref-interface) · [ToolRef](#toolref-type) · [EscalationRef](#escalationref-interface) · [DataFabricFilter](#datafabricfilter-interface) · [QueuePriority](#queuepriority-type) · [SchedulePreset](#schedulepreset-type) · [Step](#step-type) · [FlowActionSpec](#flowactionspec-type) · [CaseValue](#casevalue-type) · [NodeLayout](#nodelayout-interface) · [EdgeRoute](#edgeroute-interface) · [StickyNoteColor](#stickynotecolor-type) · [VarDecl](#vardecl-interface) · [BuiltEntryPoint](#builtentrypoint-interface) · [HttpBranch](#httpbranch-interface) · [ScriptReturnType](#scriptreturntype-type) · [FilterRule](#filterrule-interface) · [FilterMatch](#filtermatch-type) · [FieldMapping](#fieldmapping-interface) · [Aggregation](#aggregation-interface) · [ShownField](#shownfield-interface) · [AskedField](#askedfield-interface) · [InOutField](#inoutfield-interface) · [HitlChannel](#hitlchannel-type) · [HitlAssigneeType](#hitlassigneetype-type) · [HitlConnection](#hitlconnection-interface) · [CustomGuardrail](#customguardrail-interface) · [BuiltInValidatorGuardrail](#builtinvalidatorguardrail-interface) · [BuiltinToolRef](#builtintoolref-interface) · [ConnectorToolRef](#connectortoolref-interface) · [ProcessToolRef](#processtoolref-interface) · [IxpToolRef](#ixptoolref-interface) · [McpToolRef](#mcptoolref-interface) · [RemoteA2aToolRef](#remotea2atoolref-interface) · [ClientSideToolRef](#clientsidetoolref-interface) · [HttpRequestToolRef](#httprequesttoolref-interface) · [SwitchArm](#switcharm-interface) · [FilterCondition](#filtercondition-type) · [Transformation](#transformation-type) · [AggregationOperation](#aggregationoperation-type) · [FormFieldType](#formfieldtype-type) · [GuardrailSelector](#guardrailselector-interface) · [GuardrailAction](#guardrailaction-type) · [GuardrailRule](#guardrailrule-type) · [BuiltinToolName](#builtintoolname-type) · [ProcessToolKind](#processtoolkind-type) · [GuardrailScope](#guardrailscope-type) · [GuardrailFieldReference](#guardrailfieldreference-interface) · [GuardrailFieldSelector](#guardrailfieldselector-type)
+**Supporting types** — [ContributionDiagnostic](#contributiondiagnostic-interface) · [DefinitionReference](#definitionreference-type) · [ContributionContext](#contributioncontext-interface) · [BindingContribution](#bindingcontribution-interface) · [NodeContribution](#nodecontribution-interface) · [FlowNode](#flownode-class) · [FlowAction](#flowaction-class) · [FlowTrigger](#flowtrigger-class) · [FlowResource](#flowresource-class) · [rawNode](#rawnode-function) · [TriggerSpec](#triggerspec-type) · [ChildFlow](#childflow-type) · [Expr](#expr-class) · [SubflowSpec](#subflowspec-interface) · [ActionSpec](#actionspec-type) · [ErrorEnvelopeField](#errorenvelopefield-type) · [RawReference](#rawreference-type) · [EventFilter](#eventfilter-type) · [ScheduleEvery](#scheduleevery-type) · [FlowLayout](#flowlayout-interface) · [StickyNote](#stickynote-interface) · [TypeDesc](#typedesc-type) · [VarSpec](#varspec-interface) · [BuiltFlow](#builtflow-interface) · [ScriptReturns](#scriptreturns-type) · [TransformVariant](#transformvariant-type) · [TransformOperation](#transformoperation-type) · [HitlVariant](#hitlvariant-type) · [AppRef](#appref-interface) · [FormField](#formfield-type) · [Outcome](#outcome-type) · [HitlRecipient](#hitlrecipient-interface) · [OutputColumn](#outputcolumn-interface) · [ReturnFieldType](#returnfieldtype-type) · [VoiceSettings](#voicesettings-interface) · [ConversationalAgentSettings](#conversationalagentsettings-interface) · [AgentGuardrail](#agentguardrail-type) · [AgenticProcessCompletion](#agenticprocesscompletion-type) · [AgentLocation](#agentlocation-type) · [AgentFlavour](#agentflavour-type) · [InlineAgentFieldType](#inlineagentfieldtype-type) · [AgentMemoryRef](#agentmemoryref-interface) · [ContextIndexRef](#contextindexref-interface) · [ToolRef](#toolref-type) · [EscalationRef](#escalationref-interface) · [DataFabricFilter](#datafabricfilter-interface) · [QueuePriority](#queuepriority-type) · [SchedulePreset](#schedulepreset-type) · [Step](#step-type) · [FlowActionSpec](#flowactionspec-type) · [CaseValue](#casevalue-type) · [NodeLayout](#nodelayout-interface) · [EdgeRoute](#edgeroute-interface) · [StickyNoteColor](#stickynotecolor-type) · [VarDecl](#vardecl-interface) · [BuiltEntryPoint](#builtentrypoint-interface) · [HttpBranch](#httpbranch-interface) · [ScriptReturnType](#scriptreturntype-type) · [FilterRule](#filterrule-interface) · [FilterMatch](#filtermatch-type) · [FieldMapping](#fieldmapping-interface) · [Aggregation](#aggregation-interface) · [ShownField](#shownfield-interface) · [AskedField](#askedfield-interface) · [InOutField](#inoutfield-interface) · [HitlChannel](#hitlchannel-type) · [HitlAssigneeType](#hitlassigneetype-type) · [HitlConnection](#hitlconnection-interface) · [CustomGuardrail](#customguardrail-interface) · [BuiltInValidatorGuardrail](#builtinvalidatorguardrail-interface) · [BuiltinToolRef](#builtintoolref-interface) · [ConnectorToolRef](#connectortoolref-interface) · [ProcessToolRef](#processtoolref-interface) · [IxpToolRef](#ixptoolref-interface) · [McpToolRef](#mcptoolref-interface) · [RemoteA2aToolRef](#remotea2atoolref-interface) · [ClientSideToolRef](#clientsidetoolref-interface) · [HttpRequestToolRef](#httprequesttoolref-interface) · [SwitchArm](#switcharm-interface) · [FilterCondition](#filtercondition-type) · [Transformation](#transformation-type) · [AggregationOperation](#aggregationoperation-type) · [FormFieldType](#formfieldtype-type) · [GuardrailSelector](#guardrailselector-interface) · [GuardrailAction](#guardrailaction-type) · [GuardrailRule](#guardrailrule-type) · [BuiltinToolName](#builtintoolname-type) · [ProcessToolKind](#processtoolkind-type) · [GuardrailScope](#guardrailscope-type) · [GuardrailFieldReference](#guardrailfieldreference-interface) · [GuardrailFieldSelector](#guardrailfieldselector-type)
 
 ## SCHEDULE_PRESETS (const)
 
@@ -1041,6 +1041,17 @@ export interface TriggerOptions<W = Record<string, string>> {
      * `{ parentFolderId: '<mail folder id>' }`.
      */
     where?: W;
+    /**
+     * The OBJECT a GENERIC event watches — the one thing its node type does not
+     * say. `record-created` / `record-updated` on Data Fabric, Salesforce,
+     * ServiceNow, Jira and some sixty other connectors fire for ONE object of the
+     * connection (an entity, a table, a custom object), and the library carries no
+     * default for it: `uip is triggers objects <key> <EVENT> --connection-id <id>`
+     * lists the choices. REQUIRED for such an event, refused for a curated one whose
+     * object is built in (Outlook `email-received` is always `Message`). It is not
+     * an event parameter, so it does not go in `where`.
+     */
+    object?: string;
     /** Optional filters on the payload. Omit to take every event in scope. */
     filters?: EventFilter[];
     /** bindings.json id for the connection (defaults to the flow's single binding). */
@@ -1069,6 +1080,12 @@ export interface EventSubscription {
      * --connection-id <id>`).
      */
     where?: Record<string, string>;
+    /**
+     * The OBJECT a GENERIC event watches (a Data Fabric entity, a Salesforce or
+     * ServiceNow object, a Jira record type). Required for such an event, refused
+     * for a curated one; see `TriggerOptions.object`.
+     */
+    object?: string;
     /** Optional filters on the payload. Omit to take every event in scope. */
     filters?: EventFilter[];
     /** bindings.json id for the connection (defaults to the flow's single binding). */
@@ -2449,13 +2466,30 @@ type RawReference = {
 } | undefined;
 ````
 
-## EventFilter (interface)
+## EventFilter (type)
 
 ````ts
-export interface EventFilter {
+export type EventFilter = {
     field: string;
+} & ({
     contains: string;
-}
+} | {
+    startsWith: string;
+} | {
+    endsWith: string;
+} | {
+    equals: string | number | boolean;
+} | {
+    notEquals: string | number | boolean;
+} | {
+    lessThan: string | number;
+} | {
+    lessThanOrEqual: string | number;
+} | {
+    greaterThan: string | number;
+} | {
+    greaterThanOrEqual: string | number;
+});
 ````
 
 ## ScheduleEvery (type)

--- a/preview/uipath-maestro-flow/references/data-fabric.md
+++ b/preview/uipath-maestro-flow/references/data-fabric.md
@@ -12,6 +12,12 @@ entity is reached through the Integration Service connector key
 Read entity records with filters (`core.datafabric.read`) and write fields back
 to one record (`core.datafabric.update`).
 
+Data Fabric **events** (Record Created / Record Updated on an entity) are
+Integration Service connector events on `uipath-uipath-dataservice`, not this
+node family: `onEvent(RecordCreated, { object: '<Entity>', … })`, with the
+entity named through `object`. See
+[`event-trigger.md`](event-trigger.md#generic-events-name-the-object).
+
 Signatures: `dataFabricRead({ entity, filters? })`;
 `dataFabricUpdate({ entity, record, set })`.
 

--- a/preview/uipath-maestro-flow/references/event-trigger.md
+++ b/preview/uipath-maestro-flow/references/event-trigger.md
@@ -59,6 +59,58 @@ If a known tenant event is absent after refreshing the registry/cache, report a
 cache-generation gap instead of inventing a node type, binding, or field. Do
 not patch a prebuilt sample/cache entry to make the missing event appear.
 
+## Generic events: name the object
+
+Most connectors expose their record events generically — `record-created`,
+`record-updated` (Data Fabric, Salesforce, ServiceNow, Jira, Dynamics, …).
+One node type covers every object of the connection, so the subscription must
+say which one with `object`. It is not an event parameter: these operations
+take none, so `where` stays empty and `check` refuses a subscription that
+omits `object` (`EVENT_GENERIC_NO_OBJECT`) or puts the object in `where`.
+
+```ts
+import { RecordCreated, RecordUpdated } from './connectors/uipath-uipath-dataservice.ts';
+
+// Start when a ContractRegistry record is created with dueDate before 2026-08-04.
+.trigger(onEvent(RecordCreated, {
+  object: 'ContractRegistry',
+  filters: [{ field: 'dueDate', lessThan: '2026-08-04' }],
+  connection: 'dataFabric', folder: 'shared',
+}))
+
+// Pause until a FileUploadVerify_20260618 record is updated.
+.step('updated', waitForEvent(RecordUpdated, {
+  object: 'FileUploadVerify_20260618', connection: 'dataFabric', folder: 'shared',
+}))
+```
+
+The objects come from the bound connection, never from a guess:
+
+```bash
+uip is triggers objects uipath-uipath-dataservice CREATED --connection-id <id> --output json
+```
+
+The emitted node carries the object as `inputs.detail.objectName` (and inside
+`configuration`), its event as `eventType`, and the platform-declared
+`eventMode`. A curated event (Outlook `email-received`, OneDrive `file-created`)
+has its object built in — passing `object` there is an error.
+
+## Filter operators
+
+A filter is `{ field, <operator>: value }` with exactly one operator. The
+vocabulary is the designer's, and each form compiles to the same
+`filterExpression` the canvas would write:
+
+| Operator | Value | Emitted expression |
+|---|---|---|
+| `contains`, `startsWith`, `endsWith` | text | `contains(subject,'Invoice')` |
+| `equals`, `notEquals` | text, number or boolean | `status=='open'`, ``priority==`3` `` |
+| `lessThan`, `lessThanOrEqual`, `greaterThan`, `greaterThanOrEqual` | number, or an ISO date string | ``priority>`3` ``, `to_number(dueDate)<to_number('2026-08-04')` |
+
+Ordering a plain string is refused (`EVENT_FILTER_BAD_VALUE`): JMESPath
+compares numbers only, so the subscription would match nothing. Write the
+value as a number or an ISO-8601 date, or use a text operator.
+
 ## Evidence boundary
 
 A local start-trigger run injects a payload; it does not fire a subscription.


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `c30ff64` to current `UiPath/flow-builder-sdk@main` (`965313a`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)