### PR TITLE
Accept a table as bundle name/code pairing, not just parentheses

### DIFF
--- a/tests/tasks/uipath-platform/licensing/users_licenses_get.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_get.yaml
@@ -4,7 +4,7 @@ description: >
   user currently leases and reports the result using the friendly-name format
   from the docs. Verifies (1) `uip platform users licenses get <user>
   --output json` shape, (2) docs page fetch for code resolution, and
-  (3) the written answer reports bundles as `<Friendly Name> (<CODE>)`.
+  (3) the written answer pairs each bundle's friendly name with its code.
   CLI auth failure is expected in this offline environment.
 tags: [uipath-platform, smoke, licensing, users, mode:operate, lifecycle:discover]
 
@@ -78,13 +78,14 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  # Pairing, not typography: a friendly name followed by its parenthesised
-  # code, tolerating markdown (backticks, bold, list bullets) around either
-  # half. Rejects the two failure modes that matter — bare codes with no
-  # friendly name, and friendly names with no code.
+  # Pairing, not typography: a friendly name followed by its code, separated
+  # by either "(" (inline, "Attended - Named User (ATTUNU)") or "|" (a markdown
+  # table row). Markdown around either half is tolerated. Rejects the two
+  # failure modes that matter — bare codes with no friendly name, and friendly
+  # names with no code.
   - type: run_command
-    description: "bundles.md reports at least one bundle as `<Friendly Name> (<CODE>)`"
-    command: "grep -Eq '(Attended|Unattended|Developer|Tester|Named User|Citizen|Automation)[A-Za-z .*`-]{0,40}\\( *[`*]* *[A-Z][A-Z0-9]{3,} *[`*]* *\\)' bundles.md"
+    description: "bundles.md pairs at least one bundle's friendly name with its code (inline or table)"
+    command: "grep -Eq '(Attended|Unattended|Developer|Tester|Named User|Citizen|Automation)[A-Za-z .*`-]{0,40}[(|][ `*]*[A-Z][A-Z0-9]{3,}' bundles.md"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0


### PR DESCRIPTION
Nightly [2026-09-02_09-32-42](https://coder-evalboard.uipath-dev.com/runs/2026-09-02_09-32-42/skill-platform-licensing-users-licenses-get) failed `users-licenses-get` at **0.733** (codex / gpt-5.6-terra). Four of five criteria passed.

This is a regression in the criterion I added in #2955 (merged 07:25 today; this nightly ran at 09:32 with it).

## What the agent did

It complied with the prompt — friendly name *and* code for three bundles — but laid them out as a markdown table:

```
| Bundle                            | Code          | Assignment source              |
| Automation Developer - Named User | `RPADEVPRONU` | Not determined (user not found)|
| Attended - Named User             | `ATTUNU`      | Not determined (user not found)|
```

My regex required the code in parentheses immediately after the name, so a table column separator failed it. That's the same typography pedantry the `llm_judge` it replaced was guilty of — I traded an LLM's fussiness for my own.

## Fix

Accept `(` **or** `|` as the separator between a friendly name and its code. One line changed.

## Verification

Nine fixtures, including both real agent artifacts:

| Fixture | Want | Result |
|---|---|---|
| Today's markdown table | accept | accept |
| Bullets with backticks (the green smoke run) | accept | accept |
| Plain inline `Automation Developer Named User (RPADEVPRONU)` | accept | accept |
| Bold `**Attended Named User** (**ATTUNU**)` | accept | accept |
| Codes only, no friendly names | reject | reject |
| Friendly names only, no codes | reject | reject |
| The original pre-fix artifact with no pairs | reject | reject |
| Table whose second column is `Not found` / `TBD` | reject | reject |
| Table header with no data rows | reject | reject |

The last two are new adversarial cases for the `|` branch specifically — a pipe separator must still be followed by something code-shaped, so widening the separator did not weaken the check.

## Note

This is the third iteration on this one criterion. The pattern across all three: each fix was verified against the artifacts I had, and the next agent produced a legitimate format I had not seen. If it recurs, the criterion is probably better expressed as a small `_shared/*.py` checker that tests "a known bundle code and a friendly name appear on the same line", rather than a regex encoding specific separators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)