### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@efef6c1

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 66c7651. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ efef6c1. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 66c7651. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ efef6c1. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 66c7651. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ efef6c1. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in

--- a/preview/uipath-maestro-flow/references/CLI-LOOP.md
+++ b/preview/uipath-maestro-flow/references/CLI-LOOP.md
@@ -30,14 +30,16 @@ artifact can establish.
 
 ## Local authoring hard gates
 
-Use this section only when emit-only mode is disabled. Source and compiled
-checks are separate commands: use the source check as the fast no-output inner
-loop, compile to emit, then run the deep checker on the artifact.
+Use this section only when emit-only mode is disabled. Use the source check as
+the fast no-output inner loop (with a library and a `bindings.json` beside the
+source it reports every connector-input and binding refusal `compile` would
+raise), compile to emit, then run the product's static check on the artifact.
+There is no compiled-artifact `check`; `validate` is that rung.
 
 ```bash
 uip maestro flow check <Name>.flow.ts --source
 uip maestro flow compile <Name> -o <Name>.flow
-uip maestro flow check <Name>.flow --compiled
+uip maestro flow validate <Name>.flow --output json
 ```
 
 Warnings require deliberate review; whether one blocks a release comes from the

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -355,6 +355,19 @@ The compiler emits the product's `multipartParameters` envelope. This is a Flow
 artifact transport; the separate `uip is resources run` command does not expose
 a multipart flag and is not the execution surface for this wiring.
 
+Only a **file** part is an input. A string-typed part (Teams `body`, Gmail
+`body`, GenAI `RagRequest`) is the container the runtime composes from the
+operation's body fields — write those (`'body.content'`, `Body`, `prompt`), never
+the part itself; the compiler lists the part without a value, as the designer does.
+
+```ts
+.step('notify', connector(SendChannelMessage, {
+  team_id: lookup(SendChannelMessage, 'team_id').byDisplayName('Sales'),
+  channel_id: lookup(SendChannelMessage, 'channel_id').byDisplayName('alerts'),
+  body: { content: 'A request was routed to Sales.' },   // or 'body.content': …
+}, { connection: 'teams', folder: 'shared' }))
+```
+
 Preparation requires a working live connection. When a task explicitly uses
 offline/validate-only evidence and does not require connection-specific fields,
 use the baked descriptor with its published static inputs; do not run discovery


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `66c7651` to current `UiPath/flow-builder-sdk@main` (`efef6c1`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)