### PR TITLE
chore(uipath-insights): own the insights activation eval file as a team [IN-13526]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -192,6 +192,7 @@
 # Insights skill (job monitoring and analytics)
 /skills/uipath-insights/ @UiPath/insights
 /tests/tasks/uipath-insights/ @UiPath/insights
+/tests/tasks/activation/uipath-insights.jsonl @UiPath/insights
 
 # Automation Discovery skill
 /skills/uipath-automation-discovery/ @uisherif


### PR DESCRIPTION
Related to [IN-13526](https://uipath.atlassian.net/browse/IN-13526).

## What

Adds `/tests/tasks/activation/uipath-insights.jsonl` to the `@UiPath/insights` CODEOWNERS entries, next to the existing `/skills/uipath-insights/` and `/tests/tasks/uipath-insights/` lines.

## Why

Rocky asked for the insights team to own its activation eval file, the way the functions, connector-builder, troubleshoot, and process-mining skills already own theirs. Without this line, edits to the file only route to the repo default owners.

Ownership change only, no skill or eval content touched.

[IN-13526]: https://uipath.atlassian.net/browse/IN-13526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