### PR TITLE
MST-14620: test(case): rename misleading guardrails test in case

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -121,7 +121,6 @@
 # Case Management skill
 /skills/uipath-maestro-case/ @charlesliu9 @song-zhao-25 @abhiram-vad @roberts-cliff @StephenHanzlik
 /tests/tasks/uipath-maestro-case/ @charlesliu9 @song-zhao-25 @abhiram-vad @roberts-cliff @StephenHanzlik
-/tests/tasks/uipath-maestro-case/guardrails/ @apetraru-uipath @valentinabojan @ctiliescuuipath
 
 # Coded Apps skill
 /skills/uipath-coded-apps/ @Raina451 @deepeshrai-tech @Sandeepan-Ghosh-0312 @swati354 @ninja-shreyash

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_01_action_task_placed.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_01_action_task_placed.yaml
@@ -88,10 +88,10 @@ initial_prompt: |
 
   Important:
   - The `uip` CLI is already available in the environment.
-  - Treat every build gate as pre-approved — do not block on any HARD STOP
-    / AskUserQuestion approval step (Phase 0, Phase 1, or Phase 2a→2b).
-  - If the action-app cannot be resolved from the registry, write a skeleton
-    action task per the skill's skeleton-tasks reference (type "action",
+  - Treat the Phase 1 and Phase 2→3 build gates as pre-approved — do not
+    block on their HARD STOP / AskUserQuestion approval steps.
+  - If the action-app cannot be resolved from the registry, write a placeholder
+    action task per the skill's placeholder-tasks reference (type "action",
     empty data) — do NOT fabricate a taskTypeId.
   - Do NOT run `uip maestro case debug`.
 

--- a/tests/tasks/uipath-maestro-case/safety_guard/artifact_safety_guard.yaml
+++ b/tests/tasks/uipath-maestro-case/safety_guard/artifact_safety_guard.yaml
@@ -1,8 +1,8 @@
 task_id: skill-case-artifact-safety-guard
 description: >
   Rule 13 negative guard: while building a two-stage case (HITL action →
-  downstream process), the agent MUST assemble caseplan.json / tasks.md
-  with Read + Write/Edit only. It must NOT shell out to a script or
+  downstream process), the agent MUST assemble caseplan.json /
+  registry-resolved.json with Read + Write/Edit only. It must NOT shell out to a script or
   interpreter to write, parse, or redirect into a skill artifact
   (`node -e ...fs`, `python ...open(...)`, `jq ... > caseplan.json`,
   `sed -i`, a `/tmp/build-caseplan.js` helper, etc.). The sanctioned
@@ -146,8 +146,8 @@ initial_prompt: |
 
   Important:
   - The `uip` CLI is already available.
-  - Treat the generated plan as pre-approved — do not block on any HARD STOP
-    / AskUserQuestion approval step (Phase 0, post-tasks.md, or Phase 2a→2b).
+  - Treat every build gate as pre-approved — do not block on any HARD STOP
+    / AskUserQuestion approval step (Phase 0, Phase 1, or Phase 2a→2b).
   - If a resource cannot be resolved from the registry, write a skeleton task
     per the skill's skeleton-tasks reference — do NOT fabricate a taskTypeId.
   - Do NOT run `uip maestro case debug`.
@@ -188,18 +188,18 @@ success_criteria:
   - type: command_not_executed
     description: "Rule 13: no inline interpreter or stream-editor manipulation of a skill artifact (sed -i, perl -i, gawk in-place, jq on/into an artifact, python open(), node -e ...fs.*)"
     tool_name: "Bash"
-    command_pattern: '(sed\s+-i|perl\s+-i|awk\b[^\n]*-i\s*inplace|jq\b[^\n]*([<>]|caseplan\.json|tasks\.md|bindings_v2\.json|entry-points\.json)|python[0-9]?\b[^\n]*open\s*\(|(node|nodejs)\s+(-e|--eval)\b[^\n]*fs\.)'
+    command_pattern: '(sed\s+-i|perl\s+-i|awk\b[^\n]*-i\s*inplace|jq\b[^\n]*([<>]|caseplan\.json|registry-resolved\.json|bindings_v2\.json|entry-points\.json)|python[0-9]?\b[^\n]*open\s*\(|(node|nodejs)\s+(-e|--eval)\b[^\n]*fs\.)'
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_not_executed
-    description: "Rule 13: no shell redirection into a skill artifact and no helper-script build-assembler (`> caseplan.json`, `| tee tasks.md`, `node build-caseplan.js`, `python gen.py`)"
+    description: "Rule 13: no shell redirection into a skill artifact and no helper-script build-assembler (`> caseplan.json`, `| tee registry-resolved.json`, `node build-caseplan.js`, `python gen.py`)"
     tool_name: "Bash"
     # The script path must be the token immediately after the interpreter: agents wrap every
     # command in `/bin/bash -lc '...'`, so `bash\s+[^\n]*\.sh` would match any command that merely
