### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@049d5bd

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ e51c885. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 049d5bd. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ e51c885. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 049d5bd. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ e51c885. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 049d5bd. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in

--- a/preview/uipath-maestro-flow/references/bindings.md
+++ b/preview/uipath-maestro-flow/references/bindings.md
@@ -73,8 +73,18 @@ uip is connections list --all-folders --output json
 
 `Id` is the connection binding's `resourceKey`; **`FolderKey` is the folder
 binding's**. Never fill either with a made-up GUID or with the binding's own
-name: `compile` refuses a binding whose `resourceKey` is its own name, and a
-plausible GUID compiles and then faults at run time.
+name: `compile` refuses a binding whose `resourceKey` is its own name, warns
+`CONNECTION_STUB` on an all-zero GUID, an `<angle-bracket>` placeholder, any
+non-GUID value or a symbol no entry declares (the run would fault at dispatch —
+`'Connection' has an invalid GUID value` or a `401 Invalid Organization or User
+secret`), and a plausible-looking but wrong GUID still compiles and faults at run
+time. Only an id read from the tenant is right.
+
+Several connections often share one name (a team tenant can hold three Slack
+connections all named `is-sandboxes`, in different folders). A name then cannot
+pick one: `prepare … --connection <name>` lists each candidate with its
+`--connection-id <id>` and folder — pass the id of the one in the folder you mean,
+and `prepare` still writes both entries into `bindings.json`.
 
 **Do not go looking in Orchestrator for the folder.** `uip or folders list` is a
 different resource with different keys, and a folder binding wants the one the

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -393,7 +393,12 @@ both the connection id AND its folder key into `bindings.json`. So one command
 covers the lookup, the connection binding and the folder binding. Pass
 `--connection <name>` only when several connections match the same connector;
 it reports the candidates rather than guessing, because connections for one
-connector are not interchangeable.
+connector are not interchangeable. When the candidates share a name, pick one
+by the `--connection-id <id>` each candidate line prints; `bindings.json` is
+written on that route too. The entries are named `<connector's last segment>`
+(`slack`) and `shared` unless you pass `--bind-connection` / `--bind-folder`;
+`connection:` and `folder:` in source must use those names, and `compile` warns
+`CONNECTION_STUB` when they do not resolve to a tenant id.
 
 `check` names the exact command when a lookup is unresolved, and warns when a
 lookup field is given a literal id. It also speaks up when a lookup field is


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `e51c885` to current `UiPath/flow-builder-sdk@main` (`049d5bd`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)