### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@9856764

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ efef6c1. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 9856764. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ efef6c1. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 9856764. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ efef6c1. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 9856764. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in

--- a/preview/uipath-maestro-flow/references/brownfield.md
+++ b/preview/uipath-maestro-flow/references/brownfield.md
@@ -90,6 +90,19 @@ whose definition is MISSING from the file — nothing can carry it, so it lowers
 to `mock() /* TODO: unsupported node type … */`; leave that node untouched and
 merge restores the original.
 
+Two findings the source cannot carry are printed on stderr as
+`flow-decompile: warning: …` (and `--strict` turns the first into an error):
+
+- A node **no trigger reaches** — no edge leads to it, as when a designer or
+  `node add` left it unconnected. The builder has no detached-node construct,
+  so the source omits it and marks the spot with `// TODO: node "<id>" … is not
+  reachable`; recompiling drops that node. If it is your edit target, connect
+  it in the `.flow` first or edit that node's JSON directly.
+- A core `(type, typeVersion)` **this SDK does not bundle** — the registry
+  serves `core.trigger.manual@1.0`, the SDK ships `1.0.0`, and versions resolve
+  exactly. The source keeps the file's pair, so `compile` refuses it until you
+  drop that `{ version }`; the node then takes the SDK's pinned version.
+
 Validate `Deployed.merged.flow`, not the intermediate edited compile. Before
 placing it in a solution, copy it over the canonical artifact rather than next
 to it, then validate the canonical project path again.


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `efef6c1` to current `UiPath/flow-builder-sdk@main` (`9856764`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)