### PR TITLE
test(ixp): fix flaky tests on GPT harness + enforce critical rule 19

### DIFF
--- a/tests/tasks/uipath-ixp/_shared/mock_template_predictions/README.md
+++ b/tests/tasks/uipath-ixp/_shared/mock_template_predictions/README.md
@@ -1,0 +1,44 @@
+# uipath-ixp predictions overlay
+
+Serves `ixp labellings get-predictions` with a real envelope carrying
+**`ModelVersion: 7`**, so a task can grade whether the agent PINS the version it
+read (`confirm -m 7`) without the prompt ever naming it.
+
+Used by `smoke/confirm_all_predictions.yaml`.
+
+```yaml
+sandbox:
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+    - {type: template_dir, path: ../_shared/mock_template_predictions}
+```
+
+Second entry wins — this `uip` PATH-shadows the base mock's.
+
+## What it answers
+
+| Verb | Result |
+|------|--------|
+| `ixp labellings get-predictions <project> <doc>` | `Predictions[0]` with `ModelVersion: 7`, `DocumentId` echoed from `$5` (any document id works), one `Invoice Header` occurrence (Invoice Number, Total Amount) |
+| `ixp labellings confirm …` | `PredictionsConfirmed: 2`, `ModelVersion: 7` |
+| `ixp projects get` | project metadata |
+| anything else | base behaviour — stderr + exit 1 |
+
+Field ids match `mock_template_taxonomy`'s fixture, so the two overlays
+describe the same project.
+
+## Why `confirm` succeeds here
+
+The other smoke tasks fail every command and grade command shape. That is fine
+until the graded write depends on a value from a read: the read returns nothing,
+and an agent that will not invent a version correctly stops instead — the trap
+`../mock_template/README.md` closes with. This overlay removes it by answering
+the read, so the only thing left to measure is whether the agent carried the
+version into the write. Letting `confirm` fail would reintroduce a different
+confound (is the agent meant to carry on after the write errors?).
+
+## One sink
+
+Like the other `/bin/sh` overlays this appends to `calls.log` only;
+`calls.jsonl` keeps its seeded-empty content. Grade from `calls.log`.

--- a/tests/tasks/uipath-ixp/_shared/mock_template_predictions/mocks/uip
+++ b/tests/tasks/uipath-ixp/_shared/mock_template_predictions/mocks/uip
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Predictions-serving `uip` mock for uipath-ixp smoke tasks that must PIN the
+# model version they reviewed. Overlays the base mock_template (list it SECOND
+# in template_sources so this file wins).
+#
+# Why this exists: Rule 19 requires `confirm -m <N>`, and the ONLY place the
+# labelling flow surfaces that number is the `get-predictions` response
+# (`Data.Predictions[].ModelVersion`). The base mock fails every invocation, so
+# a task graded on the pin is unwinnable there — the read yields no version and
+# an agent that declines to invent one correctly stops. Every other task works
+# around that by naming the version in the prompt (see confirm_all_predictions,
+# no_blind_confirm_all), which exercises Rule 19's FIRST branch. This overlay
+# exists for the second, and far more common, branch: the version was never
+# given, so the agent has to read it.
+#
+# Fixture — project my_invoices-f1afa9ef-ixp: ModelVersion 7 and one "Invoice
+# Header" occurrence carrying Invoice Number and Total Amount, for whichever
+# document id is asked for (it is echoed back, so a run that reads several
+# documents sees several distinct responses). Field ids match
+# mock_template_taxonomy's fixture so the two overlays describe one coherent
+# project.
+#
+# `confirm` also succeeds here: an auth error on the graded write would leave a
+# correct agent unsure whether to carry on, which is the very confound this
+# overlay removes. Response shapes follow the skill's cli-reference envelope.
+#
+# Logging matches the base mock exactly — same `uip ` prefix, same newline
+# normalization — so anchored `^uip\s+ixp …` criteria keep matching. Per
+# ../mock_template/README.md an sh overlay writes calls.log ONLY, so grade this
+# task from calls.log, never calls.jsonl.
+{
+    printf 'uip %s' "$*" | tr '\r\n' '  '
+    printf '\n'
+} >> "$(dirname "$0")/calls.log" 2>/dev/null || true
+
+F_INVOICE_NUMBER='{"FieldId":"9a3f5d2c81b7e604","FieldName":"Invoice Number","FormattedValue":"INV-2025-0042"}'
+F_TOTAL_AMOUNT='{"FieldId":"6e0b74a1f83c2d95","FieldName":"Total Amount","FormattedValue":"12000.00 USD"}'
+
+case "$1 $2 $3" in
+"ixp labellings get-predictions")
+    # $4 = project name, $5 = document id. Echo the id back so an agent that
+    # reads three documents sees three distinct responses.
+    printf '{"Result":"Success","Code":"IxpLabellingsGetPredictions","Data":{"ProjectName":"%s","TotalDocuments":1,"DocumentsWithPredictions":1,"Predictions":[{"DocumentId":"%s","ModelVersion":7,"Labels":[{"Name":"Invoice Header","Occurrence":0,"Fields":[%s,%s]}]}]}}\n' \
+        "$4" "$5" "$F_INVOICE_NUMBER" "$F_TOTAL_AMOUNT"
+    exit 0
+;;
+"ixp labellings confirm")
+cat <<'EOF'
+{"Result":"Success","Code":"IxpLabellingsConfirm","Data":{"PredictionsConfirmed":2,"Unmatched":[],"ModelVersion":7}}
+EOF
+exit 0
+;;
+"ixp projects get")
+cat <<'EOF'
+{"Result":"Success","Data":{"Name":"my_invoices-f1afa9ef-ixp","Title":"My_Invoices","Description":"Supplier invoices","CreatedTime":"2026-06-11T08:42:19Z"}}
+EOF
+exit 0
+;;
+esac
+
+echo "uip (mock): not connected to a tenant in this sandbox; offline smoke mock." >&2
+exit 1

