### PR TITLE
fix(flow-check): INTERIM — rotate the SolutionId when Studio Web's Overwrite answers 400/1001 (UiPath/cli#3938)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -130,6 +130,101 @@ def _output_blob(result: subprocess.CompletedProcess) -> str:
     return f"{result.stdout}\n{result.stderr}".lower()
 
 
+# INTERIM — Studio Web `Solution/{id}/Overwrite` regression (UiPath/cli#3938).
+#
+# Since 2026-09-02 (last known good: 2026-09-01 07:30Z) Studio Web answers
+# `400 {"code":"1001","message":"An argument had an invalid value."}` when a
+# solution that EXISTS is overwritten. `uip maestro flow debug` imports the
+# project on its first run and writes the server's solution id back into the
+# `.uipx`, so every LATER debug of the same project is an overwrite — and the
+# CLI treats any non-404 Overwrite as fatal. Result: the second debug of a
+# project dies at solution upload, so every multi-case checker fails its later
+# cases, and a task whose agent debugged during its turn fails its first.
+# A fresh bundled SolutionId imports as new and Completes, so ONLY overwrite is
+# broken. The only earlier archived Overwrite 400 (2026-08-26) was code 20001, a
+# content error that must still fail.
+#
+# So: on exactly that signature, rotate the bundled SolutionId to a fresh uuid4
+# and retry ONCE — the retry is a new import. Self-limiting: once Overwrite
+# recovers the signature never fires and nothing here runs. Cost while it does:
+# one extra tenant solution per affected case, which `cleanup_solutions.py`
+# cannot see (it reads the `.uipx`'s CURRENT id) — the ids are printed so they
+# are not lost. Delete this block when Overwrite works again.
+_OVERWRITE_STUCK_ISSUE = "UiPath/cli#3938"
+_OVERWRITE_STUCK_MARKER = "overwrite failed (400)"
+_OVERWRITE_STUCK_CODE = re.compile(r'\\?"code\\?":\s*\\?"1001\\?"')
+# Since UiPath/cli#3951 (main 2026-09-02, `016231474`) the CLI reports a refused
+# upload against its stage instead of echoing the raw body:
+#   Message: "Failed during overwrite-solution: HTTP 400 on POST …/Overwrite — An argument had an invalid value."
+#   Context: {"HttpStatus": 400, "Stage": "overwrite-solution", "ErrorCode": "1001"}
+# The rotation must recognise both envelopes: an image whose CLI carries #3951
+# but whose checker knows only the legacy text fails every second debug of a
+# project with a plain `flow debug exit 1`.
+_OVERWRITE_STUCK_STAGE = "overwrite-solution"
+_OVERWRITE_STUCK_ATTEMPTS = 2  # the failed overwrite + one import-as-new retry
+_SOLUTION_ID_RE = re.compile(r'("SolutionId"\s*:\s*")([0-9a-fA-F-]{36})(")')
+
+
+def _is_overwrite_stuck(result: subprocess.CompletedProcess) -> bool:
+    """True iff ``flow debug`` died on the Studio Web Overwrite 400/1001 regression
+    (see :data:`_OVERWRITE_STUCK_ISSUE`) — never on any other overwrite failure.
+
+    Matches the legacy envelope (``Overwrite failed (400): {"code":"1001",…}``)
+    and the staged one the CLI emits since UiPath/cli#3951 (``Context.Stage ==
+    "overwrite-solution"`` with ``Context.ErrorCode == "1001"``, or HTTP 400 and
+    the platform's "invalid value" wording when the code is absent)."""
+    if result.returncode == 0:
+        return False
+    blob = _output_blob(result)
+    if _OVERWRITE_STUCK_MARKER in blob and _OVERWRITE_STUCK_CODE.search(blob) is not None:
+        return True
+    data = _parse_json(result.stdout)
+    context = _get_ci(data or {}, "Context", default={})
+    if not isinstance(context, dict):
+        return False
+    stage = _get_ci(context, "Stage")
+    if not isinstance(stage, str) or stage.lower() != _OVERWRITE_STUCK_STAGE:
+        return False
+    code = _get_ci(context, "ErrorCode")
+    if str(code) == "1001":
+        return True
+    http = _get_ci(context, "HttpStatus")
+    return http == 400 and "invalid value" in blob
+
+
+def _rotate_solution_id(project_dir: str) -> tuple[str, str] | None:
+    """Give the project's solution a fresh bundled ``SolutionId`` so the next
+    ``flow debug`` imports it as a NEW Studio Web solution instead of overwriting.
+
+    Walks up from ``project_dir`` to the nearest ancestor holding exactly one
+    ``*.uipx`` (a JSON text file; ``uip solution init`` writes it beside the
+    project directory). Returns ``(old, new)``, or ``None`` when no unambiguous
+    ``.uipx`` is found — the caller then fails the plain way."""
+    import uuid
+
+    here = os.path.abspath(project_dir)
+    for _ in range(4):
+        uipx = sorted(glob.glob(os.path.join(glob.escape(here), "*.uipx")))
+        if len(uipx) == 1:
+            try:
+                with open(uipx[0], encoding="utf-8") as handle:
+                    text = handle.read()
+            except OSError:
+                return None
+            match = _SOLUTION_ID_RE.search(text)
+            if match is None:
+                return None
+            new = str(uuid.uuid4())
+            with open(uipx[0], "w", encoding="utf-8") as handle:
+                handle.write(text[: match.start(2)] + new + text[match.end(2):])
+            return match.group(2), new
+        parent = os.path.dirname(here)
+        if parent == here:
+            break
+        here = parent
+    return None
+
+
 def _is_transient_debug_error(result: subprocess.CompletedProcess) -> bool:
     """True iff a failed ``flow debug`` invocation looks like a transient
     server-side error (5xx / RetryLater / poll-budget expiry) worth retrying,
@@ -275,7 +370,15 @@ def run_debug(
     # Mirrors debug_budget: pricing an attempt the loop never makes left `r` unbound.
     attempts = max(1, retries)
 
-    for attempt in range(attempts):
+    overwrite_rotations = 0
+    rotated_solution_ids: list[str] = []
+    # `max_attempts` starts at the transient allowance and is extended by one for
+    # an INTERIM SolutionId rotation: that retry has its own allowance, never the
+    # 5xx/RetryLater one. The deadline below still bounds every attempt, so the
+    # criterion budget holds.
+    max_attempts = attempts
+    attempt = 0
+    while attempt < max_attempts:
         attempt_cap = min(timeout, int(deadline - time.monotonic()))
         cli_timeout = max(
             _MIN_CLI_TIMEOUT_SECONDS, attempt_cap - _CLI_TIMEOUT_HEADROOM_SECONDS
@@ -300,16 +403,36 @@ def run_debug(
                 f"stdout: {_as_text(exc.stdout)}\nstderr: {_as_text(exc.stderr)}"
             )
         _LAST_DEBUG_RAW = r.stdout
-        if r.returncode == 0 or not _is_transient_debug_error(r):
+        if r.returncode == 0:
+            break
+        if _is_overwrite_stuck(r) and overwrite_rotations < _OVERWRITE_STUCK_ATTEMPTS - 1:
+            # INTERIM (see _OVERWRITE_STUCK_ISSUE): its own single allowance; the
+            # deadline below still bounds it.
+            rotated = _rotate_solution_id(project_dir)
+            if rotated is None:
+                break
+            overwrite_rotations += 1
+            rotated_solution_ids.append(rotated[0])
+            print(
+                f"INTERIM ({_OVERWRITE_STUCK_ISSUE}: Studio Web Overwrite → 400/1001 for an "
+                f"existing solution since 2026-09-02): rotated the bundled SolutionId "
+                f"{rotated[0]} → {rotated[1]}; retrying as a new import. The solution "
+                f"{rotated[0]} stays on the tenant (cleanup reads only the current id).",
+                file=sys.stderr,
+                flush=True,
+            )
+            max_attempts = max(max_attempts, attempt + 2)
+        elif not _is_transient_debug_error(r):
             break
         if _is_poll_timeout(r) and attempt + 1 >= _POLL_TIMEOUT_ATTEMPTS:
             break
-        if attempt + 1 < attempts:
+        if attempt + 1 < max_attempts:
             left = deadline - time.monotonic() - backoff_seconds
             if left < _MIN_RETRY_BUDGET_SECONDS:
                 out_of_budget = True
                 break
             time.sleep(backoff_seconds)
+        attempt += 1
 
     if r.returncode != 0:
         spent = (
@@ -326,6 +449,14 @@ def run_debug(
     if data is None:
         _fail(f"Could not parse JSON from flow debug\n{r.stdout}")
     payload = _get_ci(data, "Data") or {}
+    if rotated_solution_ids:
+        print(
+            f"INTERIM ({_OVERWRITE_STUCK_ISSUE}): debug ran as a new import; Studio Web "
+            f"solution {_get_ci(payload, 'solutionId', 'SolutionId')} (previous: "
+            f"{', '.join(rotated_solution_ids)}).",
+            file=sys.stderr,
+            flush=True,
+        )
     status = _get_ci(payload, "finalStatus", "FinalStatus")
     if status != "Completed":
         _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout}")

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -1130,3 +1130,143 @@ def test_run_debug_invariants_under_random_schedules(seed, monkeypatch):
     for cap, cli in caps:
         assert cap > 0, f"non-positive subprocess cap {cap}"
         assert cli < cap, f"CLI timeout {cli} does not fit inside the {cap}s cap"
+
+
+# ── INTERIM: Studio Web Overwrite 400/1001 rotation (UiPath/cli#3938) ────────
+# Delete this whole section with the _OVERWRITE_STUCK block in flow_check.py
+# once Studio Web's Solution/{id}/Overwrite accepts an existing solution again.
+
+
+# Verbatim from `uip maestro flow debug` on 2026-09-02 07:48Z: Studio Web's
+# Overwrite answering 400/1001 for an EXISTING solution (UiPath/cli#3938).
+_OVERWRITE_400_1001 = (
+    '{\n  "Result": "Failure",\n'
+    '  "Message": "Overwrite failed (400): {\\"code\\":\\"1001\\",\\"message\\":'
+    '\\"An argument had an invalid value.\\",\\"translatedMessage\\":null}",\n'
+    '  "Instructions": "Check that the flow project is valid, the selected folder '
+    'is accessible, and Studio Web debug is available, then retry.",\n'
+    '  "ErrorCode": "unknown_error",\n  "Retry": "RetryWillNotFix"\n}'
+)
+# The staged envelope the CLI emits since UiPath/cli#3951 (main 2026-09-02): the
+# refusal is reported against its stage, the raw body is no longer echoed.
+_OVERWRITE_STAGED_400_1001 = (
+    '{\n  "Result": "Failure",\n'
+    '  "Message": "Failed during overwrite-solution: HTTP 400 on POST '
+    '/codereval/studio_/backend/api/Solution/5ebc2eff-4eab-45a5-df6a-08df093139b4/Overwrite '
+    '— An argument had an invalid value.",\n'
+    '  "Instructions": "Studio Web refused to replace the contents of solution 5ebc2eff-4eab-45a5-df6a-08df093139b4. '
+    'Nothing was uploaded and nothing ran, so the flow is not the cause.",\n'
+    '  "Context": {"HttpStatus": 400, "Stage": "overwrite-solution", '
+    '"Endpoint": "/codereval/studio_/backend/api/Solution/5ebc2eff-4eab-45a5-df6a-08df093139b4/Overwrite", '
+    '"Method": "POST", "ErrorCode": "1001"},\n'
+    '  "ErrorCode": "invalid_argument",\n  "Retry": "RetryWillNotFix"\n}'
+)
+# Same stage, a different platform code: a content refusal, never rotated.
+_OVERWRITE_STAGED_400_20001 = _OVERWRITE_STAGED_400_1001.replace(
+    '"ErrorCode": "1001"', '"ErrorCode": "20001"'
+).replace(
+    'An argument had an invalid value.',
+    'Archive is missing project directories referenced by solution metadata.',
+)
+# Another stage with the same code must not rotate either.
+_UPLOAD_STAGED_400_1001 = _OVERWRITE_STAGED_400_1001.replace(
+    'overwrite-solution', 'upload-solution'
+)
+# The 2026-08-26 shape: a real content error that must NOT be rotated around.
+_OVERWRITE_400_20001 = _OVERWRITE_400_1001.replace('1001', '20001').replace(
+    'An argument had an invalid value.',
+    'Archive is missing project directories referenced by solution metadata: [X/temp/project.uiproj].',
+)
+
+
+def _uipx_project(tmp_path, solution_id="79cda3cb-5a10-4f37-e091-08df08c2afbe"):
+    """A `uip solution init` shape: the `.uipx` beside the project directory."""
+    sol = tmp_path / "Sol"
+    proj = sol / "Proj"
+    proj.mkdir(parents=True)
+    (sol / "Sol.uipx").write_text(
+        '{\n  "SolutionId": "%s",\n  "Name": "Sol",\n  "Projects": []\n}\n' % solution_id
+    )
+    return sol, proj
+
+
+def test_run_debug_rotates_the_solution_id_on_overwrite_1001_then_imports(monkeypatch, tmp_path, capsys):
+    """INTERIM (UiPath/cli#3938): the Studio Web Overwrite 400/1001 regression is
+    met with ONE retry as a new import — the bundled SolutionId is rotated first."""
+    sol, proj = _uipx_project(tmp_path)
+    calls = _stub_debug(monkeypatch, [_cp(1, _OVERWRITE_400_1001), _cp(0, _COMPLETED)])
+    monkeypatch.setattr(flow_check, "_find_project", lambda pattern: str(proj))
+    payload = run_debug(retries=1)
+    assert calls["n"] == 2
+    assert collect_outputs(payload) == ["Sev1"]
+    text = (sol / "Sol.uipx").read_text()
+    assert "79cda3cb-5a10-4f37-e091-08df08c2afbe" not in text
+    assert flow_check._SOLUTION_ID_RE.search(text) is not None
+    err = capsys.readouterr().err
+    assert "INTERIM (UiPath/cli#3938" in err
+    assert "rotated the bundled SolutionId 79cda3cb-5a10-4f37-e091-08df08c2afbe" in err
+    # The orphaned server id is named, because cleanup reads only the current one.
+    assert "previous: 79cda3cb-5a10-4f37-e091-08df08c2afbe" in err
+
+
+def test_run_debug_rotates_the_solution_id_on_the_staged_overwrite_envelope(monkeypatch, tmp_path, capsys):
+    """Same rotation, driven by the CLI's post-UiPath/cli#3951 envelope
+    (``Context.Stage == "overwrite-solution"``, ``Context.ErrorCode == "1001"``)."""
+    sol, proj = _uipx_project(tmp_path)
+    calls = _stub_debug(monkeypatch, [_cp(1, _OVERWRITE_STAGED_400_1001), _cp(0, _COMPLETED)])
+    monkeypatch.setattr(flow_check, "_find_project", lambda pattern: str(proj))
+    payload = run_debug(retries=1)
+    assert calls["n"] == 2
+    assert collect_outputs(payload) == ["Sev1"]
+    text = (sol / "Sol.uipx").read_text()
+    assert "79cda3cb-5a10-4f37-e091-08df08c2afbe" not in text
+    assert "INTERIM (UiPath/cli#3938" in capsys.readouterr().err
+
+
+def test_run_debug_rotates_only_once(monkeypatch, tmp_path):
+    _, proj = _uipx_project(tmp_path)
+    calls = _stub_debug(monkeypatch, [_cp(1, _OVERWRITE_400_1001), _cp(1, _OVERWRITE_400_1001)])
+    monkeypatch.setattr(flow_check, "_find_project", lambda pattern: str(proj))
+    with pytest.raises(SystemExit) as exc:
+        run_debug(retries=1)
+    assert calls["n"] == 2
+    assert "Overwrite failed (400)" in str(exc.value)
+
+
+def test_run_debug_does_not_rotate_on_a_content_overwrite_error(monkeypatch, tmp_path):
+    """Code 20001 (2026-08-26) is the archive being wrong; rotating would hide it."""
+    sol, proj = _uipx_project(tmp_path)
+    calls = _stub_debug(monkeypatch, [_cp(1, _OVERWRITE_400_20001)])
+    monkeypatch.setattr(flow_check, "_find_project", lambda pattern: str(proj))
+    with pytest.raises(SystemExit):
+        run_debug(retries=1)
+    assert calls["n"] == 1
+    assert "79cda3cb-5a10-4f37-e091-08df08c2afbe" in (sol / "Sol.uipx").read_text()
+
+
+def test_run_debug_overwrite_1001_without_a_uipx_fails_plainly(monkeypatch, tmp_path):
+    proj = tmp_path / "Proj"
+    proj.mkdir()
+    calls = _stub_debug(monkeypatch, [_cp(1, _OVERWRITE_400_1001)])
+    monkeypatch.setattr(flow_check, "_find_project", lambda pattern: str(proj))
+    with pytest.raises(SystemExit):
+        run_debug(retries=1)
+    assert calls["n"] == 1
+
+
+@pytest.mark.parametrize(
+    "cp,expected",
+    [
+        (_cp(1, _OVERWRITE_400_1001), True),
+        (_cp(1, _OVERWRITE_400_20001), False),
+        (_cp(0, _OVERWRITE_400_1001), False),
+        (_cp(1, _TRANSIENT_504), False),
+        # UiPath/cli#3951 staged envelope
+        (_cp(1, _OVERWRITE_STAGED_400_1001), True),
+        (_cp(1, _OVERWRITE_STAGED_400_20001), False),
+        (_cp(1, _UPLOAD_STAGED_400_1001), False),
+        (_cp(0, _OVERWRITE_STAGED_400_1001), False),
+    ],
+)
+def test_is_overwrite_stuck(cp, expected):
+    assert flow_check._is_overwrite_stuck(cp) is expected


### PR DESCRIPTION
## What

`run_debug` now rotates the `.uipx` `SolutionId` to a fresh uuid4 and retries **once as a new import** when Studio Web refuses an overwrite with `400 / code 1001`.

Ports #2990 and #3026 from `campaign/same-ground-expansion` onto `main`.

## Why

`uip maestro flow debug` imports the project on its first run and writes the server's solution id back into the `.uipx`. Every later debug of that project is therefore an **overwrite**, and Studio Web's `Solution/{id}/Overwrite` answers `400 {"code":"1001","message":"An argument had an invalid value."}` for a solution that exists. The CLI treats a non-404 Overwrite as fatal.

Net effect: **`flow debug` is one-shot per project.**

On the 2026-09-03 batch, 8 of 10 `uipath-maestro-flow` tasks lost their last gating criterion to this, always on the second debug of the project:

| Task | Agent debugs | Checker debugs | 400 lands on |
|---|---|---|---|
| `decision` | 0 | 2 | checker case 2 (`cool`) |
| `feet_inches` | 0 | 2 | checker case 2 (`i2f`) |
| `wiki_pageviews` | 0 | 2 | checker case 2 (invalid article) |
| `cli_dice_roller_simulated` | 1 | 1 | checker case 1 |
| `file_attachment_debug` | 1 | 1 | checker case 1 |
| `slack_http_fallback` | 1 | 1 | checker case 1 |
| `slack_weather_pipeline` | 3 | 1 | agent #3, checker |
| `generic_dynamic_node` | 3 | 1 | agent #2, checker |

`flow validate` passed in all 10. A fresh bundled `SolutionId` imports as new and Completes, so only overwrite is broken.

The fix already exists on `campaign/same-ground-expansion` but is blocked behind #2756 (262 files, open since 2026-08-22), so `main` and the nightly still take the hit.

## How

- `_is_overwrite_stuck` matches **both** envelopes: the legacy `Overwrite failed (400): {"code":"1001",…}` text and the staged one the CLI emits since UiPath/cli#3951 (`Context.Stage == "overwrite-solution"`).
- `_rotate_solution_id` walks up from the project dir to the nearest unambiguous `*.uipx` and rewrites only the id.
- The retry gets its own single allowance inside the existing deadline. `debug_budget()` is untouched.
- Never fires on code 20001, another stage, 404, or exit 0.
- Prints the orphaned id, because `cleanup_solutions.py` reads only the current one.

Rewritten onto `main`'s retry loop rather than cherry-picked: the campaign commits conflict with an unrelated unreadable-outputs retry that is not being ported here.

**Self-disabling.** Once Overwrite works again the signature stops matching. Delete the `_OVERWRITE_STUCK` block in `flow_check.py` and the matching test section together.

## Verification

- `pytest tests/tasks/uipath-maestro-flow/` — **776 passed**
- `python3 scripts/check-task-driver.py tests/tasks` — OK
- +13 tests: rotation on both envelopes, rotate-once-only, 20001 and other stages untouched, no `.uipx` → plain failure, classifier table
- All **8 real failure envelopes** from the 2026-09-03 batch classify as ROTATE
- Rotation verified against a real `.uipx` from that run (correct id replaced, rest of file byte-identical)

No prompt, criterion, weight, or `run_limits` change. No task YAML touched.

## Not in scope

Two failures from the same batch have unrelated causes and are untouched here:

- `skill-flow-coded-agent` — real authoring bug. The flow passes `review_sentence`; the LangGraph `GraphState` requires `sentence`. `flow validate` does not catch the mismatch.
- `skill-flow-outlook-trigger-inbox` — the tenant's Outlook connection grant is revoked (`AADSTS50173`). Needs reauthorization, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)