### PR TITLE
fix(flow-check): INTERIM Overwrite rotation also recognises the CLI's staged error envelope (UiPath/cli#3951)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -174,17 +174,44 @@ def _output_blob(result: subprocess.CompletedProcess) -> str:
 _OVERWRITE_STUCK_ISSUE = "UiPath/cli#3938"
 _OVERWRITE_STUCK_MARKER = "overwrite failed (400)"
 _OVERWRITE_STUCK_CODE = re.compile(r'\\?"code\\?":\s*\\?"1001\\?"')
+# Since UiPath/cli#3951 (main 2026-09-02, `016231474`) the CLI reports a refused
+# upload against its stage instead of echoing the raw body:
+#   Message: "Failed during overwrite-solution: HTTP 400 on POST …/Overwrite — An argument had an invalid value."
+#   Context: {"HttpStatus": 400, "Stage": "overwrite-solution", "ErrorCode": "1001"}
+# The rotation must recognise both envelopes: an image whose CLI carries #3951
+# but whose checker knows only the legacy text fails every second debug of a
+# project with a plain `flow debug exit 1` (seen 2026-09-03 on every
+# multi-debug task of the batch-A rerun, both arms).
+_OVERWRITE_STUCK_STAGE = "overwrite-solution"
 _OVERWRITE_STUCK_ATTEMPTS = 2  # the failed overwrite + one import-as-new retry
 _SOLUTION_ID_RE = re.compile(r'("SolutionId"\s*:\s*")([0-9a-fA-F-]{36})(")')
 
 
 def _is_overwrite_stuck(result: subprocess.CompletedProcess) -> bool:
     """True iff ``flow debug`` died on the Studio Web Overwrite 400/1001 regression
-    (see :data:`_OVERWRITE_STUCK_ISSUE`) — never on any other overwrite failure."""
+    (see :data:`_OVERWRITE_STUCK_ISSUE`) — never on any other overwrite failure.
+
+    Matches the legacy envelope (``Overwrite failed (400): {"code":"1001",…}``)
+    and the staged one the CLI emits since UiPath/cli#3951 (``Context.Stage ==
+    "overwrite-solution"`` with ``Context.ErrorCode == "1001"``, or HTTP 400 and
+    the platform's "invalid value" wording when the code is absent)."""
     if result.returncode == 0:
         return False
     blob = _output_blob(result)
-    return _OVERWRITE_STUCK_MARKER in blob and _OVERWRITE_STUCK_CODE.search(blob) is not None
+    if _OVERWRITE_STUCK_MARKER in blob and _OVERWRITE_STUCK_CODE.search(blob) is not None:
+        return True
+    data = _parse_json(result.stdout)
+    context = _get_ci(data or {}, "Context", default={})
+    if not isinstance(context, dict):
+        return False
+    stage = _get_ci(context, "Stage")
+    if not isinstance(stage, str) or stage.lower() != _OVERWRITE_STUCK_STAGE:
+        return False
+    code = _get_ci(context, "ErrorCode")
+    if str(code) == "1001":
+        return True
+    http = _get_ci(context, "HttpStatus")
+    return http == 400 and "invalid value" in blob
 
 
 def _rotate_solution_id(project_dir: str) -> tuple[str, str] | None:

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -799,6 +799,28 @@ _OVERWRITE_400_1001 = (
     '  "ErrorCode": "unknown_error",\n  "Retry": "RetryWillNotFix"\n}'
 )
 # The 2026-08-26 shape: a real content error that must NOT be rotated around.
