### PR TITLE
fix(flow-check): carry the backend's incident details when a debug run faults

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -108,6 +108,8 @@ _POLL_TIMEOUT_ATTEMPTS = 2
 # 5xx, matching the CLI's own "retry once before reporting") that keeps a third
 # full-length attempt out of every criterion ceiling. `retries=3` still works.
 _DEFAULT_RETRIES_TIMEOUT = 240
+# One backend read of a faulted instance's incidents; never worth more of the criterion budget.
+_INCIDENTS_TIMEOUT_SECONDS = 60
 _DEFAULT_RETRIES = 2
 _DEFAULT_BACKOFF_SECONDS = 5.0
 
@@ -390,6 +392,7 @@ def run_debug(
         _fail(
             f"flow debug exit {r.returncode}{spent}\n"
             f"stdout: {r.stdout}\nstderr: {r.stderr}"
+            + _incident_details(_parse_json(r.stdout))
         )
     data = _parse_json(r.stdout)
     if data is None:
@@ -397,7 +400,7 @@ def run_debug(
     payload = _get_ci(data, "Data") or {}
     status = _get_ci(payload, "finalStatus", "FinalStatus")
     if status != "Completed":
-        _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout}")
+        _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout}" + _incident_details(data))
     if unreadable is not None:
         # Every attempt completed, and every attempt's outputs were unreadable.
         # This is an infrastructure failure (INFRA), not a verdict on the flow:
@@ -1699,6 +1702,43 @@ def assert_no_flow_files() -> None:
 
 
 # ── Internals ───────────────────────────────────────────────────────────────
+
+
+def _incident_details(envelope: dict | None) -> str:
+    """The backend's own account of a faulted debug run, for the failure text.
+
+    `flow debug` reports a fault as one line per incident (`[102003] Integration
+    Services bad request (element createIssue)`) and defers the provider's
+    message to `uip maestro flow debug-instance incidents <id>`. That message is
+    the cause — 2026-09-01: `errors - {reporter=Specify a valid value for
+    Reporter}` behind six identical `[102003]` failures across three arms and two
+    weeks, none of whose task.json said so. Fetch it while the instance is still
+    on the tenant (it is gone within days) so the criterion output carries it.
+
+    Best-effort and side-effect-free: returns "" when there is no instance id,
+    the CLI is unavailable, or the tenant answers with anything but a list.
+    """
+    data = _get_ci(envelope, "Data") or {}
+    instance_id = _get_ci(data, "instanceId", "InstanceId")
+    if not instance_id:
+        return ""
+    try:
+        r = subprocess.run(
+            ["uip", "maestro", "flow", "debug-instance", "incidents", str(instance_id), "--output", "json"],
+            capture_output=True, text=True, timeout=_INCIDENTS_TIMEOUT_SECONDS,
+        )
+        parsed = _parse_json(r.stdout) or {}
+        incidents = _get_ci(parsed, "Data")
+        if not isinstance(incidents, list) or not incidents:
+            return ""
+        lines = [
+            f"  - element={_get_ci(i, 'elementId', 'ElementId')} code={_get_ci(i, 'errorCode', 'ErrorCode')} "
+            f"{_get_ci(i, 'errorMessage', 'ErrorMessage')}: {_get_ci(i, 'errorDetails', 'ErrorDetails')}"
+            for i in incidents if isinstance(i, dict)
+        ]
+        return "\nincidents (uip maestro flow debug-instance incidents):\n" + "\n".join(lines)
+    except Exception:  # noqa: BLE001 — diagnostics must never mask the real failure
+        return ""
 
 
 def _parse_json(stdout: str) -> dict | None:

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -883,6 +883,67 @@ def test_is_transient_debug_error(cp, expected):
     assert flow_check._is_transient_debug_error(cp) is expected
 
 