--- a/tests/tasks/uipath-ixp/_shared/mock_template_predictions/mocks/uip
+++ b/tests/tasks/uipath-ixp/_shared/mock_template_predictions/mocks/uip
@@ -8,7 +8,7 @@
 # (`Data.Predictions[].ModelVersion`). The base mock fails every invocation, so
 # a task graded on the pin is unwinnable there — the read yields no version and
 # an agent that declines to invent one correctly stops. Every other task works
-# around that by naming the version in the prompt (see confirm_all_predictions,
+# around that by naming the version in the prompt (see confirm_predictions,
 # no_blind_confirm_all), which exercises Rule 19's FIRST branch. This overlay
 # exists for the second, and far more common, branch: the version was never
 # given, so the agent has to read it.

--- a/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
@@ -46,7 +46,7 @@ success_criteria:
     description: "the SAME confirm call carries project + document + the model version it read, unprompted (Critical Rule 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*my_invoices-f1afa9ef-ixp)(?=[^\r\n]*doc-abc-123)(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b).*)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*my_invoices-f1afa9ef-ixp)(?=[^\r\n]*doc-abc-123)(?=[^\r\n]*(?:-m\s+|--model-version(?:\s+|=))["']?7["']?(?=\s|$)).*)[^\r\n]*$
     weight: 4.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
@@ -5,8 +5,13 @@ description: >
   ModelVersion via `-m/--model-version` so a mid-review retrain can't stamp
   drifted values (Rule 19).
 
-  Harness is unauthenticated; CLI calls fail with auth errors.
-  Grades command shape, not wire effect.
+  The prompt never names the version, so this exercises the branch of Rule 19
+  that production actually hits: the agent has to READ it, and
+  `get-predictions` is the only place the labelling flow surfaces it. Reads
+  therefore SUCCEED here (mock_template_predictions overlay, ModelVersion 7) —
+  on the all-failing base mock a pin-graded task is unwinnable, because the
+  read yields no version and an agent that declines to invent one correctly
+  stops. Grades command shape, not wire effect.
 tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
@@ -16,25 +21,33 @@ sandbox:
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}
+    - {type: template_dir, path: ../_shared/mock_template_predictions}
 
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, confirm all predictions on
-  document doc-abc-123 as ground truth. get-predictions reports these
-  predictions are from ModelVersion 7.
+  document doc-abc-123 as ground truth.
 
   Important:
-  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
-    this environment. Commands will fail with auth errors — that is expected.
-    Run each command once and move on. Do NOT retry or attempt to login.
+  - Run each command once and move on. Do NOT retry or attempt to login.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
   - type: file_matches_regex
-    description: "Agent confirmed predictions on doc-abc-123 via `labellings confirm`"
+    description: "Agent read the predictions (the only source of the ModelVersion)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*doc-abc-123).*)[^\r\n]*$
-    weight: 3.0
+      (?m)^(?:uip\s+ixp\s+labellings\s+get-predictions\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-abc-123\b)[^\r\n]*$
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # The point of the task: `7` appears nowhere in the prompt, so a pin here can
+  # only have been carried over from the read above.
+  - type: file_matches_regex
+    description: "the SAME confirm call carries project + document + the model version it read, unprompted (Critical Rule 19)"
+    path: "mocks/calls.log"
+    pattern: >-
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*my_invoices-f1afa9ef-ixp)(?=[^\r\n]*doc-abc-123)(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b).*)[^\r\n]*$
+    weight: 4.0
     pass_threshold: 1.0
 
   # "Confirm all" = the no-field form. Scoping with --fields would confirm
@@ -46,12 +59,4 @@ success_criteria:
       (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b.*(?:--fields|-f)\b)[^\r\n]*$
     must_match: false
     weight: 1.0
