### PR TITLE
feat(uipath-maestro-flow): port the bpmn reasoning-budget / working-style preamble

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -11,12 +11,12 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 
 # Working style
 
-- **Understand first, then decide.** Read this file and the capability index for the work at hand, then plan against what the CLI verbs do — not a guess. `uip maestro flow <verb> --help` and `registry get <node-type>` are ground truth for flags and node shapes.
-- **Plan the whole path up front, then chain.** Outline the sequence before running anything, batch independent steps into one turn, pipeline the rest. A greenfield build is three turns (rule #10), not ten.
+- **Understand first, then decide.** Read this file and the capability index for the work at hand, then plan against what the CLI verbs do — not a guess. `uip maestro flow <verb> --help` and `uip maestro flow registry get <node-type>` are ground truth for flags and node shapes.
+- **Plan the whole path up front, then chain.** Outline the sequence before running anything, batch independent steps into one turn, pipeline the rest (rule #10). Do not run turn-by-turn what could have been chained.
 - **Inspect an input ONCE.** To learn a shape — a node type's schema, a connector's fields, an existing `.flow`'s nodes — dump it once and search that output. Never re-read a file field-by-field or re-query the registry once per field.
 - **Don't repeat work.** Never rerun a command whose inputs and relevant state are unchanged, or re-read an unchanged file already in context. After a command may have rewritten a file (`node configure`, `format`), re-read it before relying on its contents.
 - **Prefer the CLI to ad-hoc code.** Scripting languages are a last resort for `.flow` edits and need user approval first (rule #9). When code is warranted, write it once with paths as arguments; no near-duplicate inline snippets across turns.
-- **Keep outputs small.** Extract with `--output json --output-filter` (rule #1) so a large envelope never lands in context whole. When a payload must be kept, write it to a file and inspect the file.
+- **Keep outputs small.** Extract with `--output json --output-filter` when you know the fields (rule #1). When the payload is large or the command is slow or side-effecting — `flow debug`, `job traces`, `registry get` — redirect the whole envelope to a file outside the solution tree (`uip maestro flow debug <project-dir> --output json > /tmp/flow-debug.json`) and search the file, so re-reading it never means re-running the command.
 - **Don't do anything unnecessary.** No tool call, file read, or result pulled into context before it is needed.
 
 # UiPath Flow Skill

--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -4,6 +4,21 @@ description: "TRIGGER for `.flow` files, UiPath Flow / Maestro Flow build or edi
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
+# Reasoning budget
+
+- Match reasoning to step difficulty; bias toward acting. For mechanical / IO / format steps, if a `uip` verb covers the task, run it — never hand-derive what the CLI emits (`node configure` detail and `bindings[]`, `format` layout, `registry get` node shapes).
+- Save deep reasoning for the judgments no verb can make for you: node-type selection (the external-service ladder), topology, and how data moves from one node's output into the next node's input.
+
+# Working style
+
+- **Understand first, then decide.** Read this file and the capability index for the work at hand, then plan against what the CLI verbs do — not a guess. `uip maestro flow <verb> --help` and `registry get <node-type>` are ground truth for flags and node shapes.
+- **Plan the whole path up front, then chain.** Outline the sequence before running anything, batch independent steps into one turn, pipeline the rest. A greenfield build is three turns (rule #10), not ten.
+- **Inspect an input ONCE.** To learn a shape — a node type's schema, a connector's fields, an existing `.flow`'s nodes — dump it once and search that output. Never re-read a file field-by-field or re-query the registry once per field.
+- **Don't repeat work.** Never rerun a command whose inputs and relevant state are unchanged, or re-read an unchanged file already in context. After a command may have rewritten a file (`node configure`, `format`), re-read it before relying on its contents.
+- **Prefer the CLI to ad-hoc code.** Scripting languages are a last resort for `.flow` edits and need user approval first (rule #9). When code is warranted, write it once with paths as arguments; no near-duplicate inline snippets across turns.
+- **Keep outputs small.** Extract with `--output json --output-filter` (rule #1) so a large envelope never lands in context whole. When a payload must be kept, write it to a file and inspect the file.
+- **Don't do anything unnecessary.** No tool call, file read, or result pulled into context before it is needed.
+
 # UiPath Flow Skill
 
 Comprehensive guide for creating, editing, validating, debugging, publishing, diagnosing, and evaluating UiPath Flow projects using the `uip` CLI and `.flow` file format. The skill is organized into four capabilities — **Author**, **Operate**, **Diagnose**, **Evaluate** — each with its own index doc.


### PR DESCRIPTION
## What

Adds the `# Reasoning budget` / `# Working style` preamble above the `# UiPath Flow Skill` heading, porting what [`uipath-maestro-bpmn/SKILL.md`](https://github.com/UiPath/skills/blob/main/skills/uipath-maestro-bpmn/SKILL.md?plain=1#L7-L19) has carried since #2622.

+15 lines on an always-loaded file, roughly 500 tokens. That is the cost side of the trade-off; the benefit is below.

## Why

The numbered rules cover *facts* (shapes, flags, ownership). The failures the Flow evals keep surfacing are *habits* that no single rule owns:

- Re-running a command that already answered, to reshape its output (the 2026-09-02 `skill-flow-slack-weather-pipeline` failure, addressed narrowly in #3002).
- Re-querying the registry once per field instead of dumping a node type's schema once.
- Issuing CLI calls turn-by-turn when rule #10 already asks for them chained.
- Hand-deriving layout and connector detail that `format` and `node configure` emit.

Each has a rule or an anti-pattern somewhere. None of them has a stated working style that makes the habit the default before the agent reaches the specific rule. That is what this preamble is for, and it is the same reason maestro-bpmn got one.

## Adaptations from the bpmn original

- **"Run the shipped script" becomes "run the `uip` verb."** maestro-bpmn ships scripts; Flow's mechanical work is CLI verbs, so the bullet names them: `node configure` detail and `bindings[]`, `format` layout, `registry get` node shapes. Same principle, correct mechanism.
- **Deep reasoning points at Flow's actual hard calls** rather than a generic "one hard judgment": node-type selection (the external-service ladder), topology, and cross-node data flow. Those are the three the evals keep catching.
- **Bullets defer to the numbered rules instead of restating them.** #1 for output filters, #9 for CLI vs ad-hoc scripting, #10 for chaining. One maintenance site per fact, so the "3 turns" count stays only in rule #10.
- **"Write code once and reuse" becomes "prefer the CLI to ad-hoc code."** The bpmn version encourages writing scripts. Here rule #9 makes scripting a last resort needing user approval, so the bullet leads with that and keeps the write-once advice for when code is genuinely warranted.
- **Keep-outputs-small names its candidates.** `flow debug`, `job traces`, and `registry get` are the payloads worth redirecting to a file outside the solution tree. Filtering covers "I know the fields"; capture covers "slow, side-effecting, or unrepeatable", so re-reading never means re-running. `> /tmp/*.json` matches existing precedent in `uipath-admin`, `uipath-coded-apps`, and Flow's own `inline-agent/impl.md`.
- Tightened to terse mode per `.claude/rules/token-optimization.md`.

## Notes for review

- The block sits outside every flavor marker, so all flavors inherit it. The studioweb flavor already inherits rules #1/#9/#10 unchanged and overrides only project creation and upload scope, so nothing here contradicts it. Worth a second opinion if a Studio-Web-tool-driven agent should not be pointed at `uip` verbs.
- `check-uip-commands.sh` only scans fenced code blocks, so inline commands in prose are unverified by it. Both inline commands here are fully qualified by hand.
- Checks: `.maintenance/check-all.sh` 9/9, `npm run skills:validate`, `npm run skills:check-links`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)