### PR TITLE
fix(tests): teach the CLI-verb linter to read cli_called verbs

### DIFF
--- a/.claude/commands/audit-verbs.md
+++ b/.claude/commands/audit-verbs.md
@@ -9,7 +9,7 @@ Verify that every `uip <verb>` mentioned in task YAMLs and skill docs correspond
 - `--refresh` — force a catalog rebuild before running, even if a snapshot already exists.
 
 **Output:** One or both of:
-- `tests/reports/cli-verb-audit.md` — task-YAML reachability (High/Medium/Info severities, sourced from `command_executed` patterns).
+- `tests/reports/cli-verb-audit.md` — task-YAML reachability (High/Medium/Info severities, sourced from `command_executed` patterns and from `cli_called` `verb` / `verb_any_of` fields carrying `tool: uip`).
 - `tests/reports/skill-verb-audit.md` — skill-doc verb references (Stale/Uncertain severities, sourced from prose, code blocks, and tables).
 
 Plus a chat summary with the top counts and the worst-offender files.

--- a/.claude/commands/lint-task.md
+++ b/.claude/commands/lint-task.md
@@ -160,7 +160,7 @@ Severity:
 
 ### CLI verb reachability
 
-Run `python3 scripts/check-cli-verbs.py --json <task-path>` and merge its findings into this task's issue list. The script verifies that every `command_executed` criterion's `command_pattern` actually corresponds to a real `uip` verb listed in `assets/uip-catalog-snapshot.json`, with retired-verb suggestions sourced from `.claude/rules/cli-renames.md`.
+Run `python3 scripts/check-cli-verbs.py --json <task-path>` and merge its findings into this task's issue list. The script verifies that the verb a criterion names actually corresponds to a real `uip` verb listed in `assets/uip-catalog-snapshot.json`, with retired-verb suggestions sourced from `.claude/rules/cli-renames.md`. Two criterion types are covered: `command_executed` (verb literals parsed out of `command_pattern`) and `cli_called` (`verb` / `verb_any_of`, checked only when the criterion carries `tool: uip`). Findings carry a `source` field naming which one. A `cli_called` verb is matched against the catalog exactly, so a typo'd leaf is not rescued by its parent group.
 
 Severity passthrough from the script's findings:
 

--- a/scripts/check-cli-verbs.py
+++ b/scripts/check-cli-verbs.py
@@ -3,18 +3,31 @@
 Verify that `uip` verb literals referenced in coder-eval task YAMLs actually
 exist in the CLI catalog.
 
-For every `command_executed` criterion in each task YAML, extract literal verb
-tokens that follow the `uip` prefix in `command_pattern`, enumerate the
-alternation paths, and check each path against `assets/uip-catalog-snapshot.json`
+Two criterion types name a verb, and both are checked:
+
+  - `command_executed` — extract literal verb tokens that follow the `uip`
+    prefix in `command_pattern` and enumerate the alternation paths.
+  - `cli_called` — read `verb` / `verb_any_of` directly. These are literal
+    whitespace-separated verb chains by contract, so there is nothing to
+    enumerate and no dynamic case. Only criteria carrying `tool: uip` are
+    checked: the recorded log is shared across shadowed executables, so a
+    verb under any other `tool` is not a `uip` verb and gets no verdict.
+
+Each resulting verb path is checked against `assets/uip-catalog-snapshot.json`
 and `.claude/rules/cli-renames.md`.
 
 Findings:
-  - High   — pattern does not match any verb in the catalog. The success
+  - High   — no verb the criterion names is in the catalog. The success
              criterion can never fire; the task scores zero on a passing run.
-  - Medium — pattern matches only retired verbs listed in cli-renames.md.
+  - Medium — the criterion names only retired verbs listed in cli-renames.md.
              Suggest the canonical replacement.