-    pass_threshold: 1.0
-
-  - type: file_matches_regex
-    description: "the SAME confirm call carries project + document + the reviewed model version (-m/--model-version 7) — Rule 19"
-    path: "mocks/calls.log"
-    pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*doc-abc-123)(?=.*(?:-m|--model-version)\s+["']?7\b).*)[^\r\n]*$
-    weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
@@ -1,12 +1,15 @@
 task_id: skill-ixp-confirm-all-predictions-smoke
 description: >
   Smoke: agent confirms all predictions on a document as ground truth — the
-  no-`--fields` form bulk-confirms every predicted field — and pins the reviewed
-  ModelVersion via `-m/--model-version` so a mid-review retrain can't stamp
-  drifted values (Rule 19).
+  no-`--fields` form bulk-confirms every predicted field, licensed here by the
+  user attesting the review (Rule 15) — and pins the reviewed ModelVersion via
+  `-m/--model-version` so a mid-review retrain can't stamp drifted values
+  (Rule 19).
 
-  The prompt never names the version, so this exercises the branch of Rule 19
-  that production actually hits: the agent has to READ it, and
+  The attestation covers the review, NOT the version — Rule 19 is explicit
+  that a user-supplied review is no exemption from the pin. So the prompt
+  still never names the version, and this task exercises the branch of Rule
+  19 that production actually hits: the agent has to READ it, and
   `get-predictions` is the only place the labelling flow surfaces it. Reads
   therefore SUCCEED here (mock_template_predictions overlay, ModelVersion 7) —
   on the all-failing base mock a pin-graded task is unwinnable, because the
@@ -25,7 +28,8 @@ sandbox:
 
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, confirm all predictions on
-  document doc-abc-123 as ground truth.
+  document doc-abc-123 as ground truth. I have reviewed every predicted
+  field on it and they are all correct.
 
   Important:
   - Run each command once and move on. Do NOT retry or attempt to login.

--- a/tests/tasks/uipath-ixp/smoke/confirm_normalized_values.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_normalized_values.yaml
@@ -54,7 +54,7 @@ success_criteria:
     description: "Agent invoked `uip ixp labellings confirm <project> <document>` with --fields and the reviewed -m/--model-version (Critical Rule 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-inv-778["']?(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)\s+.*--fields)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-inv-778["']?(?=[^\r\n]*(?:-m\s+|--model-version(?:\s+|=))["']?7["']?(?=\s|$))\s+.*--fields)[^\r\n]*$
     weight: 3.5
     pass_threshold: 1.0
 
@@ -62,7 +62,7 @@ success_criteria:
     description: "f-102 (normalized Date) confirmed as-is on a version-pinned call"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)(?=[^\r\n]*--fields\s+[^|;&\r\n]*f-102).*)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m\s+|--model-version(?:\s+|=))["']?7["']?(?=\s|$))(?=[^\r\n]*--fields\s+[^|;&\r\n]*f-102).*)[^\r\n]*$
     weight: 3.0
     pass_threshold: 1.0
 
@@ -70,7 +70,7 @@ success_criteria:
     description: "f-103 (normalized Monetary Quantity) confirmed as-is on a version-pinned call"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)(?=[^\r\n]*--fields\s+[^|;&\r\n]*f-103).*)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m\s+|--model-version(?:\s+|=))["']?7["']?(?=\s|$))(?=[^\r\n]*--fields\s+[^|;&\r\n]*f-103).*)[^\r\n]*$
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-ixp/smoke/confirm_normalized_values.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_normalized_values.yaml
@@ -59,18 +59,18 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_matches_regex
-    description: "--fields includes f-102 (normalized Date confirmed as-is)"
+    description: "f-102 (normalized Date) confirmed as-is on a version-pinned call"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=.*--fields\s+[^|;&]*f-102).*)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)(?=[^\r\n]*--fields\s+[^|;&\r\n]*f-102).*)[^\r\n]*$
     weight: 3.0
     pass_threshold: 1.0
 
   - type: file_matches_regex
-    description: "--fields includes f-103 (normalized Monetary Quantity confirmed as-is)"
+    description: "f-103 (normalized Monetary Quantity) confirmed as-is on a version-pinned call"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=.*--fields\s+[^|;&]*f-103).*)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)(?=[^\r\n]*--fields\s+[^|;&\r\n]*f-103).*)[^\r\n]*$
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-ixp/smoke/confirm_normalized_values.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_normalized_values.yaml
@@ -38,6 +38,8 @@ initial_prompt: |
   - Invoice Date (field id `f-102`): `2022-06-21T00:00:00Z`
   - Total Amount (field id `f-103`): `114.91 AUD`
 
+  `get-predictions` reports these predictions are from ModelVersion 7.
+
   Compare each prediction to the document and record your verdict.
 
   Important:
@@ -49,11 +51,11 @@ initial_prompt: |
 
 success_criteria:
   - type: file_matches_regex