+# ── run_debug: a faulted run carries the backend's incident details ──────────
+
+_FAULTED_102003 = (
+    '{\n  "Result": "Failure",\n  "Code": "FlowDebug",\n'
+    '  "Message": "Debug session Faulted. [102003] Integration Services bad request (element createIssue)",\n'
+    '  "Context": {"ErrorCode": "102003"},\n'
+    '  "Data": {"instanceId": "d007648d-8341-460c-92f8-c0fe4b8bde59", "finalStatus": "Faulted"}\n}'
+)
+_INCIDENTS = (
+    '{\n  "Result": "Success",\n  "Code": "DebugInstanceIncidents",\n  "Data": [{\n'
+    '    "ElementId": "createIssue", "ErrorCode": "102003",\n'
+    '    "ErrorMessage": "Integration Services bad request",\n'
+    '    "ErrorDetails": "Request to Integration Services failed with status code \'400\', message:  '
+    '{\\"providerMessage\\":\\"errors - {reporter=Specify a valid value for Reporter}\\"}"\n  }]\n}'
+)
+
+
+def test_run_debug_fault_appends_incident_details(monkeypatch):
+    """2026-09-01 escalation-jira-ticket: the CLI said `[102003]` and deferred the
+    provider's message to `debug-instance incidents`; the criterion output never
+    carried it. Now the failure text does, fetched while the instance still exists."""
+    calls = _stub_debug(monkeypatch, [_cp(1, _FAULTED_102003), _cp(0, _INCIDENTS)])
+    with pytest.raises(SystemExit) as exc:
+        run_debug()
+    text = str(exc.value)
+    assert "flow debug exit 1" in text
+    assert "incidents (uip maestro flow debug-instance incidents):" in text
+    assert "element=createIssue code=102003" in text
+    assert "reporter=Specify a valid value for Reporter" in text
+    assert calls["n"] == 2
+    assert calls["cmd"][:5] == ["uip", "maestro", "flow", "debug-instance", "incidents"]
+    assert calls["cmd"][5] == "d007648d-8341-460c-92f8-c0fe4b8bde59"
+
+
+def test_run_debug_fault_without_instance_id_is_unchanged(monkeypatch):
+    bad = '{\n  "Result": "Failure",\n  "ErrorCode": "invalid_argument",\n  "Retry": "RetryWillNotFix"\n}'
+    calls = _stub_debug(monkeypatch, [_cp(1, bad)])
+    with pytest.raises(SystemExit) as exc:
+        run_debug()
+    assert "incidents" not in str(exc.value)
+    assert calls["n"] == 1  # no incidents call without an instance to ask about
+
+
+def test_run_debug_fault_incidents_read_failure_never_masks_the_fault(monkeypatch):
+    calls = _stub_debug(monkeypatch, [_cp(1, _FAULTED_102003), _cp(1, "", "Not logged in")])
+    with pytest.raises(SystemExit) as exc:
+        run_debug()
+    assert "flow debug exit 1" in str(exc.value)
+    assert "incidents (" not in str(exc.value)
+    assert calls["n"] == 2
+
+
+def test_run_debug_exit0_faulted_appends_incident_details(monkeypatch):
+    faulted = '{\n  "Result": "Success",\n  "Data": {"finalStatus": "Faulted", "instanceId": "abc"}\n}'
+    _stub_debug(monkeypatch, [_cp(0, faulted), _cp(0, _INCIDENTS)])
+    with pytest.raises(SystemExit) as exc:
+        run_debug()
+    assert "Flow did not complete (finalStatus=Faulted)" in str(exc.value)
+    assert "reporter=Specify a valid value for Reporter" in str(exc.value)
+
+
 # ── run_debug: completed but outputs unreadable (variables fetch failed) ─────
 
 # Verbatim shape of the 2026-09-01 move-node/v2 payload: every element


### PR DESCRIPTION
## What

When `uip maestro flow debug` faults, the CLI prints one line per incident (`[102003] Integration Services bad request (element createIssue)`) and defers the provider's own message to `uip maestro flow debug-instance incidents <id>`. The checker never fetched it, so the criterion output on the board carried an opaque IS code.

`run_debug` now fetches the incidents of a faulted instance — exit ≠ 0 with a `Data.instanceId`, or exit 0 with `finalStatus ≠ Completed` — and appends one `element= code= message: ErrorDetails` line per incident to the failure text. Best-effort (60 s cap, any error → nothing appended), grading unchanged.

## Why now

`skill-flow-e2e-escalation-jira-ticket` failed six times between 08-19 and 09-01 with the identical `[102003]` at the Jira Create Issue node: 3× nightly baseline (terra, v1 skill), 3× adhoc v2 (luna). Every task.json said only "Integration Services bad request". The 09-01 v2 instance still answered on 09-02:

```
Request to Integration Services failed with status code '400' … providerMessage: "errors - {reporter=Specify a valid value for Reporter}"
```

The flow had bound `fields.reporter.id` (a lookup that sends an Atlassian `accountId`) to the sender's e-mail. With this change that sentence would have been in the criterion output on 08-19. Older instances are already gone from the tenant (404), which is why the fetch has to happen inside the criterion.

## Tests

- `_shared/test_flow_check.py`: +4 (fault → incidents appended and the CLI command shape; no instanceId → unchanged and no extra call; incidents read failure → never masks the fault; exit-0 Faulted → appended).
- `uv run … pytest tests/tasks/uipath-maestro-flow/ -q` → 1069 passed; `scripts/check-task-driver.py tests/tasks` OK.

## Measurement contract (plan §2.5 / D-1)

Diagnostics only. No criterion, weight, threshold, prompt, or artifact discovery changes. Noted on #2756.

The enabling-layer fix (the SDK's `check` now refuses an e-mail bound into a lookup-id field, `LOOKUP_RUNTIME_VALUE`) is in flow-builder-sdk; RCA: `workspaces/reports/2026-09-02-maestro-flow-escalation-jira-ticket/rca-escalation-jira-ticket.md`.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)

https://claude.ai/code/session_01TkcZFmSDDFpBghDWatA9gv
