### PR TITLE
fix(flow-check): INTERIM — retry a debug once as a new import when Studio Web's Overwrite answers 400/1001 (UiPath/cli#3938)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -148,6 +148,77 @@ def _output_blob(result: subprocess.CompletedProcess) -> str:
     return f"{result.stdout}\n{result.stderr}".lower()
 
 
+# INTERIM — Studio Web `Solution/{id}/Overwrite` regression (UiPath/cli#3938).
+#
+# Since 2026-09-02 (last known good: 2026-09-01 07:30Z) Studio Web answers
+# `400 {"code":"1001","message":"An argument had an invalid value."}` when a
+# solution that EXISTS is overwritten. `uip maestro flow debug` imports the
+# project on its first run and writes the server's solution id back into the
+# `.uipx`, so every LATER debug of the same project is an overwrite — and the
+# CLI treats any non-404 Overwrite as fatal. Result: the second seeded case of
+# every multi-case checker died at solution upload, in all three arms
+# (orchestrator_paths, escalation_slack_alert, billing_invoice_lookup,
+# decision, wiki_pageviews, canary). Reproduced on the host with two CLI
+# vintages and with `uip solution upload --force`; a fresh bundled SolutionId
+# imports as new and Completes (Slack message posted), so ONLY overwrite is
+# broken. The only earlier archived Overwrite 400 (2026-08-26) was code 20001, a
+# content error that must still fail.
+#
+# So: on exactly that signature, rotate the bundled SolutionId to a fresh uuid4
+# and retry ONCE — the retry is a new import. Self-limiting: once Overwrite
+# recovers the signature never fires and nothing here runs. Cost while it does:
+# one extra tenant solution per affected case, which `cleanup_solutions.py`
+# cannot see (it reads the `.uipx`'s CURRENT id) — the ids are printed so they
+# are not lost. The platform fix and a CLI-side fallback are asked for in the
+# issue above; delete this block when Overwrite works again.
+_OVERWRITE_STUCK_ISSUE = "UiPath/cli#3938"
+_OVERWRITE_STUCK_MARKER = "overwrite failed (400)"
+_OVERWRITE_STUCK_CODE = re.compile(r'\\?"code\\?":\s*\\?"1001\\?"')
+_OVERWRITE_STUCK_ATTEMPTS = 2  # the failed overwrite + one import-as-new retry
+_SOLUTION_ID_RE = re.compile(r'("SolutionId"\s*:\s*")([0-9a-fA-F-]{36})(")')
+
+
+def _is_overwrite_stuck(result: subprocess.CompletedProcess) -> bool:
+    """True iff ``flow debug`` died on the Studio Web Overwrite 400/1001 regression
+    (see :data:`_OVERWRITE_STUCK_ISSUE`) — never on any other overwrite failure."""
+    if result.returncode == 0:
+        return False
+    blob = _output_blob(result)
+    return _OVERWRITE_STUCK_MARKER in blob and _OVERWRITE_STUCK_CODE.search(blob) is not None
+
+
+def _rotate_solution_id(project_dir: str) -> tuple[str, str] | None:
+    """Give the project's solution a fresh bundled ``SolutionId`` so the next
+    ``flow debug`` imports it as a NEW Studio Web solution instead of overwriting.
+
+    Walks up from ``project_dir`` to the nearest ancestor holding exactly one
+    ``*.uipx`` (a JSON text file; ``uip solution init`` writes it beside the
+    project directory). Returns ``(old, new)``, or ``None`` when no unambiguous
+    ``.uipx`` is found — the caller then fails the plain way."""
+    import uuid
+
+    here = os.path.abspath(project_dir)
+    for _ in range(4):
+        uipx = sorted(glob.glob(os.path.join(glob.escape(here), "*.uipx")))
+        if len(uipx) == 1:
+            try:
+                text = open(uipx[0], encoding="utf-8").read()
+            except OSError:
+                return None
+            match = _SOLUTION_ID_RE.search(text)
+            if match is None:
+                return None
+            new = str(uuid.uuid4())
+            with open(uipx[0], "w", encoding="utf-8") as handle:
+                handle.write(text[: match.start(2)] + new + text[match.end(2):])
+            return match.group(2), new
+        parent = os.path.dirname(here)
+        if parent == here:
+            break
+        here = parent
+    return None
+
+
 def _is_transient_debug_error(result: subprocess.CompletedProcess) -> bool:
     """True iff a failed ``flow debug`` invocation looks like a transient
     server-side error (5xx / RetryLater / poll-budget expiry) worth retrying,
@@ -326,6 +397,8 @@ def run_debug(
 
     unreadable: str | None = None
     unreadable_attempts = 0
+    overwrite_rotations = 0
+    rotated_solution_ids: list[str] = []
     # `max_attempts` starts at the transient allowance and is extended by one
     # for an unreadable-outputs retry (see _VARIABLES_UNREADABLE_ATTEMPTS): that
     # retry has its own allowance, never the 5xx/RetryLater one. The deadline
@@ -370,6 +443,23 @@ def run_debug(
             if unreadable_attempts >= _VARIABLES_UNREADABLE_ATTEMPTS:
                 break
             max_attempts = max(max_attempts, attempt + 2)
+        elif _is_overwrite_stuck(r) and overwrite_rotations < _OVERWRITE_STUCK_ATTEMPTS - 1:
+            # INTERIM (see _OVERWRITE_STUCK_ISSUE): its own single allowance, like
+            # the unreadable-outputs retry; the deadline below still bounds it.
+            rotated = _rotate_solution_id(project_dir)
+            if rotated is None:
+                break
+            overwrite_rotations += 1
+            rotated_solution_ids.append(rotated[0])
+            print(
+                f"INTERIM ({_OVERWRITE_STUCK_ISSUE}: Studio Web Overwrite → 400/1001 for an "
+                f"existing solution since 2026-09-02): rotated the bundled SolutionId "
+                f"{rotated[0]} → {rotated[1]}; retrying as a new import. The solution "
+                f"{rotated[0]} stays on the tenant (cleanup reads only the current id).",
+                file=sys.stderr,
+                flush=True,
+            )
+            max_attempts = max(max_attempts, attempt + 2)
         elif not _is_transient_debug_error(r):
             break
         elif _is_poll_timeout(r) and attempt + 1 >= _POLL_TIMEOUT_ATTEMPTS:
@@ -398,6 +488,14 @@ def run_debug(
     if data is None:
         _fail(f"Could not parse JSON from flow debug\n{r.stdout}")
     payload = _get_ci(data, "Data") or {}
+    if rotated_solution_ids:
+        print(
+            f"INTERIM ({_OVERWRITE_STUCK_ISSUE}): debug ran as a new import; Studio Web "
+            f"solution {_get_ci(payload, 'solutionId', 'SolutionId')} (previous: "
+            f"{', '.join(rotated_solution_ids)}).",
+            file=sys.stderr,
+            flush=True,
+        )
     status = _get_ci(payload, "finalStatus", "FinalStatus")
     if status != "Completed":
         _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout}" + _incident_details(data))

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -788,6 +788,23 @@ _POLL_TIMEOUT = (
 )
 
 
+# Verbatim from `uip maestro flow debug` on 2026-09-02 07:48Z: Studio Web's
+# Overwrite answering 400/1001 for an EXISTING solution (UiPath/cli#3938).
+_OVERWRITE_400_1001 = (
+    '{\n  "Result": "Failure",\n'
+    '  "Message": "Overwrite failed (400): {\\"code\\":\\"1001\\",\\"message\\":'
+    '\\"An argument had an invalid value.\\",\\"translatedMessage\\":null}",\n'
+    '  "Instructions": "Check that the flow project is valid, the selected folder '
+    'is accessible, and Studio Web debug is available, then retry.",\n'
+    '  "ErrorCode": "unknown_error",\n  "Retry": "RetryWillNotFix"\n}'
+)
+# The 2026-08-26 shape: a real content error that must NOT be rotated around.
+_OVERWRITE_400_20001 = _OVERWRITE_400_1001.replace('1001', '20001').replace(
+    'An argument had an invalid value.',
+    'Archive is missing project directories referenced by solution metadata: [X/temp/project.uiproj].',
+)
+
+
 def _cp(returncode, stdout="", stderr=""):
     return subprocess.CompletedProcess(
         args=["uip", "maestro", "flow", "debug"], returncode=returncode, stdout=stdout, stderr=stderr
@@ -1027,6 +1044,80 @@ def test_run_debug_does_not_retry_present_but_empty_variables(monkeypatch):
     payload = run_debug()
     assert calls["n"] == 1
     assert flow_check.collect_outputs(payload) == []
+
+
+def _uipx_project(tmp_path, solution_id="79cda3cb-5a10-4f37-e091-08df08c2afbe"):
+    """`uip solution init` layout: `<Sol>/<Sol>.uipx` beside `<Sol>/<Proj>/`."""
+    sol = tmp_path / "Sol"
+    proj = sol / "Proj"
+    proj.mkdir(parents=True)
+    (sol / "Sol.uipx").write_text(
+        '{\n  "SolutionId": "%s",\n  "Name": "Sol",\n  "Projects": []\n}\n' % solution_id
+    )
+    return sol, proj
+
+
+def test_run_debug_rotates_the_solution_id_on_overwrite_1001_then_imports(monkeypatch, tmp_path, capsys):
+    """INTERIM (UiPath/cli#3938): the Studio Web Overwrite 400/1001 regression is
+    met with ONE retry as a new import — the bundled SolutionId is rotated first."""
+    sol, proj = _uipx_project(tmp_path)
+    calls = _stub_debug(monkeypatch, [_cp(1, _OVERWRITE_400_1001), _cp(0, _COMPLETED)])
+    monkeypatch.setattr(flow_check, "_find_project", lambda pattern: str(proj))
+    payload = run_debug(retries=1)
+    assert calls["n"] == 2
+    assert flow_check.collect_outputs(payload) == ["Sev1"]
+    text = (sol / "Sol.uipx").read_text()
+    assert "79cda3cb-5a10-4f37-e091-08df08c2afbe" not in text
+    assert flow_check._SOLUTION_ID_RE.search(text) is not None
+    err = capsys.readouterr().err
+    assert "INTERIM (UiPath/cli#3938" in err
+    assert "rotated the bundled SolutionId 79cda3cb-5a10-4f37-e091-08df08c2afbe" in err
+    # The orphaned server id is named, because cleanup reads only the current one.
+    assert "previous: 79cda3cb-5a10-4f37-e091-08df08c2afbe" in err
+
+
+def test_run_debug_rotates_only_once(monkeypatch, tmp_path):
+    _, proj = _uipx_project(tmp_path)
+    calls = _stub_debug(monkeypatch, [_cp(1, _OVERWRITE_400_1001), _cp(1, _OVERWRITE_400_1001)])
+    monkeypatch.setattr(flow_check, "_find_project", lambda pattern: str(proj))
+    with pytest.raises(SystemExit) as exc:
+        run_debug(retries=1)
+    assert calls["n"] == 2
+    assert "Overwrite failed (400)" in str(exc.value)
+
+
+def test_run_debug_does_not_rotate_on_a_content_overwrite_error(monkeypatch, tmp_path):
+    """Code 20001 (2026-08-26) is the archive being wrong; rotating would hide it."""
+    sol, proj = _uipx_project(tmp_path)
+    calls = _stub_debug(monkeypatch, [_cp(1, _OVERWRITE_400_20001)])
+    monkeypatch.setattr(flow_check, "_find_project", lambda pattern: str(proj))
+    with pytest.raises(SystemExit):
+        run_debug(retries=1)
+    assert calls["n"] == 1
+    assert "79cda3cb-5a10-4f37-e091-08df08c2afbe" in (sol / "Sol.uipx").read_text()
+
+
+def test_run_debug_overwrite_1001_without_a_uipx_fails_plainly(monkeypatch, tmp_path):
+    proj = tmp_path / "Proj"
+    proj.mkdir()
+    calls = _stub_debug(monkeypatch, [_cp(1, _OVERWRITE_400_1001)])
+    monkeypatch.setattr(flow_check, "_find_project", lambda pattern: str(proj))
+    with pytest.raises(SystemExit):
+        run_debug(retries=1)
+    assert calls["n"] == 1
+
+
+@pytest.mark.parametrize(
+    "cp,expected",
+    [
+        (_cp(1, _OVERWRITE_400_1001), True),
+        (_cp(1, _OVERWRITE_400_20001), False),
+        (_cp(0, _OVERWRITE_400_1001), False),
+        (_cp(1, _TRANSIENT_504), False),
+    ],
+)
+def test_is_overwrite_stuck(cp, expected):
+    assert flow_check._is_overwrite_stuck(cp) is expected
 
 
 def test_run_debug_unreadable_retry_does_not_burn_the_transient_budget(monkeypatch):


### PR DESCRIPTION
## Short version

A labeled **interim** measure for a platform regression, `_shared/` only, arm-neutral. Studio Web's `Solution/{id}/Overwrite` has returned `400 / code 1001` for an **existing** solution since 2026-09-02 (last known good 2026-09-01 07:30Z), so the second `flow debug` of any project fails at upload — six multi-case checkers now fail at case 2 in all three arms. `run_debug` rotates the bundled `SolutionId` and retries **once** as a new import, only on that exact signature. Real fix asked for in [UiPath/cli#3938](https://github.com/UiPath/cli/issues/3938) (Studio Web escalation + a CLI-side fallback for disposable debug pushes).

## Evidence (2026-09-02 UTC, tenant alpha/codereval)

- 07:48 / 07:52 — reruns of `skill-flow-e2e-escalation-orchestrator-paths`, v1 and v2: case 1 imports and Completes (Slack posted), **case 2 → `Overwrite failed (400): {"code":"1001",…}`**, both arms.
- 07:55 — host, current CLI, project copy carrying the imported server id: 400/1001 on every debug.
- 07:57 — **yesterday's eval image** (`uip 1.202.0-dev.8414`): 400/1001. `packages/solution-sdk/src/upload-service.ts` unchanged between vintages → platform-side.
- 07:58 — `uip solution upload --force`: 400/1001.
- 07:59 — same project, bundled `SolutionId` rotated to a fresh uuid4: **Completed, `slackMessageId 1788335996.755169`** — import works, only overwrite is broken.
- Archive: 20 seven-debug passes of this task through 09-01 07:30Z; the only earlier Overwrite 400 (08-26) was code **20001** (content error) and stays a failure here.

## What changes

`run_debug`: `_is_overwrite_stuck()` = `returncode != 0` and stdout has `Overwrite failed (400)` and `"code":"1001"`. On it, `_rotate_solution_id()` walks up from the project to the one `*.uipx`, swaps `SolutionId` for a uuid4, and the loop gets **one** extra attempt (its own allowance, like the unreadable-outputs retry; the existing deadline still bounds it; `debug_budget()` untouched). stderr gets `INTERIM (UiPath/cli#3938 …): rotated the bundled SolutionId <old> → <new>; retrying as a new import.` and, after success, the new server solution id plus the orphaned previous ids (cleanup reads only the current `.uipx` id). Never fires on 20001, 404 or exit 0. When Overwrite recovers the signature stops matching — delete the block then.

Cost while the outage lasts: one extra tenant solution per affected case (undeletable today — `solution delete` returns the same 400/1001).

## Tests

+6 in `test_flow_check.py` (rotation then import, asserting the `.uipx` changed and the INTERIM lines; rotate once only; 20001 not rotated; no `.uipx` → plain failure; classifier table). `test_flow_check.py` + `test_criterion_budgets.py`: 830 passed; `scripts/check-task-driver.py` OK. The full `tests/tasks/uipath-maestro-flow/` tree has **3 pre-existing failures in `test_same_ground_corpus.py`** on the campaign tip itself (`8d758ff1c`, after today's rebase onto main): main's new `ixp/e2e_03_project_creation_handoff` task is not in the telemetry / forbidden-prompt / package-qualified-imports allowlists. Not touched here.

## Rerun evidence

Posted in the escalation-orchestrator-paths RCA and on #2756 once the rerun completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cn8thdbhgRMqTehFhnAWW