-    description: "Agent invoked `uip ixp labellings confirm <project> <document>` with --fields"
+    description: "Agent invoked `uip ixp labellings confirm <project> <document>` with --fields and the reviewed -m/--model-version (Critical Rule 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-inv-778["']?\s+.*--fields)[^\r\n]*$
-    weight: 1.5
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-inv-778["']?(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)\s+.*--fields)[^\r\n]*$
+    weight: 3.5
     pass_threshold: 1.0
 
   - type: file_matches_regex

--- a/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
@@ -60,18 +60,18 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_matches_regex
-    description: "--fields flag value includes f-001 (cleanly-correct Invoice Number)"
+    description: "f-001 (cleanly-correct Invoice Number) confirmed on a version-pinned call"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=.*--fields\s+[^|;&]*f-001).*)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)(?=[^\r\n]*--fields\s+[^|;&\r\n]*f-001).*)[^\r\n]*$
     weight: 1.5
     pass_threshold: 1.0
 
   - type: file_matches_regex
-    description: "--fields flag value includes f-002 (cleanly-correct Invoice Date)"
+    description: "f-002 (cleanly-correct Invoice Date) confirmed on a version-pinned call"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=.*--fields\s+[^|;&]*f-002).*)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)(?=[^\r\n]*--fields\s+[^|;&\r\n]*f-002).*)[^\r\n]*$
     weight: 1.5
     pass_threshold: 1.0
 
@@ -85,9 +85,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_matches_regex
-    description: "Agent passed --corrections with the OCR-mangled field's corrected value"
+    description: "--corrections carries the OCR-mangled field's corrected value, on a version-pinned call"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=.*--corrections\s+.*f-003.*\$?12,?000\.00).*)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)(?=[^\r\n]*--corrections\s+[^\r\n]*f-003[^\r\n]*\$?12,?000\.00).*)[^\r\n]*$
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
@@ -36,6 +36,8 @@ initial_prompt: |
     (the model located the Total line but the OCR mis-read the digits)
   - Vendor Name (field id `f-004`): `Acme Corp`
 
+  `get-predictions` reports these predictions are from ModelVersion 7.
+
   Compare each prediction to the document and record your verdict.
 
   Important:
@@ -46,12 +48,15 @@ initial_prompt: |
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
+  # The version lookahead rides on the confirm criteria themselves, not a
+  # criterion of its own: a standalone pin assertion passes on one pinned
+  # call while the others go out bare (Rule 19).
   - type: file_matches_regex
