### PR TITLE
fix(uipath-api-workflow): fixes from the 2026-09-03 codereval failures (package-solution, evals gate tasks)

### DIFF
--- a/skills/uipath-api-workflow/SKILL.md
+++ b/skills/uipath-api-workflow/SKILL.md
@@ -125,7 +125,7 @@ Do NOT use for: `.flow` Maestro flows (→ `uipath-maestro-flow`), `.xaml` / cod
 <!--skill-flavor:runtime-validation-limit:end-->
 
 <!--skill-flavor:runtime-execution-consent:start-->
-21. **Never run `uip api-workflow run` without an explicit user "yes."** Validation (rule 20) is autonomous; *running* is not. Once validate passes, ask the user: (a) run now or skip, (b) if running, with `--no-auth` (fast, structure-only — IntSvc kind vendor calls fail) or with auth (real Integration Service calls — vendor side effects WILL happen: emails sent, tickets created, files uploaded). Suggest a default based on workflow content (`--no-auth` for control-flow-only + Http kind `ImplicitConnection`; with-auth for any IntSvc kind vendor activity), but wait for the user's answer. Never invoke `uip api-workflow run` with auth on speculation — once a vendor call goes out, it can't be unsent. This rule gates the run only: when the user asked to package or publish, do not end the turn on the run question — validate, pack (rule 19), and offer the run afterwards.
+21. **Never run `uip api-workflow run` without an explicit user "yes."** Validation (rule 20) is autonomous; *running* is not. Once validate passes, ask the user: (a) run now or skip, (b) if running, with `--no-auth` (fast, structure-only — IntSvc kind vendor calls fail) or with auth (real Integration Service calls — vendor side effects WILL happen: emails sent, tickets created, files uploaded). Suggest a default based on workflow content (`--no-auth` for control-flow-only + Http kind `ImplicitConnection`; with-auth for any IntSvc kind vendor activity), but wait for the user's answer. Never invoke `uip api-workflow run` with auth on speculation — once a vendor call goes out, it can't be unsent. This rule gates only `uip api-workflow run`. If the user asked to package or publish, do not stop on the run question: validate, then pack (rule 19). A local run is a separate request; do it only when the user asks for it.
 <!--skill-flavor:runtime-execution-consent:end-->
 
 22. **TDD gate — only for projects with an `evals/` folder; STOP and ask before authoring; tests are written before the workflow.** Every authoring request (create OR edit — including a one-line change) runs Phase-0 discovery of the project's `evals/` folder — `<project>/evals/`, the directory next to `Workflow.json` (list that directory; the workspace or solution root is the wrong place to look):
@@ -235,7 +235,7 @@ Fix run failures in category order — **Structure > Expression > Activity Confi
 ### Phase 4: Package, Publish, and Operate
 
 <!--skill-flavor:deployment-lifecycle:start-->