+# The staged envelope the CLI emits since UiPath/cli#3951 (main 2026-09-02): the
+# refusal is reported against its stage, the raw body is no longer echoed.
+_OVERWRITE_STAGED_400_1001 = (
+    '{\n  "Result": "Failure",\n'
+    '  "Message": "Failed during overwrite-solution: HTTP 400 on POST '
+    '/codereval/studio_/backend/api/Solution/5ebc2eff-4eab-45a5-df6a-08df093139b4/Overwrite '
+    '\u2014 An argument had an invalid value.",\n'
+    '  "Instructions": "Studio Web refused to replace the contents of solution 5ebc2eff-4eab-45a5-df6a-08df093139b4. '
+    'Nothing was uploaded and nothing ran, so the flow is not the cause.",\n'
+    '  "Context": {"HttpStatus": 400, "Stage": "overwrite-solution", '
+    '"Endpoint": "/codereval/studio_/backend/api/Solution/5ebc2eff-4eab-45a5-df6a-08df093139b4/Overwrite", '
+    '"Method": "POST", "ErrorCode": "1001"},\n'
+    '  "ErrorCode": "invalid_argument",\n  "Retry": "RetryWillNotFix"\n}'
+)
+# Same stage, a different platform code: a content refusal, never rotated.
+_OVERWRITE_STAGED_400_20001 = _OVERWRITE_STAGED_400_1001.replace('"ErrorCode": "1001"', '"ErrorCode": "20001"').replace(
+    'An argument had an invalid value.',
+    'Archive is missing project directories referenced by solution metadata.',
+)
+# Another stage with the same code must not rotate either.
+_UPLOAD_STAGED_400_1001 = _OVERWRITE_STAGED_400_1001.replace('overwrite-solution', 'upload-solution')
+
 _OVERWRITE_400_20001 = _OVERWRITE_400_1001.replace('1001', '20001').replace(
     'An argument had an invalid value.',
     'Archive is missing project directories referenced by solution metadata: [X/temp/project.uiproj].',
@@ -1076,6 +1098,20 @@ def test_run_debug_rotates_the_solution_id_on_overwrite_1001_then_imports(monkey
     assert "previous: 79cda3cb-5a10-4f37-e091-08df08c2afbe" in err
 
 
+def test_run_debug_rotates_the_solution_id_on_the_staged_overwrite_envelope(monkeypatch, tmp_path, capsys):
+    """Same rotation, driven by the CLI's post-UiPath/cli#3951 envelope
+    (``Context.Stage == "overwrite-solution"``, ``Context.ErrorCode == "1001"``)."""
+    sol, proj = _uipx_project(tmp_path)
+    calls = _stub_debug(monkeypatch, [_cp(1, _OVERWRITE_STAGED_400_1001), _cp(0, _COMPLETED)])
+    monkeypatch.setattr(flow_check, "_find_project", lambda pattern: str(proj))
+    payload = run_debug(retries=1)
+    assert calls["n"] == 2
+    assert flow_check.collect_outputs(payload) == ["Sev1"]
+    text = (sol / "Sol.uipx").read_text()
+    assert "79cda3cb-5a10-4f37-e091-08df08c2afbe" not in text
+    assert "INTERIM (UiPath/cli#3938" in capsys.readouterr().err
+
+
 def test_run_debug_rotates_only_once(monkeypatch, tmp_path):
     _, proj = _uipx_project(tmp_path)
     calls = _stub_debug(monkeypatch, [_cp(1, _OVERWRITE_400_1001), _cp(1, _OVERWRITE_400_1001)])
@@ -1114,6 +1150,11 @@ def test_run_debug_overwrite_1001_without_a_uipx_fails_plainly(monkeypatch, tmp_
         (_cp(1, _OVERWRITE_400_20001), False),
         (_cp(0, _OVERWRITE_400_1001), False),
         (_cp(1, _TRANSIENT_504), False),
+        # UiPath/cli#3951 staged envelope
+        (_cp(1, _OVERWRITE_STAGED_400_1001), True),
+        (_cp(1, _OVERWRITE_STAGED_400_20001), False),
+        (_cp(1, _UPLOAD_STAGED_400_1001), False),
+        (_cp(0, _OVERWRITE_STAGED_400_1001), False),
     ],
 )
 def test_is_overwrite_stuck(cp, expected):


### PR DESCRIPTION
## Why

The campaign checker's INTERIM rotation for the Studio Web Overwrite 400/1001 regression (UiPath/cli#3938, skills #2990) matched only the legacy CLI text `Overwrite failed (400): {"code":"1001",…}`. Since [UiPath/cli#3951](https://github.com/UiPath/cli/pull/3951) (main 2026-09-02) the CLI reports a refused upload against its stage:

```
"Message": "Failed during overwrite-solution: HTTP 400 on POST …/Overwrite — An argument had an invalid value.",
"Context": {"HttpStatus": 400, "Stage": "overwrite-solution", "ErrorCode": "1001"}
```

Result on an image built from today's main: every second `flow debug` of a project fails with a plain `flow debug exit 1`, no rotation — observed 2026-09-03 on `skill-flow-decision` and `skill-flow-wiki-pageviews` in **both** arms of the batch-A after-rerun. The nightly baseline (skills `main`) has no rotation at all; the campaign's will silently stop working the moment its image carries #3951.

## What

`_is_overwrite_stuck` also accepts the staged envelope: `Context.Stage == "overwrite-solution"` and `Context.ErrorCode == "1001"` (or HTTP 400 with the platform's "invalid value" wording when the code is absent). Another stage (`upload-solution`) or another code (`20001`, a content refusal) never rotates. The legacy match stays.

## Tests

- `test_is_overwrite_stuck`: +4 cases (staged 1001 → rotate; staged 20001 → no; other stage → no; exit 0 → no).
- `test_run_debug_rotates_the_solution_id_on_the_staged_overwrite_envelope`: end-to-end rotation + import on the new envelope.
- `pytest tests/tasks/uipath-maestro-flow/_shared` → 980 passed; `check-task-driver.py` OK.

Reach tag `shared-checker` (both arms). No prompt, criterion, weight or `run_limits` change; the INTERIM block is still to be deleted when Overwrite works again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENT7zRXbZyvku1y9BNC9TH
