### PR TITLE
MST-14619: feat(uipath-maestro-case): audit variable Category group placement

### DIFF
--- a/skills/uipath-maestro-case/scripts/audit_caseplan.py
+++ b/skills/uipath-maestro-case/scripts/audit_caseplan.py
@@ -10,8 +10,9 @@ until clean (max 3 loops, then AskUserQuestion).
 
 This gate runs against the FINAL artifact. `uip maestro case validate` only
 warns `Task has no entry rules`, and a missing entry rule hangs `case debug`
-indefinitely -- so entry-rule presence, placeholder honesty, and binding
-resource-key shape are checked here, per task, against what the SDD declared.
+indefinitely -- so entry-rule presence, placeholder honesty, binding
+resource-key shape, and Category -> `variables` group placement are checked
+here, against what the SDD declared.
 
 WARN findings (EXTRA caseplan elements, placeholder tasks, surviving
 `<UNRESOLVED>` markers) are reported but do not fail the run.
@@ -46,6 +47,17 @@ PLACEHOLDER_CELLS = {"", "-", "—", "–", "n/a", "na", "none", "tbd"}
 STAGE_NODE_TYPES = {"case-management:Stage"}
 TRIGGER_NODE_TYPES = {"uipath.case.trigger", "case-management:Trigger"}
 UNRESOLVED = re.compile(r"<UNRESOLVED[^>]*>", re.I)
+
+# A Case Variables row's Category decides which `variables` groups it must
+# reach (Loop B of global-vars/impl-json.md): In and Out need their formal slot
+# AND the root companion, a pure-state Variable is companion-only. Keys are the
+# `norm`-ed Category cell; `InOut` is unsupported in v1 and stays unchecked.
+VARIABLE_PLACEMENT = {
+    "in": ("inputs", "inputOutputs"),
+    "out": ("outputs", "inputOutputs"),
+    "variable": ("inputOutputs",),
+}
+VARIABLE_GROUPS = ("inputs", "outputs", "inputOutputs")
 
 
 # SDD headings often carry a trailing slug -- `Intake and completeness (`stage-intake`)`
@@ -169,6 +181,14 @@ def no_name_column_note(title: str, wanted: tuple[str, ...], header: list[str]) 
     )
 
 