-Packaging needs only a passing `validate` (rule 20), not a run: when the request is to build, package, or publish, pack right away and offer the run afterwards — rule 21 gates `uip api-workflow run`, never `uip solution pack`. Deploy via the solution packager. If the project must open in Studio Web, confirm it uses the `init`-produced shape first (rule 19a) — runtime/pack success does not prove it.
+Packaging needs a passing `validate` (rule 20), not a local run. When the request is to build, package, or publish, pack right away; rule 21 gates `uip api-workflow run`, never `uip solution pack`. Deploy via the solution packager. If the project must open in Studio Web, confirm it uses the `init`-produced shape first (rule 19a); runtime/pack success does not prove it.
 
 **Pack:**
 ```bash

--- a/skills/uipath-api-workflow/SKILL.md
+++ b/skills/uipath-api-workflow/SKILL.md
@@ -125,7 +125,7 @@ Do NOT use for: `.flow` Maestro flows (→ `uipath-maestro-flow`), `.xaml` / cod
 <!--skill-flavor:runtime-validation-limit:end-->
 
 <!--skill-flavor:runtime-execution-consent:start-->
-21. **Never run `uip api-workflow run` without an explicit user "yes."** Validation (rule 20) is autonomous; *running* is not. Once validate passes, ask the user: (a) run now or skip, (b) if running, with `--no-auth` (fast, structure-only — IntSvc kind vendor calls fail) or with auth (real Integration Service calls — vendor side effects WILL happen: emails sent, tickets created, files uploaded). Suggest a default based on workflow content (`--no-auth` for control-flow-only + Http kind `ImplicitConnection`; with-auth for any IntSvc kind vendor activity), but wait for the user's answer. Never invoke `uip api-workflow run` with auth on speculation — once a vendor call goes out, it can't be unsent.
+21. **Never run `uip api-workflow run` without an explicit user "yes."** Validation (rule 20) is autonomous; *running* is not. Once validate passes, ask the user: (a) run now or skip, (b) if running, with `--no-auth` (fast, structure-only — IntSvc kind vendor calls fail) or with auth (real Integration Service calls — vendor side effects WILL happen: emails sent, tickets created, files uploaded). Suggest a default based on workflow content (`--no-auth` for control-flow-only + Http kind `ImplicitConnection`; with-auth for any IntSvc kind vendor activity), but wait for the user's answer. Never invoke `uip api-workflow run` with auth on speculation — once a vendor call goes out, it can't be unsent. This rule gates the run only: when the user asked to package or publish, do not end the turn on the run question — validate, pack (rule 19), and offer the run afterwards.
 <!--skill-flavor:runtime-execution-consent:end-->
 
 22. **TDD gate — only for projects with an `evals/` folder; STOP and ask before authoring; tests are written before the workflow.** Every authoring request (create OR edit — including a one-line change) runs Phase-0 discovery of the project's `evals/` folder — `<project>/evals/`, the directory next to `Workflow.json` (list that directory; the workspace or solution root is the wrong place to look):
@@ -235,7 +235,7 @@ Fix run failures in category order — **Structure > Expression > Activity Confi
 ### Phase 4: Package, Publish, and Operate
 
 <!--skill-flavor:deployment-lifecycle:start-->
-Once the workflow runs locally, deploy via the solution packager. If the project must open in Studio Web, confirm it uses the `init`-produced shape first (rule 19a) — runtime/pack success does not prove it.
+Packaging needs only a passing `validate` (rule 20), not a run: when the request is to build, package, or publish, pack right away and offer the run afterwards — rule 21 gates `uip api-workflow run`, never `uip solution pack`. Deploy via the solution packager. If the project must open in Studio Web, confirm it uses the `init`-produced shape first (rule 19a) — runtime/pack success does not prove it.
 
 **Pack:**
 ```bash

--- a/tests/tasks/uipath-api-workflow/evals/gate_create/gate_create.yaml
+++ b/tests/tasks/uipath-api-workflow/evals/gate_create/gate_create.yaml
@@ -55,9 +55,11 @@ success_criteria:
     # false 0/1 under the old verb-plus-path-only pattern. Still Bash-text-only:
     # an agent inspecting via native Read/Glob tools is invisible here — if a
     # harness variant hits that, make this advisory like the runner checks.
-    description: "Discovery happened: the agent inspected the project / its evals folder before stopping (an agent that does nothing fails this)"
-    tool_name: "Bash"
-    command_pattern: '((ls|find|cat|tree|head|tail|sed|awk|jq|rg|python3?|grep)\s[^\n]*(AddNumbers|evals|Workflow\.json)|rg\s+--files|\bfind\s+\.|\btree\b|\bls\b)'
+    # No tool_name filter: non-Bash agents (gemini/antigravity, 2026-09-03) explore with
+    # Read/LS/Glob tool calls, which the checker matches as JSON parameters. Edit/Write
+    # calls are vetoed up front (old_string/new_string/content) so only reads count.
+    description: "Discovery happened: the agent inspected the project / its evals folder before stopping — a shell command or a Read/LS/Glob tool call (an agent that does nothing fails this)"
+    command_pattern: '^(?![\s\S]*"(old_string|new_string|content)")[\s\S]*?((ls|find|cat|tree|head|tail|sed|awk|jq|rg|python3?|grep)\s[^\n]*(AddNumbers|evals|Workflow\.json)|rg\s+--files|\bfind\s+\.|\btree\b|\bls\b|"(file_path|path|directory_path)":\s*"[^"]*(AddNumbers|/evals(/|")|Workflow\.json))'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-api-workflow/evals/gate_create/gate_create.yaml
+++ b/tests/tasks/uipath-api-workflow/evals/gate_create/gate_create.yaml
@@ -82,4 +82,7 @@ success_criteria:
 
 run_limits:
   expected_turns: 5
