### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@66c7651

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 049d5bd. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 66c7651. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 049d5bd. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 66c7651. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 049d5bd. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 66c7651. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -26,12 +26,14 @@ To author a Flow, create a root-level `<Name>.flow.ts` and import the package di
 
 **The source lives at the root; the compiled artifact does not.** Scaffold the project
 before authoring, then emit into it — `compile -o` is the authority over where the
-emitted file is written:
+emitted file is written. `<Solution>` and `<Name>` are the request's own names, used
+verbatim: a request that gives one name for both ("inside a solution of the same
+name") uses it for both, and a request that names only the Flow uses `<Name>` for both.
 
 ```bash
-uip solution init <Name>Sol
-( cd <Name>Sol && uip maestro flow init <Name> )
-uip maestro flow compile <Name> -o <Name>Sol/<Name>/<Name>.flow
+uip solution init <Solution>
+( cd <Solution> && uip maestro flow init <Name> )
+uip maestro flow compile <Name>.flow.ts -o <Solution>/<Name>/<Name>.flow
 ```
 
 Exactly one emitted `<Name>.flow` may exist, at that path. Never leave a second copy

--- a/preview/uipath-maestro-flow/references/CLI-LOOP.md
+++ b/preview/uipath-maestro-flow/references/CLI-LOOP.md
@@ -52,14 +52,17 @@ source at the workspace root beside `node_modules/`, and create the nested
 scaffold once:
 
 ```bash
-uip solution init <Name>Sol
-( cd <Name>Sol && uip maestro flow init <Name> )
+uip solution init <Solution>
+( cd <Solution> && uip maestro flow init <Name> )
 ```
 
-The result has three related names: `<Name>.flow.ts`, the `<Name>` project
-directory, and `<Name>.flow` inside that project. Keep them aligned for this
-scaffold so each command addresses the intended project; `compile -o` remains
-the authority over where the emitted file is written.
+`<Solution>` and `<Name>` are the request's own names, used verbatim: a request
+that gives one name for both ("inside a solution of the same name") uses it for
+both, and a request that names only the Flow uses `<Name>` for both. The result
+has three related names: `<Name>.flow.ts`, the `<Name>` project directory, and
+`<Name>.flow` inside that project. Keep them aligned for this scaffold so each
+command addresses the intended project; `compile -o` remains the authority over
+where the emitted file is written.
 
 ## Eval/product-CLI packaging: emit-only
 
@@ -77,17 +80,17 @@ refresh and debug only when the stated acceptance bar requires product-runtime
 behavior evidence:
 
 ```bash
-uip maestro flow compile <Name> -o <Name>Sol/<Name>/<Name>.flow
-uip maestro flow validate <Name>Sol/<Name>/<Name>.flow --output json
+uip maestro flow compile <Name>.flow.ts -o <Solution>/<Name>/<Name>.flow
+uip maestro flow validate <Solution>/<Name>/<Name>.flow --output json
 # Only for a stated runtime-behavior claim:
-( cd <Name>Sol && uip solution resources refresh --solution-folder . --output json )
-( cd <Name>Sol && uip maestro flow debug <Name> --log-level error \
+( cd <Solution> && uip solution resources refresh --solution-folder . --output json )
+( cd <Solution> && uip maestro flow debug <Name> --log-level error \
   --output-filter "{status:finalStatus,instance:instanceId,url:studioWebUrl,failed:elementExecutions[?status!='Completed'].{id:elementId,status:status},globals:variables.globals}" \
   --output json )
 ```
 
 This loop has exactly one emitted artifact:
-`<Name>Sol/<Name>/<Name>.flow`. Never emit a second root-level `<Name>.flow`;
+`<Solution>/<Name>/<Name>.flow`. Never emit a second root-level `<Name>.flow`;
 validators and evidence collectors cannot choose safely between duplicates.
 Re-run the whole sequence after the final source or binding edit.
 
@@ -222,8 +225,8 @@ For example, a direct-input claim can keep the useful status, outputs, and
 diagnostics in one read-back instead of printing the full execution envelope:
 
 ```bash
-( cd <Name>Sol && uip solution resources refresh --solution-folder . --output json )
-( cd <Name>Sol && uip maestro flow debug <Name> --log-level error \
+( cd <Solution> && uip solution resources refresh --solution-folder . --output json )
+( cd <Solution> && uip maestro flow debug <Name> --log-level error \
   --inputs @inputs.json \
   --output-filter "{status:finalStatus,instance:instanceId,url:studioWebUrl,failed:elementExecutions[?status!='Completed'].{id:elementId,status:status},globals:variables.globals}" \
   --output json )


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `049d5bd` to current `UiPath/flow-builder-sdk@main` (`66c7651`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)