### PR TITLE
fix(tests): retry the litellm judge; drop a self-report criterion

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -249,10 +249,13 @@ checker_context:
     model: azure/gpt-5.6-luna
     params:
       api_version: "2024-05-01"
+      num_retries: 3
     env_params:
       api_base: CODEX_BASE_URL
       api_key: CODEX_API_KEY
 ```
+
+`num_retries` is mandatory, not tuning. coder_eval's litellm judge has no retry of its own — `judge_litellm.py` calls `litellm.acompletion` bare, while only `judge_bedrock.py` wraps a `RetryConfig` — so a transient provider `InternalServerError` or `Timeout` raises `JudgeInfrastructureError` (CE039) and ERRORs the whole task. Worse, `checker.py`'s `check_all_async` accumulates results in a local list and lets that exception propagate, so every criterion already scored is discarded too: nightly `2026-08-31_04-15-47` lost 20 tasks this way, one of them a 21-criterion e2e whose 18 passing deterministic checks were thrown away by a single 500 on the judge at position 19. `params` is spliced into the `acompletion` call verbatim, so retry is configurable here; `num_retries` is a litellm-level kwarg and is never forwarded to the provider, so `drop_params` does not strip it. Remove once the litellm judge retries upstream.
 
 `route: litellm` is `llm_judge`-only and safe as an experiment default even when `simulation.enabled: true`: the simulator resolves its own route independently of `checker_context.api_route` (coder_eval `_resolve_routes`/`simulator_route`), so it's unaffected by this override. It is **not** safe combined with an enabled `agent_judge` criterion — coder_eval still rejects that combination at setup, since `agent_judge` shares `eval_route` with `llm_judge`. This repo has no `agent_judge` criteria today; if one is added, override `checker_context.api_route` back to `bedrock`/`direct` on that specific task.
 

--- a/tests/experiments/activation.yaml
+++ b/tests/experiments/activation.yaml
@@ -56,6 +56,12 @@ defaults:
       model: gpt-5.6-luna
       params:
         api_version: "2024-05-01"
+        # coder_eval's litellm judge has no retry of its own (judge_litellm.py
+        # calls acompletion bare; only judge_bedrock.py wraps a RetryConfig), so
+        # a transient provider 5xx/timeout ERRORs the task and discards every
+        # criterion already scored. `params` passes through to acompletion
+        # verbatim, so retry is configured here. Drop once upstream retries.
+        num_retries: 3
       env_params:
         api_base: CODEX_BASE_URL
         api_key: CODEX_API_KEY

--- a/tests/experiments/default.yaml
+++ b/tests/experiments/default.yaml
@@ -29,6 +29,12 @@ defaults:
       model: gpt-5.6-luna
       params:
         api_version: "2024-05-01"
+        # coder_eval's litellm judge has no retry of its own (judge_litellm.py
+        # calls acompletion bare; only judge_bedrock.py wraps a RetryConfig), so
+        # a transient provider 5xx/timeout ERRORs the task and discards every
+        # criterion already scored. `params` passes through to acompletion
+        # verbatim, so retry is configured here. Drop once upstream retries.
+        num_retries: 3
       env_params:
         api_base: CODEX_BASE_URL
         api_key: CODEX_API_KEY

--- a/tests/experiments/nightly.yaml
+++ b/tests/experiments/nightly.yaml
@@ -47,6 +47,12 @@ defaults:
       model: gpt-5.6-luna
       params:
         api_version: "2024-05-01"
+        # coder_eval's litellm judge has no retry of its own (judge_litellm.py
+        # calls acompletion bare; only judge_bedrock.py wraps a RetryConfig), so
+        # a transient provider 5xx/timeout ERRORs the task and discards every
+        # criterion already scored. `params` passes through to acompletion
+        # verbatim, so retry is configured here. Drop once upstream retries.
+        num_retries: 3
       env_params:
         api_base: CODEX_BASE_URL
         api_key: CODEX_API_KEY

--- a/tests/experiments/smoke-windows.yaml
+++ b/tests/experiments/smoke-windows.yaml
@@ -31,6 +31,12 @@ defaults:
       model: gpt-5.6-luna
       params:
         api_version: "2024-05-01"
+        # coder_eval's litellm judge has no retry of its own (judge_litellm.py
+        # calls acompletion bare; only judge_bedrock.py wraps a RetryConfig), so
+        # a transient provider 5xx/timeout ERRORs the task and discards every
+        # criterion already scored. `params` passes through to acompletion
+        # verbatim, so retry is configured here. Drop once upstream retries.
+        num_retries: 3
       env_params:
         api_base: CODEX_BASE_URL
         api_key: CODEX_API_KEY

--- a/tests/experiments/smoke.yaml
+++ b/tests/experiments/smoke.yaml
@@ -47,6 +47,12 @@ defaults:
       model: gpt-5.6-luna
       params:
         api_version: "2024-05-01"
+        # coder_eval's litellm judge has no retry of its own (judge_litellm.py
+        # calls acompletion bare; only judge_bedrock.py wraps a RetryConfig), so
+        # a transient provider 5xx/timeout ERRORs the task and discards every
+        # criterion already scored. `params` passes through to acompletion
+        # verbatim, so retry is configured here. Drop once upstream retries.
+        num_retries: 3
       env_params:
         api_base: CODEX_BASE_URL
         api_key: CODEX_API_KEY

--- a/tests/tasks/uipath-solution/resources_refresh_integration.yaml
+++ b/tests/tasks/uipath-solution/resources_refresh_integration.yaml
@@ -58,19 +58,15 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
-  - type: llm_judge
-    description: "Final reply confirms resources are synced and the solution is ready to pack"
-    include_agent_output: true
-    prompt: |
-      Evaluate ONLY the agent's final reply. The task asked the agent to
-      sync a solution's bundled resources/bindings and confirm readiness
-      to pack.
-
-      Score 1.0 if the reply states the resources/bindings are refreshed
-      or in sync and the solution is ready to pack (English or Romanian).
-
-      Score 0.0 if the reply skips the refresh, claims readiness without
-      having synced, reports an unresolved error, or only dumps raw output
-      with no interpretation.
+  # Behavioural stand-in for "confirm the resources are in sync": refresh's
+  # observable effect is the generated solution_folder artefacts, so assert
+  # those instead of the agent's own claim that it synced. Project name is
+  # agent-chosen (the prompt lets it scaffold one), so glob rather than
+  # naming a file. Replaced an llm_judge that graded the final reply's
+  # wording — a self-report, and redundant with the two criteria above.
+  - type: run_command
+    description: "refresh materialised solution_folder artefacts (resources actually in sync, not just claimed)"
+    command: "python3 -c \"import pathlib,sys; sys.exit(0 if list(pathlib.Path('BillingSuite/resources/solution_folder').rglob('*.json')) else 1)\""
+    timeout: 30
     weight: 1.5
     pass_threshold: 1.0


### PR DESCRIPTION
## Why

Nightly run `2026-08-31_04-15-47` ERRORed **20 of 1285 tasks** on transient judge faults — 16× `InternalServerError`, 4× `litellm.Timeout`. That is 37% of the run's 54 ERRORs, and none of them were agent failures.

`skill-solution-diagnose-resource-edit` is the clearest case: the agent produced a correct answer and had already scored `skill_triggered` 1.00 (visible in the log) when the judge 500'd. Recorded score: 0.

## Root cause (upstream, in coder_eval)

coder_eval retries the Bedrock judge but not the litellm one:

- `judge_bedrock.py:42` — `RetryConfig(max_retries=3, initial_delay=2.0, backoff_multiplier=2.0)`
- `judge_litellm.py:141` — bare `await litellm.acompletion(**kwargs)`; any exception becomes `JudgeInfrastructureError` (CE039) and ERRORs the task

Every experiment in this repo sets `checker_context.api_route.route: litellm`, so we are always on the unretried path.

`checker.py:208-214` compounds it — `results` is a local list and the exception propagates, so every criterion already scored is thrown away. `skill-datafabric-e2e-expense-tracker` (21 criteria, judge at position 19) lost 18 passing `command_executed`/`run_command` results to a single 500; its `task.json` comes back with `success_criteria_results: []`.

Exposure: **304 of 1282** tasks have `llm_judge` as their only scoring signal, and **57** more mix it with deterministic criteria.

## What this PR does

**1. `num_retries: 3` in all 5 experiments** (`default`, `smoke`, `smoke-windows`, `nightly`, `activation`), plus a rationale paragraph in `tests/README.md`.

`judge_litellm.py:133` splices `route.params` into the `acompletion` call verbatim, so retry is configurable from here without waiting on upstream. Commented as removable once the litellm judge retries on its own.

**2. Dropped a self-report criterion** from `resources_refresh_integration.yaml`.

Its `llm_judge` graded the agent's own summary wording — *"states the resources/bindings are refreshed or in sync and the solution is ready to pack"* — which `.claude/rules/test-writing.md` forbids ("Grade Behavior, Not Self-Reports … Never grade on agent monologue") and which asserted nothing the `command_executed` on `resources refresh` and the `json_check` on `length(Projects) >= 1` did not already prove.

Replaced with refresh's observable effect, the generated `solution_folder` artefacts. Weight unchanged at 1.5, task total unchanged at 6.5, so scores stay comparable across runs. That task now has zero judge exposure.

## Verification

Cloned coder_eval 0.11.6 and installed litellm 1.99.0 into a scratch venv to check the chain rather than assume it:

- `CheckerContext(**...)` accepts `num_retries` in `params` for all 5 configs — the real risk here was a strict route model rejecting the key and failing every run at setup
- `TaskDefinition(**...)` validates the edited task: `command_executed 1.0 / json_check 1.5 / command_executed 2.5 / run_command 1.5`
- litellm honours it: not a named `acompletion` parameter, so it rides `**kwargs`; `utils.py:1888` reads `kwargs["num_retries"]` on exception and, for a generic `openai.APIError` (which `InternalServerError` subclasses), sets `retry_strategy="constant_retry"` and calls `acompletion_with_retries`. It is in `all_litellm_params`, so it is stripped before the provider call and `drop_params: True` cannot eat it.
- the new criterion was run against the preserved artefact tree from that nightly (`BillingSuite/resources/solution_folder/{package,process/process}/BillingProcess.json` → exit 0) and against a missing directory and an empty one (both exit 1)

**No coder-eval run claim.** I did not re-run `skill-solution-resources-refresh` end-to-end — that needs tenant credentials I do not have here. The agent trajectory preserved from the nightly shows all three surviving criteria would have passed (it created `BillingSuite`, registered `BillingProcess`, ran `resources refresh` twice), but a real run before merge would be worth having if someone has the environment.

## Follow-ups, not in this PR

- File upstream against `UiPath/coder_eval`: mirror the Bedrock retry policy into `judge_litellm.py`, and collect per-criterion failures in `check_all_async` instead of aborting so a judge-infra fault degrades one criterion rather than zeroing the task
- `tests/README.md` documents `model: azure/gpt-5.6-luna` while all 5 configs say `gpt-5.6-luna` — pre-existing drift, left alone here
- `skill-solution-diagnose-resource-edit` stays judge-only by necessity: coder_eval ships 15 criterion types and none assert on agent text except `llm_judge`/`agent_judge`, so a pure-reasoning diagnose task has no deterministic alternative. It just needs a re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