-    # mentions a script path (e.g. `rg ... audit_plan.py`). The lookahead exempts the skill's own
-    # read-only auditor, which planning.md mandates as the final plan gate.
-    command_pattern: '([<>]{1,2}\s*\S*(caseplan\.json|tasks\.md|bindings_v2\.json|entry-points\.json)|tee\b[^\n]*(caseplan\.json|tasks\.md)|\b(node|nodejs|python[0-9]?|bash|sh)\s+(?!\S*uipath-maestro-case/scripts/)\S+\.(js|mjs|cjs|py|sh)\b)'
+    # mentions a script path (e.g. `rg ... audit_caseplan.py`). The lookahead exempts the skill's
+    # own read-only auditor, which implementation.md mandates as the Step 12 build gate.
+    command_pattern: '([<>]{1,2}\s*\S*(caseplan\.json|registry-resolved\.json|bindings_v2\.json|entry-points\.json)|tee\b[^\n]*(caseplan\.json|registry-resolved\.json)|\b(node|nodejs|python[0-9]?|bash|sh)\s+(?!\S*uipath-maestro-case/scripts/)\S+\.(js|mjs|cjs|py|sh)\b)'
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-case/safety_guard/artifact_safety_guard.yaml
+++ b/tests/tasks/uipath-maestro-case/safety_guard/artifact_safety_guard.yaml
@@ -9,7 +9,7 @@ description: >
   `node -e "crypto.randomUUID()"` UUID subprocess (no `fs`, no redirection)
   stays allowed. Grades the build succeeding via the sanctioned path, not
   a self-report.
-tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, guardrail, shape:multi-node, node:hitl]
+tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:multi-node, node:hitl]
 
 initial_prompt: |
   Create a UiPath Case Management project named "InvoiceReviewCase" with a
@@ -146,11 +146,13 @@ initial_prompt: |
 
   Important:
   - The `uip` CLI is already available.
-  - Treat every build gate as pre-approved — do not block on any HARD STOP
-    / AskUserQuestion approval step (Phase 0, Phase 1, or Phase 2a→2b).
-  - If a resource cannot be resolved from the registry, write a skeleton task
-    per the skill's skeleton-tasks reference — do NOT fabricate a taskTypeId.
+  - Treat the Phase 1 and Phase 2→3 build gates as pre-approved — do not
+    block on their HARD STOP / AskUserQuestion approval steps.
+  - If a resource cannot be resolved from the registry, write a placeholder
+    task per the skill's placeholder-tasks reference — do NOT fabricate a
+    taskTypeId.
   - Do NOT run `uip maestro case debug`.
+  - Do NOT publish to Studio Web or Orchestrator.
 
   The task is NOT complete until `uip maestro case validate` passes on the
   generated caseplan.json.
@@ -186,9 +188,9 @@ success_criteria:
   # --- Rule 13 guards: no interpreter/stream-editor/helper-script assembly of a skill artifact ---
   # crypto.randomUUID() UUID subprocess (no fs, no redirection) is NOT matched by either pattern.
   - type: command_not_executed
-    description: "Rule 13: no inline interpreter or stream-editor manipulation of a skill artifact (sed -i, perl -i, gawk in-place, jq on/into an artifact, python open(), node -e ...fs.*)"
+    description: "Rule 13: no inline interpreter or stream-editor manipulation of a skill artifact (sed -i, perl -i, gawk in-place, jq on/into an artifact, python open(), node -e ...fs. / require('fs'))"
     tool_name: "Bash"
-    command_pattern: '(sed\s+-i|perl\s+-i|awk\b[^\n]*-i\s*inplace|jq\b[^\n]*([<>]|caseplan\.json|registry-resolved\.json|bindings_v2\.json|entry-points\.json)|python[0-9]?\b[^\n]*open\s*\(|(node|nodejs)\s+(-e|--eval)\b[^\n]*fs\.)'
+    command_pattern: '(sed\s+-i|perl\s+-i|awk\b[^\n]*-i\s*inplace|jq\b[^\n]*([<>]|caseplan\.json|registry-resolved\.json|bindings_v2\.json|entry-points\.json)|python[0-9]?\b[^\n]*open\s*\(|(node|nodejs)\s+(-e|--eval)\b[^\n]*(fs\.|require\s*\(\s*[''"](node:)?fs[''"]))'
     weight: 2.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
Why:
The skill-case-artifact-safety-guard test was placed in the subfolder named "guardrails" by claude, while it's just validating assemble caseplan.json / registry-resolved.json with Read + Write/Edit only. The name is misleading, and triggered the rule requiring other code owners to approve any change on the test.
The test also needs update after removing tasks.md.
What:
Rename the folder to avoid misunderstanding, remove the required code owners for this particular test.
Verify:
https://github.com/UiPath/skills/actions/runs/33673778364 Run successfully