+def no_category_column_note(title: str, header: list[str]) -> str:
+    return (
+        f"section {title!r}: the table has rows but no Category column "
+        f"(header: {' | '.join(header) or '<none>'}) -- no row can be checked for "
+        f"`variables` group placement, so a formal argument missing half its pair passes"
+    )
+
+
 def unrecognized_heading_note(title: str, level: int) -> str:
     return (
         f"heading {title!r} (level {level}) reads like an audited section but matches no "
@@ -190,7 +210,7 @@ def parse_sdd(text: str) -> dict:
     heads = section_blocks(text)
     sdd: dict = {
         "stages": [], "case_exit_rows": 0, "triggers": 0, "variables": [],
-        "sla_case": False, "parse_notes": [],
+        "variable_categories": {}, "sla_case": False, "parse_notes": [],
     }
     notes: list[str] = sdd["parse_notes"]
     lookalikes: list[tuple[str, str]] = []
@@ -212,12 +232,18 @@ def parse_sdd(text: str) -> dict:
             header, rows = first_table(body)
             wanted = ("Name", "Variable", "Variable Name")
             name_at = column(header, *wanted)
+            category_at = column(header, "Category")
             if rows and name_at is None:
                 notes.append(no_name_column_note(title, wanted, header))
+            elif rows and category_at is None:
+                notes.append(no_category_column_note(title, header))
             for row in rows:
                 name = cell(row, name_at)
                 if name and not is_blank(name):
                     sdd["variables"].append(name.strip("`"))
+                    category = norm(cell(row, category_at))
+                    if category in VARIABLE_PLACEMENT:
+                        sdd["variable_categories"][norm(name)] = category
         elif STAGE_HEADING.match(title):
             sdd["stages"].append(parse_stage(STAGE_HEADING.match(title).group(1), head["body"], notes))
         else:
@@ -344,9 +370,11 @@ def parse_caseplan(doc: dict) -> dict:
     plan["case_sla"] = bool(metadata.get("slaRules"))
 
     variables = doc.get("variables") or {}
-    for group in ("inputs", "outputs", "inputOutputs"):
-        for variable in variables.get(group) or []:
-            plan["variables"].append(variable.get("name"))
+    plan["variable_groups"] = {}
+    for group in VARIABLE_GROUPS:
+        names = [variable.get("name") for variable in variables.get(group) or []]
+        plan["variable_groups"][group] = {norm(name) for name in names if name}
+        plan["variables"].extend(names)
 
     for node in doc.get("nodes") or []:
         node_type = node.get("type")
@@ -583,8 +611,21 @@ def compare(sdd: dict, plan: dict) -> tuple[list[str], list[str]]:
 
     plan_variables = {norm(v) for v in plan["variables"] if v}
     for name in sdd["variables"]:
-        if norm(name) not in plan_variables:
+        key = norm(name)
+        if key not in plan_variables:
             missing.append(f"variable {name!r}: declared in the SDD Case Variables table, absent from caseplan.json")
+            continue
+        category = sdd["variable_categories"].get(key)
+        for group in VARIABLE_PLACEMENT.get(category, ()):
+            if key in plan["variable_groups"][group]:
+                continue
+            found = [g for g in VARIABLE_GROUPS if key in plan["variable_groups"][g]]
+            missing.append(
+                f"variable {name!r}: SDD Category={category.capitalize()} needs an entry in "
+                f"caseplan variables.{group}[], found only in {', '.join(found)} -- "
+                f"`validate` accepts half the pair and the argument then drops out of "
+                f"entry-points.json"
+            )
 
     return missing, warn
 

--- a/tests/tasks/uipath-maestro-case/_shared/test_audit_caseplan.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_audit_caseplan.py
@@ -99,7 +99,13 @@ CASEPLAN = {
         {"id": "bFp", "resource": "process", "resourceSubType": "Api",
          "resourceKey": "Shared/widgets/Order Check.API Workflow"},
     ],
-    "variables": {"inputs": [{"name": "orderId", "type": "string"}], "outputs": [], "inputOutputs": []},
+    "variables": {
+        "inputs": [{"id": "vK3mNp9Qx", "name": "orderId", "type": "string"}],
+        "outputs": [],
+        # An In-arg is a formal slot AND a root companion (Loop B of
+        # global-vars/impl-json.md); the companion is what `=vars.orderId` resolves.
+        "inputOutputs": [{"id": "orderId", "name": "orderId", "type": "string"}],
+    },
     "nodes": [
         {"id": "trigger1", "type": "uipath.case.trigger", "data": {}},
         {
@@ -190,6 +196,100 @@ def test_dropped_variable_fails():
     plan["variables"]["inputs"] = []
     missing, _ = run(plan)
     assert any("variable 'orderId'" in f for f in missing)
+
+
+# --------------------------------------------------------------------------
+# Category -> `variables` group placement
+#
+# A row's Category decides which arrays it must reach: In and Out need their
+# formal slot AND the root companion, a pure-state Variable is companion-only.
+# Half a pair passes `uip maestro case validate` and then drops the argument
+# from the entry-point contract, so presence-anywhere is not enough.
+# --------------------------------------------------------------------------
+
+VARIABLE_ROW = "| orderId | In | string | | Order identifier |"
+
+
+def _with_variable_row(row):
+    return SDD.replace(VARIABLE_ROW, f"{VARIABLE_ROW}\n{row}")
+
+
+def _companion(name, var_type):
+    return {"id": name, "name": name, "type": var_type, "elementId": "root"}
+
+
+def test_out_variable_without_its_formal_outputs_entry_fails():
+    """The io-binding-matrix miss: the companion is written, the formal Out-arg
+    slot is not, so the argument never reaches `entry-points.json`."""
+    sdd = _with_variable_row("| totalPaid | Out | number | | Amount paid |")
+    plan = copy.deepcopy(CASEPLAN)
+    plan["variables"]["inputOutputs"].append(_companion("totalPaid", "number"))
+    missing, _ = audit_caseplan.compare(
+        audit_caseplan.parse_sdd(sdd), audit_caseplan.parse_caseplan(plan)
+    )
+    assert any("'totalPaid'" in f and "variables.outputs[]" in f for f in missing)
+
+
+def test_out_variable_with_both_entries_is_clean():
+    sdd = _with_variable_row("| totalPaid | Out | number | | Amount paid |")
+    plan = copy.deepcopy(CASEPLAN)
+    plan["variables"]["outputs"].append(
+        {"id": "vQ7rTz2Wb", "name": "totalPaid", "type": "number", "var": "totalPaid"}
+    )
+    plan["variables"]["inputOutputs"].append(_companion("totalPaid", "number"))
+    missing, _ = audit_caseplan.compare(
+        audit_caseplan.parse_sdd(sdd), audit_caseplan.parse_caseplan(plan)
+    )
+    assert missing == []
+
+
+def test_in_variable_without_its_companion_fails():
+    plan = copy.deepcopy(CASEPLAN)
+    plan["variables"]["inputOutputs"] = []
+    missing, _ = run(plan)
+    assert any("'orderId'" in f and "variables.inputOutputs[]" in f for f in missing)
+
+
+def test_pure_state_variable_in_the_wrong_group_fails():
+    sdd = _with_variable_row("| caseStatus | Variable | string | Open | Current state |")
+    plan = copy.deepcopy(CASEPLAN)
+    plan["variables"]["outputs"].append(
+        {"id": "vB4hLm6Cd", "name": "caseStatus", "type": "string", "var": "caseStatus"}
+    )
+    missing, _ = audit_caseplan.compare(
+        audit_caseplan.parse_sdd(sdd), audit_caseplan.parse_caseplan(plan)
+    )
+    assert any("'caseStatus'" in f and "variables.inputOutputs[]" in f for f in missing)
+
+
+def test_a_variable_absent_everywhere_is_reported_once():
+    """Absent is the presence finding, not one placement finding per group."""
+    plan = copy.deepcopy(CASEPLAN)
+    plan["variables"]["inputs"] = []
+    plan["variables"]["inputOutputs"] = []
+    missing, _ = run(plan)
+    assert [f for f in missing if "'orderId'" in f] == [
+        "variable 'orderId': declared in the SDD Case Variables table, absent from caseplan.json"
+    ]
+
+
+def test_case_variables_table_without_a_category_column_is_reported():
+    """Without Category the placement class empties silently while the gate
+    keeps printing AUDIT OK."""
+    parsed = audit_caseplan.parse_sdd(SDD.replace("| Name | Category |", "| Name | Kind |"))
+    assert parsed["variables"] == ["orderId"]
+    assert any("no Category column" in n for n in parsed["parse_notes"])
+
+
+def test_unsupported_category_is_not_placement_checked():
+    """`InOut` is not supported in v1; the row still has to exist somewhere."""
+    sdd = _with_variable_row("| bothWays | InOut | string | | Unsupported |")
+    plan = copy.deepcopy(CASEPLAN)
+    plan["variables"]["inputOutputs"].append(_companion("bothWays", "string"))
+    missing, _ = audit_caseplan.compare(
+        audit_caseplan.parse_sdd(sdd), audit_caseplan.parse_caseplan(plan)
+    )
+    assert missing == []
 
 
 def test_dropped_case_exit_rules_fail():


### PR DESCRIPTION
feat(uipath-maestro-case): audit variable Category group placement

A Case Variables row's Category decides which `variables` groups it must
reach, but the completeness gate flattened all three groups into one name
set and only asked whether the name appeared somewhere. 

The gate now parses the Category cell and asserts placement per Loop B of
global-vars/impl-json.md: In needs its formal slot plus the root companion,
Out likewise, a pure-state Variable is companion-only. A name absent from
every group still yields the single existing presence finding rather than
one placement finding per group. `InOut` (unsupported in v1) and a blank
Category are parsed but not placement-checked.

A Case Variables table with rows but no Category column now emits a parse
note, which fails the run with "repair the SDD" -- the same treatment a
missing Name column already gets, since a header that empties a check class
otherwise keeps the gate printing AUDIT OK. Every Case Variables table in
the repo carries the column.

Verify
https://github.com/UiPath/skills/actions/runs/33691702865
