### PR TITLE
Route group-bundle questions to the composite verb, and check the envelope root

### DIFF
--- a/skills/uipath-platform/references/licensing/user-licenses-allocations.md
+++ b/skills/uipath-platform/references/licensing/user-licenses-allocations.md
@@ -206,6 +206,10 @@ Returns one row per `(group, bundle)` pair:
 
 ### Drill into One Group
 
+One command answers "who in group X holds which bundle". Do not reconstruct that answer from
+`uip admin groups members list` plus a `users licenses get` per member: that returns each member's
+*direct* leases, loses the `orphan` and `quota` fields entirely, and costs one call per user.
+
 ```bash
 uip platform groups rules details "<GROUP_NAME_PREFIX>" --output json
 
@@ -311,6 +315,7 @@ Both mechanisms can co-exist for the same user; rows appear with separate `sourc
 - **Sort order is case-sensitive.** `Asc`/`Desc` only. `asc`, `ASC`, or `ascending` are all rejected.
 - **`orphan: true` rows** still consume a lease until the rule is re-applied or the user is fully removed.
 - **`useExternalLicense`** in `groups rules get` is informational — set externally, not via these commands.
+- **`uip admin groups` does not answer licensing questions.** It lists group membership; it knows nothing about bundles or leases. Any question of the form "who in this group holds which bundle" is `groups rules details`.
 - **Group rule summary goes to stderr.** When piping `groups rules details` output, the rule header (entitled bundles, quotas) is on `stderr` so the JSON on `stdout` stays clean for `jq`.
 
 ---

--- a/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
@@ -43,9 +43,10 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_contains
-    description: "details.json captures a JSON response envelope"
-    path: "details.json"
-    includes: ['"Result"']
+  - type: run_command
+    description: "details.json is the raw CLI envelope — `Result` at the root, not envelopes nested inside a hand-built structure"
+    command: "python3 -c \"import json,sys; d=json.load(open('details.json')); sys.exit(0 if isinstance(d,dict) and 'Result' in d else 1)\""
+    timeout: 10
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0


### PR DESCRIPTION
Eval run [33762424597](https://github.com/UiPath/skills/actions/runs/33762424597) failed `groups-rules-details` at **0.455** (claude-code / claude-sonnet-5). Real agent failure plus a criterion too weak to catch it.

## What the agent did

The task asks *"Who in the RPA Developers group currently holds which license bundle?"* — the exact question `uip platform groups rules details` exists to answer. The agent never ran it, decomposing the question instead:

```
uip admin groups list
uip admin groups members list <group-id>
uip admin users get <user-id>                 x6
uip platform users licenses get <email>       x6
```

13 calls to rebuild what one call returns — and the rebuilt answer is **not equivalent**: `users licenses get` returns each member's *direct* leases, so group-inherited rows are mislabelled, and `orphan` / `quota` are lost entirely.

## Skill fix

`user-licenses-allocations.md` already listed the verb, but only where an agent that had already chosen the licensing path would see it. This agent went to `uip admin` and never got there. Added guidance at the decomposition point:

- "Drill into One Group" now opens by saying one command answers this, and not to rebuild it from `admin groups members list` plus per-member `users licenses get`, with the reason (loses `orphan`/`quota`, direct-only, N calls).
- A gotcha stating `uip admin groups` knows nothing about bundles or leases.

## Criterion fix

`details.json captures a JSON response envelope` grepped for the substring `"Result"`. The hand-built file **nests** real envelopes inside a custom `{group, groupMembers, members[]}` structure, so it passed — only the cmdlog check caught the failure. Now asserts `Result` at the **root**:

| Fixture | Want | Result |
|---|---|---|
| The hand-built file from this run | reject | reject |
| Raw success envelope | accept | accept |
| Raw failure envelope (offline runs) | accept | accept |
| Prose header then JSON (the read-e2e failure mode) | reject | reject |

Failure envelopes still pass, so the check stays valid when the CLI is unauthenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)