-  max_turns: 14
+  # 20, not 14: agents that explore one directory per LS call and read the skill
+  # files with Read (gemini/antigravity, 2026-09-03) ran out of turns before
+  # producing the final response the llm_judge grades.
+  max_turns: 20

--- a/tests/tasks/uipath-api-workflow/evals/gate_create/gate_create.yaml
+++ b/tests/tasks/uipath-api-workflow/evals/gate_create/gate_create.yaml
@@ -48,16 +48,16 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    # Two accepted shapes: an inspector verb naming a project path, OR a bare
-    # enumeration of the sandbox (`rg --files`, `ls`, `find .`, `tree`) — which
-    # surfaces AddNumbers/evals in its output without naming it in the command
-    # text. The 2026-09-01 run discovered via `rg --files | sed` and scored a
-    # false 0/1 under the old verb-plus-path-only pattern. Still Bash-text-only:
-    # an agent inspecting via native Read/Glob tools is invisible here — if a
-    # harness variant hits that, make this advisory like the runner checks.
-    # No tool_name filter: non-Bash agents (gemini/antigravity, 2026-09-03) explore with
-    # Read/LS/Glob tool calls, which the checker matches as JSON parameters. Edit/Write
-    # calls are vetoed up front (old_string/new_string/content) so only reads count.
+    # Three accepted shapes, any tool: (1) a shell inspector verb naming a project path;
+    # (2) a bare enumeration of the sandbox (`rg --files`, `ls`, `find .`, `tree`), which
+    # surfaces AddNumbers/evals in its output without naming it — the 2026-09-01 run
+    # discovered via `rg --files | sed` and scored a false 0/1 under a verb-plus-path
+    # pattern; (3) a Read/LS/Glob tool call whose file_path / path / directory_path
+    # points into the project or its evals/ folder — non-Bash agents (gemini/antigravity,
+    # 2026-09-03) never open a shell, so there is no tool_name filter and the checker
+    # matches their JSON parameters. Edit/Write calls are vetoed up front
+    # (old_string/new_string/content) so only reads count, and `/evals(/|")` keeps a
+    # Read of the skill's own testing-and-evals.md from counting.
     description: "Discovery happened: the agent inspected the project / its evals folder before stopping — a shell command or a Read/LS/Glob tool call (an agent that does nothing fails this)"
     command_pattern: '^(?![\s\S]*"(old_string|new_string|content)")[\s\S]*?((ls|find|cat|tree|head|tail|sed|awk|jq|rg|python3?|grep)\s[^\n]*(AddNumbers|evals|Workflow\.json)|rg\s+--files|\bfind\s+\.|\btree\b|\bls\b|"(file_path|path|directory_path)":\s*"[^"]*(AddNumbers|/evals(/|")|Workflow\.json))'
     min_count: 1

--- a/tests/tasks/uipath-api-workflow/evals/gate_edit/gate_edit.yaml
+++ b/tests/tasks/uipath-api-workflow/evals/gate_edit/gate_edit.yaml
@@ -43,16 +43,16 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    # Two accepted shapes: an inspector verb naming a project path, OR a bare
-    # enumeration of the sandbox (`rg --files`, `ls`, `find .`, `tree`) — which
-    # surfaces GradeCheck/evals in its output without naming it in the command
-    # text (same false negative gate_create hit in the 2026-09-01 run via
-    # `rg --files | sed`). Still Bash-text-only: an agent inspecting via native
-    # Read/Glob tools is invisible here — if a harness variant hits that, make
-    # this advisory like the runner checks.
-    # No tool_name filter: non-Bash agents (gemini/antigravity, 2026-09-03) explore with
-    # Read/LS/Glob tool calls, which the checker matches as JSON parameters. Edit/Write
-    # calls are vetoed up front (old_string/new_string/content) so only reads count.
+    # Three accepted shapes, any tool: (1) a shell inspector verb naming a project path;
+    # (2) a bare enumeration of the sandbox (`rg --files`, `ls`, `find .`, `tree`), which
+    # surfaces GradeCheck/evals in its output without naming it — the 2026-09-01 run
+    # discovered via `rg --files | sed` and scored a false 0/1 under a verb-plus-path
+    # pattern; (3) a Read/LS/Glob tool call whose file_path / path / directory_path
+    # points into the project or its evals/ folder — non-Bash agents (gemini/antigravity,
+    # 2026-09-03) never open a shell, so there is no tool_name filter and the checker
+    # matches their JSON parameters. Edit/Write calls are vetoed up front
+    # (old_string/new_string/content) so only reads count, and `/evals(/|")` keeps a
+    # Read of the skill's own testing-and-evals.md from counting.
     description: "Discovery happened: the agent inspected the project / its evals folder before stopping — a shell command or a Read/LS/Glob tool call (an agent that does nothing fails this)"
     command_pattern: '^(?![\s\S]*"(old_string|new_string|content)")[\s\S]*?((ls|find|cat|tree|head|tail|sed|awk|jq|rg|python3?|grep)\s[^\n]*(GradeCheck|evals|Workflow\.json)|rg\s+--files|\bfind\s+\.|\btree\b|\bls\b|"(file_path|path|directory_path)":\s*"[^"]*(GradeCheck|/evals(/|")|Workflow\.json))'
     min_count: 1