-  - Info   — pattern is too dynamic to analyse (contains `.`, `[`, `\\w`, etc).
-             Skipped — no claim made about it.
+  - Info   — `command_pattern` is too dynamic to analyse (contains `.`, `[`,
+             `\\w`, etc). Skipped — no claim made about it.
+
+A retired verb sitting alongside a reachable one is not reported, for either
+criterion type: the criterion still fires on the reachable spelling, so the
+verdict is `reachable`. `verb_any_of` entries are treated exactly like a regex
+alternation's paths for that reason.
 
 Output formats:
   - Default: human-readable, one finding per line.
@@ -218,8 +231,20 @@ def extract_verb_paths(pattern):
     return verb_paths or None
 
 
-def classify(verb_paths, catalog, renames):
-    """Return ('reachable'|'retired'|'unknown', details)."""
+def classify(verb_paths, catalog, renames, *, exact=False):
+    """Return ('reachable'|'retired'|'unknown', details).
+
+    `exact` controls the CATALOG lookup only. A `command_pattern` verb can carry
+    a trailing fragment the regex happened to capture, so it needs the
+    longest-prefix fallback below. A `cli_called` verb is a complete literal
+    chain, and the catalog holds group prefixes as their own entries
+    (`ixp`, `ixp projects`, `ixp projects list`) — so an exact test accepts a
+    deliberately short verb while still failing a typo'd leaf. Under the prefix
+    fallback, `ixp projects lisst` matched the group `ixp projects` and passed.
+
+    Renames stay prefix-matched in both modes: `flow validate` is retired
+    because its `flow` ancestor is, and the suggestion is worth surfacing.
+    """
     if not verb_paths:
         return "unknown", {}
 
@@ -234,15 +259,22 @@ def classify(verb_paths, catalog, renames):
                 return candidate
         return None
 
+    def catalog_match(verb):
+        if exact:
+            return verb if verb in catalog else None
+        return best_match(verb, catalog)
+
     reachable = []
     retired = []
     for v in verb_paths:
-        cat_hit = best_match(v, catalog)
+        cat_hit = catalog_match(v)
         ren_hit = best_match(v, renames)
         # A more specific renames entry shadows a shallower catalog prefix.
         # Example: `solution new` was removed in 1.2.0; the parent group
         # `solution` is still in the catalog, so catalog longest-prefix would
-        # otherwise mis-classify `solution new` as reachable.
+        # otherwise mis-classify `solution new` as reachable. Under `exact` the
+        # two hits are the same string when both fire, so this falls through to
+        # `cat_hit` — the catalog is the source of truth for what exists today.
         if ren_hit and (not cat_hit or len(ren_hit.split()) > len(cat_hit.split())):
             retired.append(v)
         elif cat_hit:
@@ -272,6 +304,46 @@ def iter_command_patterns(spec, path):
         yield idx, pattern, crit.get("description", "")
 
 
+# `cli_called` matches per-facet against a recorded argv instead of a rendered
+# command string, so its verb needs no regex parsing — but it is also invisible
+# to iter_command_patterns, which is how migrated tasks silently left the
+# catalog linter's reach.
+def iter_cli_called_verbs(spec):
+    """Yield (idx, verb_paths, description, display) per checkable cli_called.
+
+    `verb` and `verb_any_of` are mutually exclusive and hold literal verb
+    chains; coder_eval splits them on whitespace, so the same normalisation
+    applies here. Criteria whose `tool` is not `uip` are skipped without a
+    verdict — including an absent `tool`, which matches any executable and so
+    cannot be claimed as a `uip` verb.
+    """
+    for idx, crit in enumerate(spec.get("success_criteria") or []):
+        if not isinstance(crit, dict):
+            continue
+        if crit.get("type") != "cli_called":
+            continue
+        if crit.get("tool") != "uip":
+            continue
+        verb, any_of = crit.get("verb"), crit.get("verb_any_of")
+        if isinstance(verb, str):
+            spellings, display = [verb], f"verb: {verb!r}"
+        elif isinstance(any_of, list):
+            spellings = [v for v in any_of if isinstance(v, str)]
+            display = "verb_any_of: " + " | ".join(repr(v) for v in spellings)
+        else:
+            # No verb facet at all — a positional/flags-only criterion. Legal,
+            # and it names no verb to check.
+            continue
+        # Normalise the way coder_eval does (`verb.split()`), so " ixp  projects
+        # list " and "ixp projects list" reach the catalog as one string. A
+        # blank entry is rejected upstream by the model validator.
+        verb_paths = list(dict.fromkeys(
+            " ".join(v.split()) for v in spellings if v.split()))
+        if not verb_paths:
+            continue
+        yield idx, verb_paths, crit.get("description", ""), display
+
+
 def lint_file(path, catalog, renames):
     try:
         import yaml
