### PR TITLE
test: add num_retries to checker_context api_route

### DIFF
--- a/tests/experiments/activation.yaml
+++ b/tests/experiments/activation.yaml
@@ -56,6 +56,7 @@ defaults:
       model: gpt-5.6-luna
       params:
         api_version: "2024-05-01"
+        num_retries: 5
       env_params:
         api_base: CODEX_BASE_URL
         api_key: CODEX_API_KEY

--- a/tests/experiments/default.yaml
+++ b/tests/experiments/default.yaml
@@ -29,6 +29,7 @@ defaults:
       model: gpt-5.6-luna
       params:
         api_version: "2024-05-01"
+        num_retries: 5
       env_params:
         api_base: CODEX_BASE_URL
         api_key: CODEX_API_KEY

--- a/tests/experiments/nightly.yaml
+++ b/tests/experiments/nightly.yaml
@@ -47,6 +47,7 @@ defaults:
       model: gpt-5.6-luna
       params:
         api_version: "2024-05-01"
+        num_retries: 5
       env_params:
         api_base: CODEX_BASE_URL
         api_key: CODEX_API_KEY

--- a/tests/experiments/smoke-windows.yaml
+++ b/tests/experiments/smoke-windows.yaml
@@ -31,6 +31,7 @@ defaults:
       model: gpt-5.6-luna
       params:
         api_version: "2024-05-01"
+        num_retries: 5
       env_params:
         api_base: CODEX_BASE_URL
         api_key: CODEX_API_KEY

--- a/tests/experiments/smoke.yaml
+++ b/tests/experiments/smoke.yaml
@@ -47,6 +47,7 @@ defaults:
       model: gpt-5.6-luna
       params:
         api_version: "2024-05-01"
+        num_retries: 5
       env_params:
         api_base: CODEX_BASE_URL
         api_key: CODEX_API_KEY


### PR DESCRIPTION
## Summary
- Add `num_retries: 5` under `checker_context.api_route.params` in the five experiment files that use the litellm judge route (activation, default, nightly, smoke, smoke-windows), so transient judge API failures get retried instead of failing the row.

## Test plan
- [ ] Confirm YAML parses correctly with existing experiment loader