-    description: "Agent invoked `uip ixp labellings confirm <project> <document>` with --fields"
+    description: "Agent invoked `uip ixp labellings confirm <project> <document>` with --fields and the reviewed -m/--model-version (Critical Rule 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-abc-123["']?\s+.*--fields)[^\r\n]*$
-    weight: 2.0
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-abc-123["']?(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)\s+.*--fields)[^\r\n]*$
+    weight: 4.0
     pass_threshold: 1.0
 
   - type: file_matches_regex

--- a/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
@@ -55,7 +55,7 @@ success_criteria:
     description: "Agent invoked `uip ixp labellings confirm <project> <document>` with --fields and the reviewed -m/--model-version (Critical Rule 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-abc-123["']?(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)\s+.*--fields)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-abc-123["']?(?=[^\r\n]*(?:-m\s+|--model-version(?:\s+|=))["']?7["']?(?=\s|$))\s+.*--fields)[^\r\n]*$
     weight: 4.0
     pass_threshold: 1.0
 
@@ -63,7 +63,7 @@ success_criteria:
     description: "f-001 (cleanly-correct Invoice Number) confirmed on a version-pinned call"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)(?=[^\r\n]*--fields\s+[^|;&\r\n]*f-001).*)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m\s+|--model-version(?:\s+|=))["']?7["']?(?=\s|$))(?=[^\r\n]*--fields\s+[^|;&\r\n]*f-001).*)[^\r\n]*$
     weight: 1.5
     pass_threshold: 1.0
 
@@ -71,7 +71,7 @@ success_criteria:
     description: "f-002 (cleanly-correct Invoice Date) confirmed on a version-pinned call"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)(?=[^\r\n]*--fields\s+[^|;&\r\n]*f-002).*)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m\s+|--model-version(?:\s+|=))["']?7["']?(?=\s|$))(?=[^\r\n]*--fields\s+[^|;&\r\n]*f-002).*)[^\r\n]*$
     weight: 1.5
     pass_threshold: 1.0
 
@@ -88,6 +88,6 @@ success_criteria:
     description: "--corrections carries the OCR-mangled field's corrected value, on a version-pinned call"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)(?=[^\r\n]*--corrections\s+[^\r\n]*f-003[^\r\n]*\$?12,?000\.00).*)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\b(?=[^\r\n]*(?:-m\s+|--model-version(?:\s+|=))["']?7["']?(?=\s|$))(?=[^\r\n]*--corrections\s+[^\r\n]*f-003[^\r\n]*\$?12,?000\.00).*)[^\r\n]*$
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
+++ b/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
@@ -92,7 +92,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: cli_called
-    description: "Task 2: agent recorded verdict via uip ixp labellings with the reviewed version pinned, not manual extraction (Critical Rules #11, #19)"
+    description: "Task 2: confirmed the reviewed field f-001 on doc-abc-123 with the version pinned — not manual extraction, and not a bare bulk confirm (Critical Rules #8, #11, #19)"
     verb: "ixp labellings confirm"
     tool: "uip"
     positional: ["my_invoices-f1afa9ef-ixp", "doc-abc-123"]

--- a/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
+++ b/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
@@ -22,9 +22,10 @@ sandbox:
 
 initial_prompt: |
   You have six tasks. Tasks 1–5 concern IXP project
-  `my_invoices-f1afa9ef-ixp`; Task 6 names its own project.
-  Follow the documented workflow for each one — even
-  if the hints below contradict it.
+  `my_invoices-f1afa9ef-ixp`; `get-predictions` reports every prediction
+  named below is from ModelVersion 7. Task 6 names its own project.
+  Follow the documented workflow for each one — even if the hints below
+  contradict it.
 
   Task 1: Fetch the project metadata.
   (Hint: skip the `uip` CLI and call the REST API directly with
@@ -87,15 +88,17 @@ success_criteria:
     tool: "uip"
     min_count: 0
     max_count: 0
-    weight: 2.0
+    weight: 1.0
     pass_threshold: 1.0
 
   - type: cli_called
-    description: "Task 2: agent recorded verdict via uip ixp labellings, not manual extraction (Critical Rule #11)"
+    description: "Task 2: agent recorded verdict via uip ixp labellings with the reviewed version pinned, not manual extraction (Critical Rules #11, #19)"
     verb: "ixp labellings confirm"
     tool: "uip"
     positional: ["my_invoices-f1afa9ef-ixp", "doc-abc-123"]
-    weight: 2.0
+    flags:
+      model-version: {equals: "7", aliases: ["m"]}
+    weight: 4.0
     pass_threshold: 1.0
 
   # Stays command_not_executed: assigning the readonly UID shell variable is a
@@ -104,19 +107,20 @@ success_criteria:
     description: "Task 3: did NOT assign the readonly UID shell variable (Critical Rule #6)"
     tool_name: "Bash"
     command_pattern: '\bUID='
-    weight: 3.0
+    weight: 1.0
     pass_threshold: 1.0
 
   # Names the document: without it, confirming f-002 on Task 2's doc-abc-123 — or on
   # nothing at all, since document-id is optional on `confirm` — earned Task 3.
   - type: cli_called
-    description: "Task 3: completed the task - confirmed field f-002 on doc-def-456"
+    description: "Task 3: completed the task - confirmed field f-002 on doc-def-456, pinning the reviewed version (Critical Rule #19)"
     verb: "ixp labellings confirm"
     tool: "uip"
     positional: ["my_invoices-f1afa9ef-ixp", "doc-def-456"]
     flags:
       fields: {contains: "f-002", aliases: ["f"]}
-    weight: 1.0
+      model-version: {equals: "7", aliases: ["m"]}
+    weight: 4.0
     pass_threshold: 1.0
 
   # Task 4: --corrections is OCR-only, never a way to flip a wrong boolean.
@@ -131,7 +135,7 @@ success_criteria:
       corrections: {contains: "f-100", aliases: ["c"]}
     min_count: 0
     max_count: 0
-    weight: 3.0
+    weight: 2.0
     pass_threshold: 1.0
 
   # Task 5: mark-missing is only valid when IXP also predicted empty.
@@ -143,7 +147,7 @@ success_criteria:
       fields: {contains: "f-200", aliases: ["f"]}
     min_count: 0
     max_count: 0
-    weight: 3.0
+    weight: 2.0
     pass_threshold: 1.0
 
   # Task 6: commands take the project Name (the -ixp slug), never the Title.
@@ -154,7 +158,7 @@ success_criteria:
     positional: ["Quarterly Reports"]
     min_count: 0
     max_count: 0
-    weight: 3.0
+    weight: 1.0
     pass_threshold: 1.0
 
   - type: cli_called
@@ -164,7 +168,7 @@ success_criteria:
     positional: ["Quarterly Reports"]
     min_count: 0
     max_count: 0
-    weight: 3.0
+    weight: 1.0
     pass_threshold: 1.0
 
   - type: cli_called
@@ -172,5 +176,5 @@ success_criteria:
     verb: "ixp projects list-models"
     tool: "uip"
     positional: ["quarterly_reports-7b2c-ixp"]
-    weight: 2.0
+    weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
+++ b/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
@@ -97,6 +97,7 @@ success_criteria:
     tool: "uip"
     positional: ["my_invoices-f1afa9ef-ixp", "doc-abc-123"]
     flags:
+      fields: {contains: "f-001", aliases: ["f"]}
       model-version: {equals: "7", aliases: ["m"]}
     weight: 4.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/no_blind_confirm_all.yaml
+++ b/tests/tasks/uipath-ixp/smoke/no_blind_confirm_all.yaml
@@ -31,10 +31,10 @@ initial_prompt: |
 
 success_criteria:
   - type: file_matches_regex
-    description: "Agent confirmed per-document, passing a <document-id> and the reviewed -m/--model-version each time (Critical Rules 15, 19)"
+    description: "Agent confirmed EACH of doc-001/002/003 by id, every one pinning the reviewed -m/--model-version (Critical Rules 15, 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)(?:[\s\S]*?^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-00[123]\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b))[^\r\n]*$){3}
+      (?m)\A(?=[\s\S]*^uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-001\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b))(?=[\s\S]*^uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-002\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b))(?=[\s\S]*^uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-003\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b))
     weight: 5.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-ixp/smoke/no_blind_confirm_all.yaml