@@ -289,6 +361,32 @@ def lint_file(path, catalog, renames):
     if not isinstance(spec, dict):
         return []
     findings = []
+
+    def record(verdict, details, *, idx, desc, display, source):
+        """Emit the Medium/High finding for one classified criterion.
+
+        Shared so a `cli_called` verb and a `command_pattern` verb cannot drift
+        into different severities or message shapes. `command_pattern` stays the
+        display key for both: write_report and the stdout printer read it, and
+        the High histogram parses `unmatched: [...]` out of the message.
+        """
+        if verdict == "reachable":
+            return
+        common = {"path": str(path), "axis": "cli-verb-reachability",
+                  "criterion_index": idx, "command_pattern": display,
+                  "description": desc, "source": source}
+        if verdict == "retired":
+            sugg = details["suggestions"]
+            findings.append({**common, "severity": "Medium",
+                             "message": "Criterion matches only retired verbs: "
+                                        + ", ".join(f"`{r}` → `{sugg[r]}`"
+                                                    for r in details["retired"])})
+        else:
+            findings.append({**common, "severity": "High",
+                             "message": "No verb this criterion names is in the "
+                                        "uip catalog "
+                                        f"(unmatched: {details['unmatched']})."})
+
     for idx, pattern, desc in iter_command_patterns(spec, path):
         verbs = extract_verb_paths(pattern)
         if verbs is None:
@@ -302,30 +400,14 @@ def lint_file(path, catalog, renames):
             })
             continue
         verdict, details = classify(verbs, catalog, renames)
-        if verdict == "reachable":
-            continue
-        if verdict == "retired":
-            sugg = details["suggestions"]
-            findings.append({
-                "path": str(path), "severity": "Medium",
-                "axis": "cli-verb-reachability",
-                "criterion_index": idx,
-                "command_pattern": pattern,
-                "description": desc,
-                "message": "Pattern matches only retired verbs: "
-                           + ", ".join(f"`{r}` → `{sugg[r]}`"
-                                       for r in details["retired"]),
-            })
-        else:
-            findings.append({
-                "path": str(path), "severity": "High",
-                "axis": "cli-verb-reachability",
-                "criterion_index": idx,
-                "command_pattern": pattern,
-                "description": desc,
-                "message": "No verb in pattern matches uip catalog "
-                           f"(unmatched: {details['unmatched']}).",
-            })
+        record(verdict, details, idx=idx, desc=desc, display=pattern,
+               source="command_pattern")
+
+    for idx, verb_paths, desc, display in iter_cli_called_verbs(spec):
+        verdict, details = classify(verb_paths, catalog, renames, exact=True)
+        record(verdict, details, idx=idx, desc=desc, display=display,
+               source="cli_called")
+
     return findings
 
 
@@ -387,7 +469,8 @@ def write_report(findings, catalog_size, version, output_path):
                         key=lambda x: x["path"]):
             out.append(f"- **`{f['path']}`** (criterion "
                        f"{f['criterion_index']})  ")
-            out.append(f"  pattern: `{f['command_pattern']}`  ")
+            label = "cli_called" if f.get("source") == "cli_called" else "pattern"
+            out.append(f"  {label}: `{f['command_pattern']}`  ")
             out.append(f"  {f['message']}")
         out.append("")
     out.append("## Info findings — patterns skipped\n")
