### PR TITLE
fix(uipath-maestro-flow): put the if/otherwise → Decision routing where every greenfield read reaches it

### DIFF
--- a/skills/uipath-maestro-flow/references/author/greenfield.md
+++ b/skills/uipath-maestro-flow/references/author/greenfield.md
@@ -18,6 +18,8 @@ For complex flows, produce a plan before building. Reference [planning-arch.md](
 - The flow is a straightforward linear pipeline (trigger → action → action → end)
 - The user has already described the exact topology they want
 
+**Skipping the plan never skips the node choice.** Two outcomes (*if … otherwise …*) = a `core.logic.decision` node with both `true`/`false` ports wired — never a Script ternary ([decision/planning.md](plugins/decision/planning.md)); three or more outcomes → `core.logic.switch`; a named external service → the Step 3 registry ladder below.
+
 ### Examples
 
 **Plan:** "Build a flow that receives a Jira ticket, classifies it with an AI agent, routes urgent tickets to Slack and non-urgent to a queue, and logs everything to a Google Sheet."


### PR DESCRIPTION
## Why

#3024 put the "two outcomes = a `core.logic.decision`, never a Script ternary" rule under greenfield's "Select the node type" section — **line 241**. Agents read the doc in windows: across the 09-02 run's 102 `greenfield.md` reads, 34 were `sed -n '1,220p'` and 17 were `'1,240p'`; the first after-rerun of `skill-flow-decision` opened `1,220p`, so the sentence never reached the model (verified from the transcript, 2026-09-03). The flow it built did have a Decision this time, but that was not the doc's doing.

## What

One line at the end of "Should you plan first?" (line 20, inside every observed read window): *Skipping the plan never skips the node choice — two outcomes = a Decision node with both ports wired, never a Script ternary; ≥3 → switch; a named service → the Step 3 ladder.* The Step-3 paragraph from #3024 stays.

Reach `v1-skill`; `.maintenance/check-all.sh` green; no prompt/checker/criterion/weight/`run_limits` change. Terra's baseline already builds the Decision, so the line cannot steer it worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENT7zRXbZyvku1y9BNC9TH
