### PR TITLE
feat(hooks): flow-diff hook for UiPath VS Code canvas review of .flow edits

### DIFF
--- a/hooks/flow-diff-hook.mjs
+++ b/hooks/flow-diff-hook.mjs
@@ -33,8 +33,8 @@ function readStdin() {
   });
 }
 
-/** Walk up from `startDir` looking for `.uipath/flow-agent-hook.json`; return the socket path. */
-function discoverSocket(startDir) {
+/** Walk up from `startDir` looking for `.uipath/flow-agent-hook.json`; return `{socket, token}`. */
+function discoverEndpoint(startDir) {
   let dir = startDir;
   for (let i = 0; i < 40 && dir; i++) {
     const candidate = path.join(dir, '.uipath', 'flow-agent-hook.json');
@@ -42,14 +42,16 @@ function discoverSocket(startDir) {
       if (fs.existsSync(candidate)) {
         const parsed = JSON.parse(fs.readFileSync(candidate, 'utf8'));
         if (parsed && typeof parsed.socket === 'string') {
-          return parsed.socket;
+          return { socket: parsed.socket, token: typeof parsed.token === 'string' ? parsed.token : undefined };
         }
       }
     } catch {
       /* ignore and keep walking */
     }
     const parent = path.dirname(dir);
-    if (parent === dir) break;
+    if (parent === dir) {
+      break;
+    }
     dir = parent;
   }
   return null;
@@ -114,9 +116,9 @@ async function main() {
   const cwd = payload.cwd || process.cwd();
 
   if (event === 'Stop') {
-    const socketPath = discoverSocket(cwd);
-    if (socketPath) {
-      await sendRequest(socketPath, { event: 'Stop', sessionId: payload.session_id });
+    const endpoint = discoverEndpoint(cwd);
+    if (endpoint) {
+      await sendRequest(endpoint.socket, { event: 'Stop', sessionId: payload.session_id, token: endpoint.token });
     }
     process.exit(0);
   }
@@ -131,18 +133,19 @@ async function main() {
     process.exit(0); // Not a flow edit — let it proceed normally.
   }
 
-  const socketPath = discoverSocket(path.dirname(filePath)) || discoverSocket(cwd);
-  if (!socketPath) {
+  const endpoint = discoverEndpoint(path.dirname(filePath)) || discoverEndpoint(cwd);
+  if (!endpoint) {
     process.exit(0); // Extension not listening — defer to Claude's normal flow.
   }
 
-  const response = await sendRequest(socketPath, {
+  const response = await sendRequest(endpoint.socket, {
     event: 'PreToolUse',
     tool: payload.tool_name,
     filePath,
     permissionMode: payload.permission_mode,
     toolInput,
     sessionId: payload.session_id,
+    token: endpoint.token,
   });
 
   const decision = response && response.decision;

--- a/hooks/flow-diff-hook.mjs
+++ b/hooks/flow-diff-hook.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Flow diff hook — bridges Claude Code tool events to the UiPath VS Code
+ * extension so `.flow` edits can be reviewed on the canvas before they apply.
+ *
+ * Wired in hooks.json for PreToolUse (Edit|MultiEdit|Write) and Stop.
+ *
+ * Contract (safety-first — never blocks the agent on hook failure):
+ *   - Only acts on `*.flow` files; everything else exits 0 silently.
+ *   - Discovers the extension's IPC socket via `.uipath/flow-agent-hook.json`,
+ *     walked up from the edited file's directory (and cwd). If absent, the
+ *     extension isn't running / the feature is off → exit 0 (no decision).
+ *   - PreToolUse: forwards the event and waits for an allow/deny/ask decision.
+ *     - allow/deny → emit the corresponding Claude Code permissionDecision.
+ *     - ask / no response / any error → emit nothing → Claude's normal prompt.
+ *   - Stop: notifies the extension to release manual hook control; exits 0.
+ */
+
+import net from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const RESPONSE_TIMEOUT_MS = 125_000; // Slightly under the hooks.json command timeout.
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => (data += chunk));
+    process.stdin.on('end', () => resolve(data));
+    // If stdin never closes (shouldn't happen for hooks), don't hang forever.
+    setTimeout(() => resolve(data), 2000);
+  });
+}
+
+/** Walk up from `startDir` looking for `.uipath/flow-agent-hook.json`; return the socket path. */
+function discoverSocket(startDir) {
+  let dir = startDir;
+  for (let i = 0; i < 40 && dir; i++) {
+    const candidate = path.join(dir, '.uipath', 'flow-agent-hook.json');
+    try {
+      if (fs.existsSync(candidate)) {
+        const parsed = JSON.parse(fs.readFileSync(candidate, 'utf8'));
+        if (parsed && typeof parsed.socket === 'string') {
+          return parsed.socket;
+        }
+      }
+    } catch {
+      /* ignore and keep walking */
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/** Send one request over the socket and resolve with the parsed response (or null). */
+function sendRequest(socketPath, request) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (value) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+
+    const socket = net.createConnection(socketPath);
+    let buffer = '';
+
+    const timer = setTimeout(() => {
+      socket.destroy();
+      done(null);
+    }, RESPONSE_TIMEOUT_MS);
+
+    socket.on('connect', () => {
+      socket.write(`${JSON.stringify(request)}\n`);
+    });
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+      const idx = buffer.indexOf('\n');
+      if (idx !== -1) {
+        clearTimeout(timer);
+        socket.end();
+        try {
+          done(JSON.parse(buffer.slice(0, idx)));
+        } catch {
+          done(null);
+        }
+      }
+    });
+    socket.on('error', () => {
+      clearTimeout(timer);
+      done(null);
+    });
+    socket.on('close', () => {
+      clearTimeout(timer);
+      done(null);
+    });
+  });
+}
+
+async function main() {
+  const raw = await readStdin();
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  const event = payload.hook_event_name;
+  const cwd = payload.cwd || process.cwd();
+
+  if (event === 'Stop') {
+    const socketPath = discoverSocket(cwd);
+    if (socketPath) {
+      await sendRequest(socketPath, { event: 'Stop', sessionId: payload.session_id });
+    }
+    process.exit(0);
+  }
+
+  if (event !== 'PreToolUse') {
+    process.exit(0);
+  }
+
+  const toolInput = payload.tool_input || {};
+  const filePath = toolInput.file_path;
+  if (typeof filePath !== 'string' || !filePath.endsWith('.flow')) {
+    process.exit(0); // Not a flow edit — let it proceed normally.
+  }
+
+  const socketPath = discoverSocket(path.dirname(filePath)) || discoverSocket(cwd);
+  if (!socketPath) {
+    process.exit(0); // Extension not listening — defer to Claude's normal flow.
+  }
+
+  const response = await sendRequest(socketPath, {
+    event: 'PreToolUse',
+    tool: payload.tool_name,
+    filePath,
+    permissionMode: payload.permission_mode,
+    toolInput,
+    sessionId: payload.session_id,
+  });
+
+  const decision = response && response.decision;
+  if (decision === 'allow' || decision === 'deny') {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: decision,
+          permissionDecisionReason:
+            decision === 'allow' ? 'Approved on the UiPath flow canvas.' : 'Declined on the UiPath flow canvas.',
+        },
+      })
+    );
+  }
+  // decision === 'ask' / null → emit nothing → Claude falls back to its prompt.
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -52,6 +52,11 @@
             "type": "command",
             "command": "echo `# <#` >/dev/null\nbash \"${CLAUDE_PLUGIN_ROOT}/hooks/send-telemetry.sh\"\nexit $?\n: <<'POLYEOF' #> > $null\n& \"${CLAUDE_PLUGIN_ROOT}/hooks/send-telemetry.ps1\"\nif ($null -eq $LASTEXITCODE) { exit 1 } else { exit $LASTEXITCODE }\nPOLYEOF\n",
             "async": true
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/flow-diff-hook.mjs\"",
+            "timeout": 5
           }
         ]
       }