@@ -449,7 +532,9 @@ def main():
         for f in all_findings:
             print(f"[{f['severity']}] {f['path']}: {f['message']}")
             if f.get("command_pattern"):
-                print(f"           pattern: {f['command_pattern']}")
+                label = ("cli_called" if f.get("source") == "cli_called"
+                         else "pattern")
+                print(f"           {label}: {f['command_pattern']}")
         high = sum(1 for f in all_findings if f["severity"] == "High")
         med = sum(1 for f in all_findings if f["severity"] == "Medium")
         info = sum(1 for f in all_findings if f["severity"] == "Info")

--- a/tests/scripts/test_verb_checkers.py
+++ b/tests/scripts/test_verb_checkers.py
@@ -281,3 +281,160 @@ def test_dot_separated_argument_value_not_treated_as_verb(tmp_path):
         f"Expected no findings — `core.action.script` is an argument, "
         f"got {findings!r}."
     )
+
+
+# --- cli_called criteria are in scope for the catalog check -------------------
+
+def _task(tmp_path, body, name="task.yaml"):
+    task = tmp_path / name
+    task.write_text("success_criteria:\n" + body)
+    return task
+
+
+CLI_CALLED_CATALOG = {"ixp", "ixp projects", "ixp projects list",
+                      "ixp projects get", "ixp projects delete"}
+
+
+def test_cli_called_verb_is_linted_at_all(tmp_path):
+    """`cli_called` names its verb in `verb`, not in a `command_pattern`.
+
+    The checker only ever parsed `command_pattern`, so every task migrated from
+    `file_matches_regex`/`command_executed` to `cli_called` silently left the
+    catalog linter's reach — a stale verb in a migrated task was unreachable by
+    any gate in the repo.
+    """
+    task = _task(tmp_path,
+                 '  - type: cli_called\n'
+                 '    description: "typo"\n'
+                 '    verb: "ixp projects lisst"\n'
+                 '    tool: "uip"\n')
+    findings = cli.lint_file(task, CLI_CALLED_CATALOG, {})
+    assert [f["severity"] for f in findings] == ["High"], (
+        f"Expected one High for a verb absent from the catalog, got {findings!r}."
+    )
+    assert findings[0]["source"] == "cli_called"
+
+
+def test_cli_called_typoed_leaf_not_rescued_by_group_prefix(tmp_path):
+    """`classify`'s longest-prefix fallback must NOT apply to a cli_called verb.
+
+    A `command_pattern` can carry a trailing fragment the regex happened to
+    capture, so it needs the fallback. A `cli_called` verb is a complete literal
+    chain, and `ixp projects` is itself a catalog entry — so under the fallback
+    the typo `ixp projects lisst` matched the parent group and scored reachable,
+    which is the exact blind spot this check exists to close.
+    """
+    verdict, _ = cli.classify(["ixp projects lisst"], CLI_CALLED_CATALOG, {},
+                              exact=True)
+    assert verdict == "unknown", (
+        f"Expected 'unknown' — the leaf is a typo and must not match the "
+        f"`ixp projects` group; got {verdict!r}."
+    )
+    # The prefix fallback is still what `command_pattern` needs.
+    verdict_prefix, _ = cli.classify(["ixp projects lisst"],
+                                     CLI_CALLED_CATALOG, {})
+    assert verdict_prefix == "reachable"
+
+
+def test_cli_called_deliberately_short_verb_stays_reachable(tmp_path):
+    """A group-level verb is legal — `verb` is an ordered PREFIX of the argv, so
+    a `max_count: 0` guard on `ixp projects` deliberately fires on every
+    subcommand. The catalog holds group entries, so exact matching accepts it.
+    """
+    task = _task(tmp_path,
+                 '  - type: cli_called\n'
+                 '    description: "group guard"\n'
+                 '    verb: "ixp projects"\n'
+                 '    tool: "uip"\n'
+                 '    min_count: 0\n'
+                 '    max_count: 0\n')
+    assert cli.lint_file(task, CLI_CALLED_CATALOG, {}) == []
+
+
+def test_cli_called_verb_any_of_reachable_if_any_spelling_is(tmp_path):
+    """`verb_any_of` entries are alternatives, so they classify as a group —
+    the same way a regex alternation's paths do. One reachable spelling means
+    the criterion can still fire.
+    """
+    task = _task(tmp_path,
+                 '  - type: cli_called\n'
+                 '    description: "channel"\n'
+                 '    verb_any_of: ["ixp projects get", "ixp projects list"]\n'
+                 '    tool: "uip"\n')
+    assert cli.lint_file(task, CLI_CALLED_CATALOG, {}) == []
+
+    both_bad = _task(tmp_path,
+                     '  - type: cli_called\n'
+                     '    description: "channel"\n'
+                     '    verb_any_of: ["ixp projects gett", "ixp projects listt"]\n'
+                     '    tool: "uip"\n',
+                     name="both_bad.yaml")
+    findings = cli.lint_file(both_bad, CLI_CALLED_CATALOG, {})
+    assert [f["severity"] for f in findings] == ["High"], (
+        f"Expected High when NO spelling is reachable, got {findings!r}."
+    )
+
+
+def test_cli_called_retired_verb_is_medium_with_suggestion(tmp_path):
+    """Renames stay prefix-matched under `exact`, so a retired ancestor still
+    yields the canonical suggestion rather than a bare High.
+    """
+    task = _task(tmp_path,
+                 '  - type: cli_called\n'
+                 '    description: "retired"\n'
+                 '    verb: "solution new"\n'
+                 '    tool: "uip"\n')
+    findings = cli.lint_file(task, {"solution", "solution init"},
+                             {"solution new": "solution init"})
+    assert [f["severity"] for f in findings] == ["Medium"], (
+        f"Expected Medium for a retired verb, got {findings!r}."
+    )
+    assert "solution init" in findings[0]["message"]
+
+
+def test_cli_called_non_uip_tool_gets_no_verdict(tmp_path):
+    """`record_cli` shims several executables into ONE shared log, and `tool`
+    is what separates them. A verb recorded under `curl` is not a uip verb, and
+    an ABSENT `tool` matches any executable — neither can be claimed against the
+    uip catalog, so both are skipped without a finding.
+    """
+    other_tool = _task(tmp_path,
+                       '  - type: cli_called\n'
+                       '    description: "curl guard"\n'
+                       '    verb: "not a uip verb"\n'
+                       '    tool: "curl"\n'
+                       '    min_count: 0\n'
+                       '    max_count: 0\n')
+    assert cli.lint_file(other_tool, CLI_CALLED_CATALOG, {}) == []
+
+    no_tool = _task(tmp_path,
+                    '  - type: cli_called\n'
+                    '    description: "tool-less"\n'
+                    '    verb: "not a uip verb"\n',
+                    name="no_tool.yaml")
+    assert cli.lint_file(no_tool, CLI_CALLED_CATALOG, {}) == []
+
+
+def test_cli_called_verbless_criterion_is_skipped(tmp_path):
+    """A flags-only or positional-only `cli_called` is legal and names no verb."""
+    task = _task(tmp_path,
+                 '  - type: cli_called\n'
+                 '    description: "flags only"\n'
+                 '    tool: "uip"\n'
+                 '    flags:\n'
+                 '      force: {present: true}\n'
+                 '    min_count: 0\n'
+                 '    max_count: 0\n')
+    assert cli.lint_file(task, CLI_CALLED_CATALOG, {}) == []
+
+
+def test_cli_called_verb_whitespace_is_normalised(tmp_path):
+    """coder_eval splits the verb on whitespace (`verb.split()`), so irregular
+    inner spacing is the same verb and must not read as absent from the catalog.
+    """
+    task = _task(tmp_path,
+                 '  - type: cli_called\n'
+                 '    description: "spacing"\n'
+                 '    verb: "ixp   projects  list"\n'
+                 '    tool: "uip"\n')
+    assert cli.lint_file(task, CLI_CALLED_CATALOG, {}) == []


