### PR TITLE
fix(flow-check): close the .uipx read handle in the interim SolutionId rotation (#2990 review nit)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -202,7 +202,8 @@ def _rotate_solution_id(project_dir: str) -> tuple[str, str] | None:
         uipx = sorted(glob.glob(os.path.join(glob.escape(here), "*.uipx")))
         if len(uipx) == 1:
             try:
-                text = open(uipx[0], encoding="utf-8").read()
+                with open(uipx[0], encoding="utf-8") as handle:
+                    text = handle.read()
             except OSError:
                 return None
             match = _SOLUTION_ID_RE.search(text)


### PR DESCRIPTION
Addresses the one Low finding of the Claude review on #2990: `_rotate_solution_id` read the `.uipx` without a `with` block. Behaviour unchanged; `test_flow_check.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cn8thdbhgRMqTehFhnAWW