### PR TITLE
fix(maestro-case): complete the activation-mode table, scope the ordered-run heuristic to the design lane

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
@@ -53,7 +53,7 @@ The Case App selector has three distinct modes:
 
 `adhoc` is task-entry-only. It is never a stage entry rule, never a case trigger, never a substitute for `wait-for-connector`, and never the way to model a user-selected interrupting lane. Use a secondary stage with `user-selected-stage` for that.
 
-While authoring a new SDD, any requirement that says `then`, `after`, `before`, `in order`, or otherwise declares an immediate dependency should be authored as `runs-sequentially` on every task in that run. Do not convert it to parallel `current-stage-entered` tasks merely because no data binding links them. Use parallel mode only when the rationale says the tasks are independent. **Phase 1 does not re-author a supplied or approved SDD:** if its task row explicitly says `selected-tasks-completed("<previous task>")`, preserve that exact rule and selector even when the selected task is immediately previous.
+During design-lane authoring (`uipath-planner`), any requirement that says `then`, `after`, `before`, `in order`, or otherwise declares an immediate dependency should be authored as `runs-sequentially` on every task in that run. Do not convert it to parallel `current-stage-entered` tasks merely because no data binding links them. Use parallel mode only when the rationale says the tasks are independent. **Phase 1 does not re-author a supplied or approved SDD:** if its task row explicitly says `selected-tasks-completed("<previous task>")`, preserve that exact rule and selector even when the selected task is immediately previous.
 
 ## Phase 1 Plan Presentation Contract
 
@@ -72,6 +72,7 @@ For every task-entry-condition T-entry, verify the task's `activation-mode` and 
 |---|---|
 | `sequential` | `runs-sequentially` |
 | `parallel` | `current-stage-entered` |
+| `parallel-after-predecessor` | `runs-sequentially`, with the siblings sharing the next task set after one predecessor |
 | `event-triggered` | `wait-for-connector` or another explicitly authored event/condition rule |
 | `adhoc` | `adhoc` |
 | `fan-in` | `selected-tasks-completed` with multiple selected tasks or an explicit convergence rationale |


### PR DESCRIPTION
Two defects in `references/plugins/conditions/task-entry-conditions/planning.md`, both wording. One file, two lines.

## 1. The activation-mode table was missing a mode

[The table](https://github.com/UiPath/skills/blob/main/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md#L71-L78) listed six modes. The auditor accepts seven.

| source | modes |
|---|---|
| [`audit_plan.py` `ACTIVATION_MODES`](https://github.com/UiPath/skills/blob/main/skills/uipath-maestro-case/scripts/audit_plan.py#L39-L42) | 7 |
| [`planning.md` §4.6 field list](https://github.com/UiPath/skills/blob/main/skills/uipath-maestro-case/references/planning.md#L320) | 7 |
| the table in this file | **6** |

`parallel-after-predecessor` had no row, so the table read as a closed list that excludes it. Three other places disagree:

- [`ENTRY_RULE_MODES`](https://github.com/UiPath/skills/blob/main/skills/uipath-maestro-case/scripts/audit_plan.py#L46-L52) pairs it with `runs-sequentially`
- [`uipath-planner` names it for the same case](https://github.com/UiPath/skills/blob/main/skills/uipath-planner/references/case-design-layers-guide.md#L170) — *Independent siblings after one predecessor*
- [an eval task grades it](https://github.com/UiPath/skills/tree/main/tests/tasks/uipath-maestro-case/multi_stages_tasks/parallel_after_predecessor)

**An incomplete enumeration invites a truncated guess.** One archived run of `skill-case-athena-cm-event` wrote `activation-mode: conditional` on two tasks. That is `conditional-gate` cut short, and it is not one of the seven. The new row uses the planner's own wording so the two skills read the same.

After this change all three vocabularies list the same seven values.

## 2. The ordered-run heuristic still opened with a precondition this skill cannot meet

The paragraph began `While authoring a new SDD, any requirement that says then, after, before, in order ... should be authored as runs-sequentially on every task in that run.`

[#2431](https://github.com/UiPath/skills/pull/2431) made `uipath-planner` the sole case-SDD author, so the build lane always receives a supplied or approved SDD and never authors one. Read as a live instruction, the sentence says to write `runs-sequentially` on every task of an ordered run — which is the rewrite its own next sentence forbids (*Phase 1 does not re-author a supplied or approved SDD*), along with [`SKILL.md` Rule 6](https://github.com/UiPath/skills/blob/main/skills/uipath-maestro-case/SKILL.md#L38), [`planning.md` § Authority order](https://github.com/UiPath/skills/blob/main/skills/uipath-maestro-case/references/planning.md#L333), [`planning.md:341`](https://github.com/UiPath/skills/blob/main/skills/uipath-maestro-case/references/planning.md#L341), and [the eval prompt itself](https://github.com/UiPath/skills/blob/main/tests/tasks/uipath-maestro-case/athena_cm_event/athena_cm_event.yaml#L29-L30).

[The sibling passage further down the same file](https://github.com/UiPath/skills/blob/main/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md#L80) was rescoped to the design lane at the time. This one was missed. It now reads `During design-lane authoring (uipath-planner)`, matching it.

Both defects show up in the same failure: across the archived `tasks/tasks.md` artifacts of `skill-case-athena-cm-event`, the authored entry rule was rewritten into `runs-sequentially` in 14 of them, and the selector was dropped from a preserved `selected-tasks-completed` in 4 more. The reference that is supposed to prevent that opened by describing it.

## Relation to the open case PRs

- [#2943](https://github.com/UiPath/skills/pull/2943) rewrites this file's `tasks.md` vocabulary but touches neither edit site; both are byte-identical on `main` and on `feat/case-remove-tasks-md`, so this rebases either way.
- [#2816](https://github.com/UiPath/skills/pull/2816) ports the auditors to Node without changing a check, so the seven-value list it carries is the same one this table now matches.
- Neither PR changes the pairing table or the heuristic's scope.

## Verification

- `npm run skills:validate` — OK, default 27 skills / 1756 files, studioweb 27 / 1756 / 174 replacements
- `hooks/validate-skill-descriptions.sh` — 477 chars
- The seven values in the table, in `ACTIVATION_MODES`, and in the §4.6 field list compared programmatically: identical sets
- No flavor override on the file and no flavor marker in it