--- a/tests/tasks/uipath-api-workflow/evals/gate_edit/gate_edit.yaml
+++ b/tests/tasks/uipath-api-workflow/evals/gate_edit/gate_edit.yaml
@@ -79,4 +79,7 @@ success_criteria:
 
 run_limits:
   expected_turns: 5
-  max_turns: 14
+  # 20, not 14: agents that explore one directory per LS call and read the skill
+  # files with Read (gemini/antigravity, 2026-09-03) ran out of turns before
+  # producing the final response the llm_judge grades.
+  max_turns: 20

--- a/tests/tasks/uipath-api-workflow/evals/gate_edit/gate_edit.yaml
+++ b/tests/tasks/uipath-api-workflow/evals/gate_edit/gate_edit.yaml
@@ -50,9 +50,11 @@ success_criteria:
     # `rg --files | sed`). Still Bash-text-only: an agent inspecting via native
     # Read/Glob tools is invisible here — if a harness variant hits that, make
     # this advisory like the runner checks.
-    description: "Discovery happened: the agent inspected the project / its evals folder before stopping (an agent that does nothing fails this)"
-    tool_name: "Bash"
-    command_pattern: '((ls|find|cat|tree|head|tail|sed|awk|jq|rg|python3?|grep)\s[^\n]*(GradeCheck|evals|Workflow\.json)|rg\s+--files|\bfind\s+\.|\btree\b|\bls\b)'
+    # No tool_name filter: non-Bash agents (gemini/antigravity, 2026-09-03) explore with
+    # Read/LS/Glob tool calls, which the checker matches as JSON parameters. Edit/Write
+    # calls are vetoed up front (old_string/new_string/content) so only reads count.
+    description: "Discovery happened: the agent inspected the project / its evals folder before stopping — a shell command or a Read/LS/Glob tool call (an agent that does nothing fails this)"
+    command_pattern: '^(?![\s\S]*"(old_string|new_string|content)")[\s\S]*?((ls|find|cat|tree|head|tail|sed|awk|jq|rg|python3?|grep)\s[^\n]*(GradeCheck|evals|Workflow\.json)|rg\s+--files|\bfind\s+\.|\btree\b|\bls\b|"(file_path|path|directory_path)":\s*"[^"]*(GradeCheck|/evals(/|")|Workflow\.json))'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-api-workflow/evals/gate_off_no_evals/gate_off_no_evals.yaml
+++ b/tests/tasks/uipath-api-workflow/evals/gate_off_no_evals/gate_off_no_evals.yaml
@@ -9,7 +9,9 @@ description: >
 
   The negative twin of gate_create (which seeds the panel-created folder and
   expects the agent to stop and ask): together they pin the condition the gate
-  hinges on. Local-only.
+  hinges on. The prompt names the output key because the grader exact-matches
+  `{ "sum": 5 }` — an agent that picks `result`, or returns `{ result, sum }`
+  (gemini-3.6-flash, 2026-09-03), is not what this task measures. Local-only.
 tags: [uipath-api-workflow, integration, mode:build, lifecycle:generate, feature:eval]
 
 sandbox:
@@ -21,7 +23,7 @@ pre_run:
 
 initial_prompt: |
   Create an API workflow in the scaffolded project ./AddNumbers that takes two
-  numbers `a` and `b` and returns their sum.
+  numbers `a` and `b` and returns their sum as `{ "sum": <a + b> }`.
 
 success_criteria:
   - type: run_command