@@ -63,6 +68,18 @@
             "type": "command",
             "command": "echo `# <#` >/dev/null\nbash \"${CLAUDE_PLUGIN_ROOT}/hooks/send-telemetry.sh\"\nexit $?\n: <<'POLYEOF' #> > $null\n& \"${CLAUDE_PLUGIN_ROOT}/hooks/send-telemetry.ps1\"\nif ($null -eq $LASTEXITCODE) { exit 1 } else { exit $LASTEXITCODE }\nPOLYEOF\n",
             "async": true
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/flow-diff-hook.mjs\"",
+            "timeout": 130
           }
         ]
       }


### PR DESCRIPTION
## Flow-diff hook: bridge Claude Code `.flow` edits to the UiPath VS Code extension

Companion to the agent diff review shipping in `UiPath/flow-workbench` (kit merged; VS Code host wiring in UiPath/flow-workbench#3581). Until this hook ships, VS Code users get the live canvas mirror only — no permission-mode detection and no end-of-turn review toast.

### What it does
Two entries in `hooks.json` run `hooks/flow-diff-hook.mjs` (Node ESM, no dependencies):

- **`PreToolUse`** (matcher `Edit|MultiEdit|Write`, timeout 130s): for `.flow` edits, forwards `{event, tool, filePath, permissionMode, toolInput, sessionId}` to the extension's per-workspace IPC socket and waits for a decision. `allow`/`deny` → emitted as `hookSpecificOutput.permissionDecision`; `ask` / no reply / any failure → emits nothing, Claude's own prompt proceeds. This is also how the extension learns **auto vs manual** mode.
- **`Stop`** (timeout 5s, appended to the existing Stop group so telemetry is unaffected): notifies turn end — what triggers the extension's end-of-turn before/after review.

### Discovery & degradation
The socket is advertised by the running extension in `<workspace>/.uipath/flow-agent-hook.json` (`{socket, pid, version}`), discovered by walking up from the edited file / cwd. Every failure mode — no discovery file, dead extension, timeout, bad JSON — **exits 0 silently**: the agent is never blocked, and users without the extension (or with the feature flag off) see zero behavior change. Neither side hard-depends on the other's version; the discovery file's `version` field is the compatibility lever.

### Testing
- `node --check` passes; `hooks.json` valid.
- Smoke: non-`.flow` edit → exit 0 no output; `.flow` edit with no extension → exit 0 no output; `Stop` with no extension → exit 0.
- End-to-end against the extension branch (`feat/agent-diff-4-vsix`): mode detection + review toast verified in earlier live testing of the protocol.