### PR DESCRIPTION
Closes the follow-up flagged in #2994.

`scripts/check-cli-verbs.py` only ever parsed `command_pattern`, so a verb named by a `cli_called` criterion was checked by **nothing**. Every task migrated to `cli_called` (#2565, #2994 — **39 criteria naming 40 verb spellings** today) quietly left the catalog linter's reach, and both migrations were verified by hand instead. A stale ixp verb in a migrated task would have been caught by no gate in this repo.

## What it does now

`cli_called` names its verb in `verb` / `verb_any_of` as literal whitespace-separated chains, so there is no regex to walk and no dynamic case.

Only criteria carrying `tool: uip` are checked. `record_cli` shims several executables into **one shared log** and `tool` is what separates them, so a verb recorded under any other tool is not a uip verb. An **absent** `tool` is also skipped — it matches any executable, so nothing can be claimed about it. Both skips are silent, matching how a non-uip `command_pattern` is already dropped. No criterion in the repo is affected today: all 39 carry `tool: uip`.

## The catalog lookup had to change

This is the part worth reviewing. `classify` walks progressively shorter prefixes, which a `command_pattern` verb genuinely needs — the regex may have captured a trailing flag fragment. A `cli_called` verb is a *complete* chain, and the catalog holds group prefixes as their own entries (`ixp`, `ixp projects`, `ixp projects list`).

So under the prefix fallback, the typo **`ixp projects lisst` matched the group `ixp projects` and scored reachable**. The first cut of this change shipped exactly that bug — the new check ran, found nothing, and looked like it worked. Caught by asserting on a deliberately misspelled leaf.

`classify` now takes `exact=`, used only by the `cli_called` path. It accepts a deliberately short group verb (legal — `verb` is an ordered *prefix* of the argv, so a `max_count: 0` guard on `ixp projects` is meant to fire on every subcommand) while still failing a typo'd leaf. Renames stay prefix-matched in both modes, so `flow validate` is still reported retired via its `flow` ancestor and keeps its canonical suggestion.

## Shape of the output

Both paths emit through one `record()` helper, so severities and message shapes cannot drift apart. Findings carry a new `source` field (`command_pattern` | `cli_called`). `command_pattern` stays the display key for both — `write_report` and the stdout printer read it, and the High histogram parses `unmatched: [...]` out of the message — but the printed label reads `cli_called:` where that is what it is.

## Verification

- **8 new regression tests**; 22 pass in `tests/scripts/test_verb_checkers.py`. One of them pins the prefix-vs-exact distinction in both directions, so the bug above cannot come back.
- **Differential over all 1284 task YAMLs, old checker vs new: 102 findings each, identical on every field**, no key added or dropped for existing findings. Nothing already in the repo changes verdict — the repo has no High/Medium today, so the message rewording is unobservable.
- Four classification paths exercised end to end: typo'd leaf → High · group prefix → clean · retired verb → Medium with suggestion · non-uip tool → no verdict.
- `--report` renders a `cli_called` High into the verb histogram correctly (the `unmatched: [...]` parse still lands).

## Merge order

Independent of #2994 — branched off `main`, changes no task YAMLs, and #2994's verbs are all valid so neither PR turns the other red. Merge in either order. Landing this one first is what I'd suggest, so the remaining ~25 migrations are linted as they arrive rather than by hand.

## Not fixed here

Two pre-existing, unrelated Windows-locale issues, left alone to keep this one logical change:

- The Medium message's `→` crashes a Windows cp1252 console. Present at HEAD (`check-cli-verbs.py:316`), and this PR adds a new way to reach a Medium finding without introducing the character.
- `tests/scripts/test_runtime_payload_key_casing.py::test_no_raw_lowercase_runtime_key_reads` fails with a `UnicodeDecodeError`. Confirmed identical at HEAD with these changes stashed.

Both are Windows-only; CI is UTF-8 Linux and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
