### PR TITLE
fix(jira-teardown): confirm the irreversible delete — every Jira e2e teardown since 08-19 leaked its ticket

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
@@ -125,6 +125,10 @@ def delete_issue(conn_id: str, key: str) -> bool:
     env = _run(
         "is", "resources", "run", "delete", CONNECTOR, "issue",
         "--connection-id", conn_id, "--query", f"issueId={key}",
+        # The CLI never prompts and REFUSES an irreversible delete without this
+        # flag ("Confirmation required … Re-run with --yes"). Without it every
+        # teardown since 08-19 printed WARN and left its ticket in the CE project.
+        "--yes",
     )
     if str(env.get("Result", "")).lower() != "failure":
         return True

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/test_jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/test_jira_is.py
@@ -1,0 +1,71 @@
+"""Teardown contract for the escalation task's Jira helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+HERE = Path(__file__).parent
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("escalation_jira_is", HERE / "jira_is.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class Result:
+    def __init__(self, envelope: object, returncode: int = 0) -> None:
+        self.stdout = json.dumps(envelope)
+        self.stderr = ""
+        self.returncode = returncode
+
+
+def _stub(monkeypatch: pytest.MonkeyPatch, jira_is: ModuleType, envelope: object) -> list[list[str]]:
+    seen: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        seen.append(list(cmd))
+        return Result(envelope)
+
+    monkeypatch.setattr(jira_is.subprocess, "run", fake_run)
+    return seen
+
+
+def test_delete_issue_confirms_and_reports_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI refuses an unconfirmed delete with a Failure envelope
+    ("Confirmation required … Re-run with --yes"), which `delete_issue`
+    correctly reports as NOT confirmed — so every run 08-19 → 09-01 printed
+    `WARN: could NOT confirm deletion` and left its ticket in CE. `--yes` is
+    the missing word."""
+    jira_is = _load_module()
+    seen = _stub(monkeypatch, jira_is, {"Result": "Success", "Data": {"Value": ""}})
+    assert jira_is.delete_issue("conn", "CE-1257") is True
+    (cmd,) = seen
+    assert cmd[:5] == ["uip", "is", "resources", "run", "delete"]
+    assert "--yes" in cmd and "issueId=CE-1257" in cmd
+
+
+def test_delete_issue_unconfirmed_failure_is_not_a_deletion(monkeypatch: pytest.MonkeyPatch) -> None:
+    jira_is = _load_module()
+    _stub(monkeypatch, jira_is, {
+        "Result": "Failure",
+        "Message": "Confirmation required: this will delete resource 'issue' and cannot be undone.",
+        "Instructions": "Re-run with --yes to confirm.",
+    })
+    assert jira_is.delete_issue("conn", "CE-1257") is False
+
+
+def test_delete_issue_structured_404_counts_as_gone(monkeypatch: pytest.MonkeyPatch) -> None:
+    jira_is = _load_module()
+    _stub(monkeypatch, jira_is, {
+        "Result": "Failure",
+        "Message": "Request failed with status code '404': Issue does not exist or you do not have permission to see it.",
+    })
+    assert jira_is.delete_issue("conn", "CE-1257") is True

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/jira_is.py
@@ -106,4 +106,8 @@ def delete_issue(conn_id: str, key: str) -> None:
     _run(
         "is", "resources", "run", "delete", CONNECTOR, "issue",
         "--connection-id", conn_id, "--query", f"issueId={key}",
+        # The CLI never prompts and REFUSES an irreversible delete without this
+        # flag ("Confirmation required … Re-run with --yes"). Without it every
+        # teardown since 08-19 printed WARN and left its ticket in the CE project.
+        "--yes",
     )

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/test_jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/test_jira_is.py
@@ -68,3 +68,22 @@ def test_invalid_json_does_not_echo_cli_output(monkeypatch: pytest.MonkeyPatch) 
     assert "invalid JSON" in message
     assert "exit 1" in message
     assert "must-not-appear" not in message
