### PR TITLE
fix(eval-checker): discover the orchestrator-paths flow for validate instead of hardcoding the v1 solution path

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
@@ -94,9 +94,14 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
+  # ── The delivered flow validates ────────────────────────────────────────
+  # Discovered, not hardcoded: the SDK loop scaffolds `<Name>Sol/<Name>/<Name>.flow`
+  # (its SKILL.md says `uip solution init <Name>Sol`), so a fixed
+  # `<Name>/<Name>/<Name>.flow` path failed "File not found" on flows that were
+  # otherwise green (adhoc 2026-08-31 22:43 v2: seeded paths passed, validate 0.0).
   - type: run_command
-    description: "Generated CustomerEscalationOrchestrator Flow validates without errors"
-    command: "uip maestro flow validate CustomerEscalationOrchestrator/CustomerEscalationOrchestrator/CustomerEscalationOrchestrator.flow --output json"
+    description: "Generated CustomerEscalationOrchestrator Flow validates without errors, independent of solution layout"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 180
     expected_exit_code: 0
     weight: 3.0


### PR DESCRIPTION
## What

`e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml`: the "Generated CustomerEscalationOrchestrator Flow validates without errors" criterion now runs `_shared/validate_flow.py` (project-discovered `.flow` files) instead of `uip maestro flow validate CustomerEscalationOrchestrator/CustomerEscalationOrchestrator/CustomerEscalationOrchestrator.flow`. Weight 3.0 / threshold 1.0 / timeout 180 unchanged. Prompt untouched.

## Why

The SDK loop's SKILL.md scaffolds `uip solution init <Name>Sol`, so a doc-following v2 agent emits `<Name>Sol/<Name>/<Name>.flow`; the hardcoded path then fails "File not found" on a flow that is otherwise green.

Archive (all arms, `skill-flow-e2e-escalation-orchestrator-paths`):
- adhoc 2026-08-31 22:43 v2 — score 0.68: every seeded path case passed, validate 0.0 on `CustomerEscalationOrchestratorSol/…`.
- adhoc 2026-08-29 04:25 v2 — validate 0.0 on `CustomerEscalationOrchestratorSolution/…` (plus a separate connection defect).

Every sibling e2e task (`escalation_slack_alert`, `escalation_jira_ticket`, `jira_*`) already uses `validate_flow.py`; this task was the one left behind. `validate_flow.py`'s own docstring names this exact failure mode.

## Evidence

- `uv run … pytest tests/tasks/uipath-maestro-flow/_shared/{test_same_ground_corpus,test_criterion_budgets,test_validate_flow}.py` → 716 passed.
- `python3 scripts/check-task-driver.py tests/tasks` → OK.
- Part of the escalation-orchestrator-paths RCA (v2 0.47 on adhoc 2026-09-01; the debug-graded root cause is a flow-sdk connection-binding gap, fixed separately in flow-builder-sdk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cn8thdbhgRMqTehFhnAWW



## Passing run

Ran `skill-flow-e2e-escalation-orchestrator-paths` locally with this criterion (mounted campaign worktree at `00c290f49`, image `uip 1.202.0-dev.local.gd09c8883b1dc` + flow-sdk 3.30.6) on 2026-09-02 08:12–08:29 UTC: **v1 SUCCESS 1.000, v2 SUCCESS 1.000**, validate criterion 1.0 in both arms. (The same task an hour earlier failed case 2 in both arms on a Studio Web Overwrite 400/1001 regression — UiPath/cli#3938, interim in #2990 — unrelated to this criterion.)
