### PR TITLE
fix(eval-prompt): name the graded flow artifact in local_crud (SmokeEval.flow)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
@@ -21,7 +21,7 @@ initial_prompt: |
   Web round-trip.
 
   Create the solution and the Flow project, keeping the Flow inside a solution
-  of the same name.
+  of the same name; the flow file is `SmokeEval.flow`.
 
   Declare a string input variable named `name` before adding data points. The
   eval data point below uses `{"name":"Alice"}`, so its input must be declared


### PR DESCRIPTION
## What

One loop-neutral clause in `evaluate/local_crud.yaml`'s prompt:

> Create the solution and the Flow project, keeping the Flow inside a solution of the same name**; the flow file is `SmokeEval.flow`.**

## Why

The graded criterion is `flow_contains.py --flow-name SmokeEval`. Main's prompt named `SmokeEval.flow` three times (with layout coaching); the sweep in #2752 removed the coaching and, with it, every mention of the artifact. The name survived only as `Flow project called "SmokeEval"` in the first line.

In `adhoc-2026-09-01_06-35-33` the SDK-arm agent (gpt-5.6-luna) scaffolded `Smoke/Smoke/Smoke.flow`, wrote `Smoke.flow.ts`, and passed every other criterion → `FAILURE 0.923`. Reasoning is hidden by OpenAI policy. Tally before the fix:

| | runs | named `SmokeEval` |
|---|---:|---:|
| v2 (SDK) arm, campaign prompt | 6 | 5 |
| v1 arm, campaign prompt | 6 | 6 |
| nightly baseline (main prompt) | 55 | 55 |

Across the whole archive this is the only miss of an explicitly prompted flow name (918 graded `--flow-name` criteria; the other 42 misses are the seven `*-simulated` dialog tasks, which miss in the baseline too). The 09-01 nightly "pass" for this task was `mature_skipped`, not a run.

The v1 loop binds the file name mechanically (`flow init SmokeEval`); the SDK loop has the agent type the name into the source, the scaffold and `compile -o`, so the prompt is the only anchor. Per the campaign rule, a loop-neutral prompt names the graded artifact. Checker unchanged: it asked for `SmokeEval`, the prompt asked for `SmokeEval`.

Siblings that lost the same anchor in the sweep and have 0 misses so far, left for Tao: `evaluator_type_choice`, `inline_agent_eval`, `no_auto_upload`, `simulation/simulation_crud`, `smoke/init_validate`, `smoke/inline_agent_robust`.

## Measurement contract (#2756 §2.5 / D-1)

Prompt-only; both arms read the same text. `test_same_ground_corpus.py`: my branch reproduces exactly the three pre-existing failures of the campaign tip (`ixp/e2e_03_project_creation_handoff` allowlists), nothing new. `check-task-driver.py` OK. RCA: `workspaces/reports/2026-09-02-maestro-flow-eval-local-crud/rca-eval-local-crud.md` (in progress). Companion doc fix on the SDK skill's `<Name>Sol` template: UiPath/flow-builder-sdk (link in the RCA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjcoqnpHbNPvfCBsp3gB9V