+
+
+def test_delete_issue_confirms_the_irreversible_delete(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`uip is resources run delete` never prompts and refuses without `--yes`
+    ("Confirmation required: this will delete resource 'issue' …"). Every
+    teardown in the 08-19 → 09-01 run archive omitted it and leaked its ticket."""
+    jira_is = _load_module()
+    seen: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        seen.append(list(cmd))
+        return Result({"Result": "Success", "Data": {"Value": ""}})
+
+    monkeypatch.setattr(jira_is.subprocess, "run", fake_run)
+    jira_is.delete_issue("conn", "CE-1")
+    (cmd,) = seen
+    assert cmd[:5] == ["uip", "is", "resources", "run", "delete"]
+    assert "--yes" in cmd
+    assert "issueId=CE-1" in cmd

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_get_issue/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_get_issue/jira_is.py
@@ -59,4 +59,8 @@ def delete_issue(conn_id: str, key: str) -> None:
     _run(
         "is", "resources", "run", "delete", CONNECTOR, "issue",
         "--connection-id", conn_id, "--query", f"issueId={key}",
+        # The CLI never prompts and REFUSES an irreversible delete without this
+        # flag ("Confirmation required … Re-run with --yes"). Without it every
+        # teardown since 08-19 printed WARN and left its ticket in the CE project.
+        "--yes",
     )

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_lifecycle/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_lifecycle/jira_is.py
@@ -60,4 +60,8 @@ def delete_issue(conn_id: str, key: str) -> None:
     _run(
         "is", "resources", "run", "delete", CONNECTOR, "issue",
         "--connection-id", conn_id, "--query", f"issueId={key}",
+        # The CLI never prompts and REFUSES an irreversible delete without this
+        # flag ("Confirmation required … Re-run with --yes"). Without it every
+        # teardown since 08-19 printed WARN and left its ticket in the CE project.
+        "--yes",
     )

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_search_triage/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_search_triage/jira_is.py
@@ -58,4 +58,8 @@ def delete_issue(conn_id: str, key: str) -> None:
     _run(
         "is", "resources", "run", "delete", CONNECTOR, "issue",
         "--connection-id", conn_id, "--query", f"issueId={key}",
+        # The CLI never prompts and REFUSES an irreversible delete without this
+        # flag ("Confirmation required … Re-run with --yes"). Without it every
+        # teardown since 08-19 printed WARN and left its ticket in the CE project.
+        "--yes",
     )


### PR DESCRIPTION
## What

`uip is resources run delete` never prompts and **refuses** without `--yes`:

```
"Message": "Confirmation required: this will delete resource 'issue' and cannot be undone.",
"Instructions": "Re-run with --yes to confirm."
```

The five task-local `jira_is.py` helpers (`escalation_jira_ticket`, `jira_create_issue`, `jira_get_issue`, `jira_lifecycle`, `jira_search_triage`) called it without the flag. The escalation helper correctly treated the Failure envelope as "not confirmed" and printed `WARN: could NOT confirm deletion of CE-…` on **every** run in the archive that created a ticket (08-19 → 09-01, 20 runs); the other four return `None` and never said anything. Result: CE-1150 → CE-1256 all exist and are all eval-created (search-triage, lifecycle, jira flow e2e, ESC-JIRA), none deleted.

This PR adds `--yes` to the five delete calls. Nothing else changes.

## Verified

Host, 09-02, the same call with `--yes` on this session's two rerun tickets: `Result: Success`, and an independent `curated_get_issue` re-read answers `404 Not Found` (CE-1257, CE-1258).

## Tests

- `jira_create_issue/test_jira_is.py` +1: the delete command carries `--yes`.
- `escalation_jira_ticket/test_jira_is.py` (new): confirmed delete → `True`; "Confirmation required" Failure → `False`; structured 404 → `True`.
- `uv run … pytest tests/tasks/uipath-maestro-flow/ -q` → 1073 passed; `check-task-driver.py` OK.

## Measurement contract (plan §2.5 / D-1)

Teardown only (post_run). No criterion, weight, threshold, prompt, or artifact discovery changes. Note to follow on #2756.

## Left for Tao

The historical tickets are not deleted here (other sessions' runs; a bulk delete of a shared project is your call). This task's: CE-1169, CE-1172, CE-1173, CE-1183, CE-1186, CE-1222, CE-1225, CE-1247, CE-1248. One-liner per key: `uip is resources run delete uipath-atlassian-jira issue --connection-id f5273a4d-d492-4bcd-a106-5a20bf89a3ef --query issueId=<KEY> --yes`.

Found while closing the escalation-jira-ticket RCA (`workspaces/reports/2026-09-02-maestro-flow-escalation-jira-ticket/rca-escalation-jira-ticket.md` §6).

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)

https://claude.ai/code/session_01TkcZFmSDDFpBghDWatA9gv
