### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@1639d92

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 965313a. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 1639d92. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 965313a. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 1639d92. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 965313a. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 1639d92. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -396,8 +396,14 @@ it reports the candidates rather than guessing, because connections for one
 connector are not interchangeable.
 
 `check` names the exact command when a lookup is unresolved, and warns when a
-lookup field is given a literal id. Run it before compiling: it finds everything
-else that is wrong first, so the one expensive call is spent last.
+lookup field is given a literal id. It also speaks up when a lookup field is
+bound to a runtime expression (`LOOKUP_RUNTIME_VALUE`): a warning that states
+the id the field sends (`reporter.accountId`, not a name), and an error when
+the expression reads an e-mail field — an address is never that id, and the
+provider refuses it only once the flow runs. A required lookup field you have no
+value for is resolved with its helper, not filled from a look-alike input. Run
+`check` before compiling: it finds everything else that is wrong first, so the
+one expensive call is spent last.
 
 Each operation's markdown page lists its lookup fields, the helper for each, and
 what it can be searched by. The generated descriptor carries the same facts as a


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `965313a` to current `UiPath/flow-builder-sdk@main` (`1639d92`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)