### PR TITLE
fix(eval-prompt): routing tasks say where the deliverable goes (current working directory, not a parent)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
@@ -61,7 +61,8 @@ initial_prompt: |
   confirmation, or missing details; pick a sensible default and state it in
   your final report. Do not iterate on validation errors to make the flow
   runnable — a broken skeleton is acceptable, as long as the `.flow` file has
-  been produced.
+  been produced. Work inside the current working directory: create the
+  solution and project here, never in a parent directory.
 
 success_criteria:
   # What this checks: did the agent search the registry for IxP nodes?

--- a/tests/tasks/uipath-maestro-flow/ixp/routing_negative.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing_negative.yaml
@@ -66,7 +66,8 @@ initial_prompt: |
   confirmation, or missing details; pick a sensible default and state it in
   your final report. Do not iterate on validation errors to make the flow
   runnable — a broken skeleton is acceptable, as long as the `.flow` file has
-  been produced.
+  been produced. Work inside the current working directory: create the
+  solution and project here, never in a parent directory.
 
 success_criteria:
   # Inverted twin of the positive routing.yaml artifact check.


### PR DESCRIPTION
## What

Adds one loop-neutral sentence to the scope clause of `ixp/routing_negative.yaml` and `ixp/routing.yaml`:

> Work inside the current working directory: create the solution and project here, never in a parent directory.

## Why

The v1 prompt carried *"Work inside the stated working directory — do NOT `cd` to a parent."* The campaign sweep dropped it with the "Important:" block; the 09-01 restoration (`636b0724c`/`28a91d7db`) named the artifact but not its location.

On 2026-09-02 17:11Z (rerun for the teams-decision RCA, image flow-sdk 3.30.8 + CLI `d09c8883b1dc`) the **v1 live-skill agent** (`gpt-5.6-luna`) on `ixp-routing-negative/teams-decision` ran `uip solution init TeamsDecisionSolution` one directory above its row sandbox (`/work/output/artifacts/skill-flow-ixp-routing-negative/` instead of `…/teams-decision/`), wrote a correct skeleton there, and the checker — cwd = the row sandbox — found no `.flow`: `FAILURE 0.00`. Codex picks the shell's working directory per call and coder-eval does not record it; the transcript shows no `cd`. Archive: 2 of 495 fanned rows show the same class (`ixp-routing/forms-classify`, live 08-24, 0.50; this one). The SDK arm has never done it (0/52).

## Not changed

Checker (`flow_contains.py` searches from the sandbox — searching the parent would read sibling rows), `run_limits`, the v1 skill.

RCA: `workspaces/reports/2026-09-02-maestro-flow-ixp-routing-negative-teams-decision/`. Measurement-contract note on #2756 follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JizSrmrTUbJdHz8xKt65ks