### PR DESCRIPTION
Analysis of six failing `uipath-api-workflow` runs from the 2026-09-03 codereval (2× claude-sonnet-5, 4× gemini-3.6-flash / antigravity). One commit per problem. Infra failures are left alone (see bottom). PR #2925 (ForEach `?.` + run_execute grader) does not touch any of these.

## 1. Skill: `package-solution` stopped at the rule-21 run question (`85006cc88`)

claude-sonnet-5 scaffolded, authored, validated — then ended its turn asking whether to run locally before packaging. Nobody answers in an eval, so `uip solution pack` never ran and no artifact was produced (score 0). Two passages combined badly: Phase 4 opened with *"Once the workflow runs locally, deploy via the solution packager"* and rule 21 says to ask run-or-skip once validate passes.

**Fix:** Phase 4 now says pack needs only a passing `validate`, not a run; rule 21 says it gates the run only — when asked to package or publish, validate, pack, then offer the run. Both passages are in flavor blocks that the Studio Web override replaces; the override never coupled pack to a run, so it is unchanged.

## 2. Test: `gate_off_no_evals` prompt vs exact-match grader (`13fcfa343`)

gemini authored a valid workflow returning `{"result": 5, "sum": 5}`; `check_authored.py` exact-matches `{"sum": 5}`. The prompt only said "returns their sum", so the key was the agent's guess. The task measures the gate staying silent without `evals/`, not output naming.

**Fix:** prompt now spells out `{ "sum": <a + b> }` (a ground-truth anchor, same as the grader).

## 3. Test: `gate_create` / `gate_edit` discovery criterion was Bash-only (`34d58601c`)

gemini explored with `LS` / `Read` / `Glob` tool calls, never a shell command, so the "discovery happened" criterion scored 0 even though discovery did happen. A gate-compliant non-Bash agent could not pass these tasks. (gemini also edited before asking — a real rule-22 violation, correctly failed by `check_gate.py`; the skill already leads with the gate, so no skill change for that.)

**Fix:** drop `tool_name: "Bash"` (the checker then matches non-Bash tools against their JSON parameters), accept `file_path` / `path` / `directory_path` into the project or `evals/`, veto Edit/Write calls via `old_string|new_string|content` so only reads count, and keep a Read of the skill's own `testing-and-evals.md` from counting. Regex checked against 13 positive/negative samples taken from the real transcripts.

## 4. Test: `gate_create` / `gate_edit` max_turns 14 → 20 (`4cc0eb6d6`)

Both gemini runs ended `MAX_TURNS_EXHAUSTED` at 14 turns — one `LS` per directory level plus `Read`s of the skill files — before producing the final response the `llm_judge` grades.

## Left alone — infra

`skill-api-workflow-diagnose-cloud-job-fault` failed twice (both models) in **pre-run**: `seed_faulted_job.py deploy` → `uip solution deploy run` returned `Deployment failed with status: ValidationFailed` on `Shared/uipath-platform-e2e`. Pack/publish succeeded and the artifact is well-formed; the fixture is unchanged since #2653. Tenant/CLI side — needs the full deploy response to diagnose.

## Checks

- `npm run skills:validate` / `npm run skills:build` pass
- `/lint-task` on the three edited YAMLs: `gate_off_no_evals` OK; `gate_create` / `gate_edit` Low only (documented llm_judge weight, loose discovery guard); CLI-verb axis Info only
- **Passing run:** ran `skill-api-workflow-evals-gate-off-no-evals` locally under `experiments/default.yaml` (tempdir, claude-sonnet-4-6) and it passed — 3/3 criteria, weighted score 1.000, 63.5s. The agent returned `{ sum: … }` as the prompt now specifies.
- **Accepted exception — `gate_create` / `gate_edit` not re-run:** both tasks grade on an `llm_judge` criterion (weight 3.0) that needs the `CODEX_BASE_URL` / `CODEX_API_KEY` judge transport, which is not available on this machine, and the failing model (gemini-3.6-flash via antigravity) is not runnable locally. The changed criterion's regex was instead checked against 13 positive/negative samples lifted from the real gemini transcripts (LS/Read/Glob parameters, Edit/Write vetoes, the `testing-and-evals.md` false positive). The nightly runner is the first place these two get a full pass.
- Stale "Still Bash-text-only" comment blocks flagged by the PR bot are merged into the new discovery note (`06eb62ba4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
