### PR TITLE
fix(preview-docs): carry the flow-builder-sdk@efef6c1 re-sync onto the campaign (#3010)

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 66c7651. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ efef6c1. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 66c7651. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ efef6c1. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 66c7651. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ efef6c1. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in

--- a/preview/uipath-maestro-flow/references/CLI-LOOP.md
+++ b/preview/uipath-maestro-flow/references/CLI-LOOP.md
@@ -30,14 +30,16 @@ artifact can establish.
 
 ## Local authoring hard gates
 
-Use this section only when emit-only mode is disabled. Source and compiled
-checks are separate commands: use the source check as the fast no-output inner
-loop, compile to emit, then run the deep checker on the artifact.
+Use this section only when emit-only mode is disabled. Use the source check as
+the fast no-output inner loop (with a library and a `bindings.json` beside the
+source it reports every connector-input and binding refusal `compile` would
+raise), compile to emit, then run the product's static check on the artifact.
+There is no compiled-artifact `check`; `validate` is that rung.
 
 ```bash
 uip maestro flow check <Name>.flow.ts --source
 uip maestro flow compile <Name> -o <Name>.flow
-uip maestro flow check <Name>.flow --compiled
+uip maestro flow validate <Name>.flow --output json
 ```
 
 Warnings require deliberate review; whether one blocks a release comes from the

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -355,6 +355,19 @@ The compiler emits the product's `multipartParameters` envelope. This is a Flow
 artifact transport; the separate `uip is resources run` command does not expose
 a multipart flag and is not the execution surface for this wiring.
 
+Only a **file** part is an input. A string-typed part (Teams `body`, Gmail
+`body`, GenAI `RagRequest`) is the container the runtime composes from the
+operation's body fields — write those (`'body.content'`, `Body`, `prompt`), never
+the part itself; the compiler lists the part without a value, as the designer does.
+
+```ts
+.step('notify', connector(SendChannelMessage, {
+  team_id: lookup(SendChannelMessage, 'team_id').byDisplayName('Sales'),
+  channel_id: lookup(SendChannelMessage, 'channel_id').byDisplayName('alerts'),
+  body: { content: 'A request was routed to Sales.' },   // or 'body.content': …
+}, { connection: 'teams', folder: 'shared' }))
+```
+
 Preparation requires a working live connection. When a task explicitly uses
 offline/validate-only evidence and does not require connection-specific fields,
 use the baked descriptor with its published static inputs; do not run discovery


### PR DESCRIPTION
Cherry-pick of main's #3010 (`chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@efef6c1`) onto the campaign branch, `preview/` files only.

Why a cherry-pick and not a rebase: rebasing the campaign onto today's main conflicts at its 2nd commit on `single_node/rpa/rpa.yaml` (main #2971 moved the task to the HelpDeskLookup fixture; the campaign's #2748 prompt still says ProjectEuler) and `smoke/inline_agent_robust.yaml` (main #2975's checker glob). Those are content decisions for Tao; the rerun of `ixp-routing-negative/teams-decision` only needs the docs.

What the docs change (flow-builder-sdk #671, RCA `2026-09-02-maestro-flow-ixp-routing-negative-teams-decision`):
- `CLI-LOOP.md`: the retired `uip maestro flow check <Name>.flow --compiled` line (refused by the CLI since flow-builder-sdk #529; agents ran it in 10+ archived runs) becomes `validate`; the source check now reports connector-input and binding refusals.
- `connector-params.md`: a string-typed multipart part (Teams `body`, Gmail `body`, GenAI `RagRequest`) is the transport container, not an input — write its fields (`body.content`, `Body`, `prompt`).
- Provenance line in the three SKILL.md headers.

No task YAML or checker changes. Measurement-contract note on #2756 follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JizSrmrTUbJdHz8xKt65ks
