### PR TITLE
fix(skill-flavors): studioweb — the Flow debug verb is `uip flow debug`

### DIFF
--- a/skill-flavors/studioweb/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skill-flavors/studioweb/uipath-maestro-flow/references/shared/cli-commands.md
@@ -8,7 +8,7 @@
 <!--skill-flavor:upload-pack-note:end-->
 
 <!--skill-flavor:upload-refresh-prereq:start-->
-Re-scan all projects in the solution and sync resource declarations (connections, processes, queues, etc.) from their `bindings_v2.json` files. Creates new resources for bindings not yet in the solution, imports from Orchestrator when a matching resource exists. **Always run this before `uip maestro flow debug`.**
+Re-scan all projects in the solution and sync resource declarations (connections, processes, queues, etc.) from their `bindings_v2.json` files. Creates new resources for bindings not yet in the solution, imports from Orchestrator when a matching resource exists. **Always run this before `uip flow debug`.**
 <!--skill-flavor:upload-refresh-prereq:end-->
 
 <!--skill-flavor:upload-solution-dir-note:start-->
@@ -17,3 +17,27 @@ Re-scan all projects in the solution and sync resource declarations (connections
 
 <!--skill-flavor:upload-command-section:start-->
 <!--skill-flavor:upload-command-section:end-->
+
+<!--skill-flavor:flow-debug-command-usage:start-->
+## uip flow debug
+
+Debug the open Flow through the host. **In Studio Web the verb is `uip flow debug`, not `uip maestro flow debug`** — the browser bundle registers each tool under its own prefix, so `flow` is top-level here even though the Node CLI reaches it only under `uip maestro flow`. The three-token form is not intercepted and lands on a command whose debug service is excluded from the bundle, failing with `TypeError: FlowDebugService is not a constructor`. Authentication comes from the active Studio Web session; there is no `uip login` step.
+
+```bash
+uip flow debug --output json
+
+# Pass input arguments to the flow
+uip flow debug --inputs '{"numberA": 5, "numberB": 7}' --output json
+
+# Target a project other than the active one by name
+uip flow debug "<ProjectName>" --inputs '{"numberA": 5}' --output json
+```
+
+The positional argument is a **project name in the open solution**, not a directory path, and it defaults to the active project. The host runs the already-saved project, so there is no pack or upload step.
+
+> **Only `-i` / `--inputs` is honoured.** The host interceptor accepts the project name and inputs; `--attachment` is not part of its surface and is ignored without warning, so a file-typed input cannot be bound this way. `--bpmn-file` and a local `.xaml` target are rejected with an explicit message. Inline JSON only — `@file` indirection is not supported.
+<!--skill-flavor:flow-debug-command-usage:end-->
+
+<!--skill-flavor:flow-debug-help-pointer:start-->
+Run `uip flow debug --help` for the host's exact surface.
+<!--skill-flavor:flow-debug-help-pointer:end-->

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -147,6 +147,7 @@ uip solution upload <SolutionDir> --output json
 > **This is the default publish path.** When the user asks to "publish" without specifying where, run `uip solution upload <SolutionDir>` to push to Studio Web. Share the resulting URL with the user.
 <!--skill-flavor:upload-command-section:end-->
 
+<!--skill-flavor:flow-debug-command-usage:start-->
 ## uip maestro flow debug
 
 Debug a Flow in the cloud via Studio Web + Orchestrator. **Requires `uip login`.**
@@ -164,6 +165,7 @@ UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
   --attachment <variableId>=<localPath> \
   --attachment <variableId>=<localPath>
 ```
+<!--skill-flavor:flow-debug-command-usage:end-->
 
 The argument is the **project directory path** (the folder containing `project.uiproj`). Use `<ProjectName>/` from the solution dir, or `.` if already inside the project dir. Always run `uip maestro flow validate` first.
 
@@ -183,7 +185,9 @@ The CLI does not validate `<variableId>` — a mismatch uploads successfully the
 
 > **Reading the bound file in a Script node.** A `file` variable hydrates at runtime as an object; read the uploaded name via `$vars.{triggerNodeId}.output.{id}.FullName`. See [variables-and-expressions.md — Runtime shape of a `file` variable](variables-and-expressions.md#file-input).
 
+<!--skill-flavor:flow-debug-help-pointer:start-->
 Run `uip maestro flow debug --help` for other options.
+<!--skill-flavor:flow-debug-help-pointer:end-->
 
 ### Reporting the run back to the user
 


### PR DESCRIPTION
## The issue

The studioweb flavor of `uipath-maestro-flow` teaches `uip maestro flow debug`. In the Studio Web browser bundle that command does not just fail — it fails in a way the agent cannot interpret.

Three mechanisms combine:

1. **The bundle ignores `TOOLS_WHITELIST`.** `build-browser.ts` discovers tools by scanning `packages/*-tool/browser.json` and registers each under its own `metadata.commandPrefix`. So `flow` is a **top-level prefix in the browser**, while the Node CLI — where `flow-tool` is absent from the whitelist — reaches it only as `uip maestro flow`.
2. **Only the flat form is intercepted.** Autopilot's interceptor map keys `flow:debug` and routes it to `runProject()`. `maestro:flow` maps to the *init* interceptor, which declines every non-init verb, so the three-token form falls through to the bundle.
3. **What it falls through to is a stub.** The build aliases `@uipath/flow-tool` onto `src/tool.ts` so `maestro`'s flow branch hydrates. `flow-tool` ships `commands/debug` but lists `./services/flow-debug-service` in `excludedImports`, and excluded modules are replaced by `export const X = () => undefined`. `debug.ts` then runs `new FlowDebugService()` → **`TypeError: FlowDebugService is not a constructor`**.

So the taught form produces a JavaScript type error, not a "command not available" message. The agent has no way to recognise that as "wrong verb for this host."

## Current behaviour vs desired

| | Current | Desired |
|---|---|---|
| Verb taught in the studioweb tree | `uip maestro flow debug` ×6 | `uip flow debug` |
| Result if followed | `TypeError: FlowDebugService is not a constructor` | intercepted, runs the project |
| Positional argument | project **directory path** | project **name** in the open solution |
| Pack/upload step | documented as required | none — the host runs the saved project |
| `--attachment` | documented as supported | stated as silently ignored |
| Default (Node CLI) tree | `uip maestro flow debug` | unchanged |

## Why the one-line fix was not enough

The flavor already had a marked block mentioning the verb, but the file's `## uip maestro flow debug` **section** is unmarked canonical text. Overrides replace only marked blocks, so the composed studioweb tree kept teaching the broken form six times regardless.

This change therefore marks the two canonical passages that carry the verb — the heading plus usage block (`flow-debug-command-usage`) and the `--help` pointer (`flow-debug-help-pointer`) — and supplies studioweb replacements, per `manage-skill-flavors`: mark the smallest complete canonical passage, keep `SKILL.md` and references complete for default consumers, and put only complete replacement blocks in the override.

## Comparing with the Studio Web UI

The UI's **Debug** button and the flat `uip flow debug` are the same operation: both end at `requestStartExecution` on the unified-build `Debug` service, and the host runs the project already saved in the solution. That is why the Studio Web form needs no path, no `uip login` and no upload — the three things the canonical (Node CLI) text spends most of its words on, because there the local project must be packed and pushed to the cloud first.

The override now says what the host interceptor actually accepts, matching its own `--help`: a project **name** defaulting to the active project, `-i`/`--inputs` as inline JSON, and explicit non-support for `--attachment` (silently ignored), `--bpmn-file` and local `.xaml` targets (both rejected with a message), and `@file` indirection.

## Verification

```
skills:validate  → OK, studioweb 176 replacements (was 174)
skills:build     → 2 marker-free trees
skills:pack      → 2 verified tarballs
```

- Composed studioweb tree: `uip flow debug` ×7; the single remaining `uip maestro flow debug` is the explanatory clause that names the wrong form.
- Composed **default** tree: unchanged at 6 occurrences — Node CLI consumers keep the correct form.
- No `skill-flavor:` markers leak into either built tree.

## Deliberately out of scope

`references/operate/run.md` still instructs the agent to report `Data.studioWebUrl` and `Data.instanceId` as the first two lines of any debug summary. The host interceptor returns neither — it returns status, run logs and a trace digest, and its own comment notes "no `studioWebUrl` return like the Node CLI gives." That is a reporting-contract fix rather than a command-form one, and it belongs with the wider Autopilot run/debug work (see UiPath/Autopilot#5536, which restores the runtime prefix-list guidance that would have steered the agent off the broken verb in the first place).