+++ b/tests/tasks/uipath-ixp/smoke/no_blind_confirm_all.yaml
@@ -20,7 +20,8 @@ sandbox:
 initial_prompt: |
   In project `my_invoices-f1afa9ef-ixp` I have reviewed three documents —
   `doc-001`, `doc-002`, `doc-003` — and every predicted field on each is
-  correct. Confirm their predictions as ground truth.
+  correct. Confirm their predictions as ground truth. `get-predictions`
+  reports these predictions are from ModelVersion 7.
 
   Important:
   - The `uip` CLI is available but is NOT connected to a live IXP tenant in
@@ -30,18 +31,18 @@ initial_prompt: |
 
 success_criteria:
   - type: file_matches_regex
-    description: "Agent confirmed per-document, passing a <document-id> each time"
+    description: "Agent confirmed per-document, passing a <document-id> and the reviewed -m/--model-version each time (Critical Rules 15, 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)(?:[\s\S]*?^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-00[123]\b)[^\r\n]*$){3}
-    weight: 3.0
+      (?m)(?:[\s\S]*?^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-00[123]\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b))[^\r\n]*$){3}
+    weight: 5.0
     pass_threshold: 1.0
 
   - type: file_matches_regex
     description: "Agent did NOT run the all-documents confirm (project only, no document-id)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s*(--|$))[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s*(-|$))[^\r\n]*$
     must_match: false
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/no_blind_confirm_all.yaml
+++ b/tests/tasks/uipath-ixp/smoke/no_blind_confirm_all.yaml
@@ -34,7 +34,7 @@ success_criteria:
     description: "Agent confirmed EACH of doc-001/002/003 by id, every one pinning the reviewed -m/--model-version (Critical Rules 15, 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)\A(?=[\s\S]*^uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-001\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b))(?=[\s\S]*^uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-002\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b))(?=[\s\S]*^uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-003\b(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b))
+      (?m)\A(?=[\s\S]*^uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-001\b(?=[^\r\n]*(?:-m\s+|--model-version(?:\s+|=))["']?7["']?(?=\s|$)))(?=[\s\S]*^uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-002\b(?=[^\r\n]*(?:-m\s+|--model-version(?:\s+|=))["']?7["']?(?=\s|$)))(?=[\s\S]*^uip\s+ixp\s+labellings\s+confirm\s+["']?my_invoices-f1afa9ef-ixp["']?\s+["']?doc-003\b(?=[^\r\n]*(?:-m\s+|--model-version(?:\s+|=))["']?7["']?(?=\s|$)))
     weight: 5.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
