### PR TITLE
test(maestro-flow): keep the corpus guard exact after the 2026-09-02 rebase onto main

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
@@ -1,8 +1,9 @@
 """Permanent same-ground contract for uipath-maestro-flow eval tasks.
 
-The temporary allowlists name pre-campaign debt. Each family batch removes its
-own entries as the task contract becomes neutral; exact equality prevents stale
-allowlist entries from hiding completed work.
+The temporary allowlists name pre-campaign debt plus tasks that landed on
+`main` after the alignment sweep and have not been aligned yet. Each family
+batch removes its own entries as the task contract becomes neutral; exact
+equality prevents stale allowlist entries from hiding completed work.
 """
 
 from __future__ import annotations
@@ -12,11 +13,22 @@ from pathlib import Path
 
 FLOW_TASKS = Path(__file__).resolve().parent.parent
 
-V1_AUTHORING_ALLOWLIST = set()
+# Post-sweep upstream arrivals, carried as-is until their own alignment pass:
+# - evaluate/child_simulation (#2965, 2026-09-02) gates on `uip solution init`
+#   and `uip maestro flow init` telemetry.
+# - ixp/e2e_03_project_creation_handoff (#2809, 2026-09-02) gates on two
+#   skill_triggered criteria and tells the agent not to run `flow debug`.
+V1_AUTHORING_ALLOWLIST = {
+    "evaluate/child_simulation/child_simulation_crud.yaml",
+}
 
-SKILL_TELEMETRY_ALLOWLIST = set()
+SKILL_TELEMETRY_ALLOWLIST = {
+    "ixp/e2e_03_project_creation_handoff/e2e_03_project_creation_handoff.yaml",
+}
 
-FORBIDDEN_PROMPT_ALLOWLIST = set()
+FORBIDDEN_PROMPT_ALLOWLIST = {
+    "ixp/e2e_03_project_creation_handoff/e2e_03_project_creation_handoff.yaml",
+}
 
 # These born-neutral escalation tasks are outside the recipe-edit sweep. Their
 # prompts already require the same-name solution and tell the agent to leave

--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_03_project_creation_handoff/handoff.py
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_03_project_creation_handoff/handoff.py
@@ -83,9 +83,9 @@ from datetime import datetime, timezone
 from typing import Any
 
 TASK_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.join(TASK_DIR, "..", "..", "_shared"))
+sys.path.insert(0, os.path.join(TASK_DIR, "..", ".."))
 
-from flow_check import find_project_dir  # noqa: E402
+from _shared.flow_check import find_project_dir  # noqa: E402
 
 # ── shared helpers ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Short version

After rebasing `campaign/same-ground-expansion` onto today's `main`, the permanent same-ground corpus guard failed on four contracts. None of the failures come from the conflict resolution itself. They come from two upstream tasks the alignment sweep never saw. This PR carries those two tasks in the guard's *temporary* allowlists (named with their upstream PR) and fixes the one contract that has no allowlist.

## What the guard caught

The guard (`tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py`) scans every task tagged `uipath-maestro-flow` and asserts the same-ground contract, e.g. "no gating `command_executed` on v1-only authoring commands". Its allowlists use exact set equality, so a new offender turns the test red instead of being silently accepted.

| Contract | Offender | Where it came from |
|---|---|---|
| v1-only authoring commands must be advisory | `evaluate/child_simulation/child_simulation_crud.yaml` gates on `uip solution init` and `uip maestro flow init` | main #2965, merged 2026-09-02 |
| `skill_triggered` must be advisory | `ixp/e2e_03_project_creation_handoff/…yaml` gates on two `skill_triggered` criteria | main #2809, merged 2026-09-02 (inherited on the previous rebase) |
| prompts must not say "do not … debug" | same e2e_03 yaml: "do not run `uip maestro flow debug`" | same |
| external graders use package-qualified `_shared` imports | `ixp/e2e_03_project_creation_handoff/handoff.py` did `from flow_check import …` after pushing `../../_shared` on `sys.path` | same |

## What changed

- **Allowlists** — the two yaml files are added to `V1_AUTHORING_ALLOWLIST`, `SKILL_TELEMETRY_ALLOWLIST`, `FORBIDDEN_PROMPT_ALLOWLIST` with a comment naming the upstream PR. The module docstring now says the lists also cover post-sweep upstream arrivals. The task files themselves are untouched, so nothing about how those tasks grade changes.
- **`handoff.py` import** — switched to the form every converted grader uses:
  ```python
  sys.path.insert(0, os.path.join(TASK_DIR, "..", ".."))
  from _shared.flow_check import find_project_dir
  ```
  Example of why this matters: in coder-eval's isolated task mount, `_shared` is co-located two levels up, not a sibling of `$TASK_DIR/..`, so the bare `from flow_check import` form would fail with `ModuleNotFoundError` there.

## Verification

- `pytest tests/tasks/uipath-maestro-flow/` — 1140 passed (was 4 failed on the rebased tip)
- `pytest tests/tasks/uipath-maestro-flow/ixp/e2e_03_project_creation_handoff/test_handoff.py` — 51 passed
- `handoff.py` imports standalone; `find_project_dir` resolves from `_shared.flow_check`

## Follow-up (not in this PR)

Both tasks still need their own alignment pass before they can leave the allowlists: decide whether `child_simulation_crud` (a CLI-feature test by construction) belongs in the same-ground manifest at all, and whether e2e_03's `uipath-ixp` handoff signal should stay gating.

Co-Authored-By: [Claude](mailto:noreply@anthropic.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwTyMj73xjaUbCMsADvTSr