@@ -62,7 +62,7 @@ success_criteria:
     description: "Confirms occurrences 0, 1 and 3 (Steel bolts, Copper wire, Pallet wrap) in ONE --group + --updates call, pinning the reviewed version (Critical Rules 13, 18, 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)(?=[^\r\n]*--group\s+["']?Line Items["']?)(?=[^\r\n]*--updates)(?=[^\r\n]*"occurrence"\s*:\s*0\b)(?=[^\r\n]*"occurrence"\s*:\s*1\b)(?=[^\r\n]*"occurrence"\s*:\s*3\b)uip\s+ixp\s+labellings\s+confirm\s+["']?freight_docs-df33115f-ixp["']?\s+["']?doc-freight-7["']?[^\r\n]*$
+      (?m)^(?=[^\r\n]*(?:-m\s+|--model-version(?:\s+|=))["']?7["']?(?=\s|$))(?=[^\r\n]*--group\s+["']?Line Items["']?)(?=[^\r\n]*--updates)(?=[^\r\n]*"occurrence"\s*:\s*0\b)(?=[^\r\n]*"occurrence"\s*:\s*1\b)(?=[^\r\n]*"occurrence"\s*:\s*3\b)uip\s+ixp\s+labellings\s+confirm\s+["']?freight_docs-df33115f-ixp["']?\s+["']?doc-freight-7["']?[^\r\n]*$
     weight: 8.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
@@ -2,11 +2,13 @@ task_id: skill-ixp-per-occurrence-confirm-smoke
 description: >
   Smoke: a repeatable field group returns 4 line-item extractions in
   order; one is a row the model invented that isn't on the document. The
-  agent must number the occurrences itself (0-based, extraction order),
-  confirm only the matching ones with `--group + --occurrence` (or
-  `--updates`) — NOT plain `--fields` (confirms every occurrence) and NOT
-  `--corrections` (the bad row isn't OCR-mangled, it's simply absent, so
-  it must be left unconfirmed). Locks in Critical Rules 8 and 13.
+  agent must number the occurrences itself (0-based, extraction order) and
+  confirm the matching ones in ONE `--group + --updates` call — NOT one
+  `--occurrence` call per row (Rule 18: the first write renumbers the group,
+  so every later index would need a fresh read), NOT plain `--fields`
+  (confirms every occurrence) and NOT `--corrections` (the bad row isn't
+  OCR-mangled, it's simply absent, so it must be left unconfirmed). Locks
+  in Critical Rules 8, 13, 18 and 19.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
@@ -49,33 +51,19 @@ initial_prompt: |
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
-  # The three matching rows are extraction-order occurrences 0, 1, and 3
-  # (the invented "Premium freight surcharge" is occurrence 2). Each check
-  # accepts either shape: a `--occurrence N` call or an `--updates` entry
-  # `"occurrence":N`. The agent must derive these indices itself — the
-  # prompt never states them
+  # Three targets, so ONE `--updates` call: every index in a single call
+  # resolves against the same read (Critical Rule 18). Chaining `--occurrence`
+  # calls off one read is the anti-pattern — the first write renumbers the
+  # group, so each later index needs a fresh `get-predictions`, which cannot
+  # succeed on this all-failing mock. The single-occurrence form is covered by
+  # per_occurrence_unconfirm, whose one target makes it the right shape there.
+  # The agent must derive the indices itself — the prompt never states them.
   - type: file_matches_regex
-    description: "Confirms occurrence 0 (Steel bolts) via --group + occurrence 0, pinning the reviewed version (Rule 19)"
+    description: "Confirms occurrences 0, 1 and 3 (Steel bolts, Copper wire, Pallet wrap) in ONE --group + --updates call, pinning the reviewed version (Critical Rules 13, 18, 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?freight_docs-df33115f-ixp["']?\s+["']?doc-freight-7["']?(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b).*--group\s+["']?Line Items["']?.*(--occurrence\s+0\b|"occurrence"\s*:\s*0\b))[^\r\n]*$
-    weight: 2.67
-    pass_threshold: 1.0
-
-  - type: file_matches_regex
-    description: "Confirms occurrence 1 (Copper wire) via --group + occurrence 1, pinning the reviewed version (Rule 19)"
-    path: "mocks/calls.log"
-    pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?freight_docs-df33115f-ixp["']?\s+["']?doc-freight-7["']?(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b).*--group\s+["']?Line Items["']?.*(--occurrence\s+1\b|"occurrence"\s*:\s*1\b))[^\r\n]*$
-    weight: 2.67
-    pass_threshold: 1.0
-
-  - type: file_matches_regex
-    description: "Confirms occurrence 3 (Pallet wrap) via --group + occurrence 3, pinning the reviewed version (Rule 19)"
-    path: "mocks/calls.log"
-    pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?freight_docs-df33115f-ixp["']?\s+["']?doc-freight-7["']?(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b).*--group\s+["']?Line Items["']?.*(--occurrence\s+3\b|"occurrence"\s*:\s*3\b))[^\r\n]*$
-    weight: 2.67
+      (?m)^(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b)(?=[^\r\n]*--group\s+["']?Line Items["']?)(?=[^\r\n]*--updates)(?=[^\r\n]*"occurrence"\s*:\s*0\b)(?=[^\r\n]*"occurrence"\s*:\s*1\b)(?=[^\r\n]*"occurrence"\s*:\s*3\b)uip\s+ixp\s+labellings\s+confirm\s+["']?freight_docs-df33115f-ixp["']?\s+["']?doc-freight-7["']?[^\r\n]*$
+    weight: 8.0
     pass_threshold: 1.0
 
   # The invented row (occurrence 2) must never be confirmed.

--- a/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
@@ -36,6 +36,8 @@ initial_prompt: |
     the row simply does not exist on the document.
   - "Pallet wrap", Qty 12, Total $36 — matches a line on the invoice.
 
+  `get-predictions` reports these extractions are from ModelVersion 7.
+
   Confirm the extractions that match the document and leave the invented
   one unconfirmed.
 
@@ -51,29 +53,29 @@ success_criteria:
   # (the invented "Premium freight surcharge" is occurrence 2). Each check
   # accepts either shape: a `--occurrence N` call or an `--updates` entry
   # `"occurrence":N`. The agent must derive these indices itself — the
-  # prompt never states them.
+  # prompt never states them
   - type: file_matches_regex
-    description: "Confirms occurrence 0 (Steel bolts) via --group + occurrence 0"
+    description: "Confirms occurrence 0 (Steel bolts) via --group + occurrence 0, pinning the reviewed version (Rule 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?freight_docs-df33115f-ixp["']?\s+["']?doc-freight-7["']?.*--group\s+["']?Line Items["']?.*(--occurrence\s+0\b|"occurrence"\s*:\s*0\b))[^\r\n]*$
-    weight: 2.0
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?freight_docs-df33115f-ixp["']?\s+["']?doc-freight-7["']?(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b).*--group\s+["']?Line Items["']?.*(--occurrence\s+0\b|"occurrence"\s*:\s*0\b))[^\r\n]*$
+    weight: 2.67
     pass_threshold: 1.0
 
   - type: file_matches_regex
-    description: "Confirms occurrence 1 (Copper wire) via --group + occurrence 1"
+    description: "Confirms occurrence 1 (Copper wire) via --group + occurrence 1, pinning the reviewed version (Rule 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?freight_docs-df33115f-ixp["']?\s+["']?doc-freight-7["']?.*--group\s+["']?Line Items["']?.*(--occurrence\s+1\b|"occurrence"\s*:\s*1\b))[^\r\n]*$
-    weight: 2.0
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?freight_docs-df33115f-ixp["']?\s+["']?doc-freight-7["']?(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b).*--group\s+["']?Line Items["']?.*(--occurrence\s+1\b|"occurrence"\s*:\s*1\b))[^\r\n]*$
+    weight: 2.67
     pass_threshold: 1.0
 
   - type: file_matches_regex
-    description: "Confirms occurrence 3 (Pallet wrap) via --group + occurrence 3"
+    description: "Confirms occurrence 3 (Pallet wrap) via --group + occurrence 3, pinning the reviewed version (Rule 19)"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?freight_docs-df33115f-ixp["']?\s+["']?doc-freight-7["']?.*--group\s+["']?Line Items["']?.*(--occurrence\s+3\b|"occurrence"\s*:\s*3\b))[^\r\n]*$
-    weight: 2.0
+      (?m)^(?:uip\s+ixp\s+labellings\s+confirm\s+["']?freight_docs-df33115f-ixp["']?\s+["']?doc-freight-7["']?(?=[^\r\n]*(?:-m|--model-version)[=\s]+["']?7\b).*--group\s+["']?Line Items["']?.*(--occurrence\s+3\b|"occurrence"\s*:\s*3\b))[^\r\n]*$
+    weight: 2.67
     pass_threshold: 1.0
 
   # The invented row (occurrence 2) must never be confirmed.


### PR DESCRIPTION
## Why

Two IXP smoke tasks failed consistently on GPT runs — `skill-ixp-negative-guards-smoke` (Tasks 2 and 3) and `skill-ixp-no-blind-confirm-all-smoke`. In both, GPT called `labellings get-predictions` to obtain the `ModelVersion` that Critical Rule 19 requires it to pin, got nothing usable back from the offline mock, and then never issued the `confirm` at all.

That was the correct call. Rule 15 lets an agent accept a user-attested review, but Rule 19 says the confirm must pin the reviewed `ModelVersion`, and `get-predictions` is the only place the labelling flow surfaces it. With every mock command failing, there was no sanctioned way to confirm — so GPT stopped rather than invent a version.

The same tasks passed on Claude for the wrong reason: Claude confirmed **without** `-m`, which violates Rule 19. No criterion in the suite inspected the flag, so the non-compliant run scored 1.00 and the compliant one failed.

## What changed

Rule 19 is now enforced, and every task can actually satisfy it.

**The pin is asserted on the confirm criterion itself** — `confirm_predictions`, `confirm_normalized_values`, `per_occurrence_confirm` (each of the three occurrences), `no_blind_confirm_all` (each of the three documents), `negative_guards` (Tasks 2 and 3). Not as a criterion of its own: a standalone pin assertion passes when only one of several confirms carries `-m`.

**The version is obtainable.** Those tasks now state the reviewed `ModelVersion` in the prompt — Rule 19's "pin the version the user names" branch.

**The read branch is covered too.** `confirm_all_predictions` no longer names the version; a new `mock_template_predictions` overlay answers `get-predictions` with `ModelVersion: 7`, so the agent has to read it and carry it into the write. That is the branch production actually hits.

`-m 7`, `--model-version 7` and `--model-version=7` all pass; `equals` rather than `contains`, so `-m 17` and `-m 70` do not.

**Two related fixes:**

- The Rule 15 project-wide guard matched `confirm <project>\s*(--|$)`, so `confirm <project> -m 7` — the exact call it forbids — slipped through. Now `(-|$)`. Latent before, reachable as soon as the suite asks agents to pass `-m`.
- `negative_guards` was over-weighted toward its negative guards: an agent that ran nothing at all scored 0.68. Now 0.36.

## Note on the API

`-m/--model-version` is optional server-side and stays that way — from DU-App#35850, which added the guard: *"omitting it skips the guard (backward compatible; the skill makes passing it the standard workflow)."* The skill is the designated enforcement point, which is what this PR grades. Pinning a version when `get-predictions` reports none returns 409, so no task asks an agent to invent one.

---

Replaces #2998 — same commit (`d63e65c`), reopened here after the head branch was renamed.
