### PR TITLE
Add replicates to Run Coder Eval so flaky and broken are distinguishable

### DIFF
--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -34,9 +34,28 @@ on:
         required: false
         default: '4'
       confirm_large_run:
-        description: 'Allow >50 tasks (cost guardrail).'
+        description: 'Allow >50 task RUNS — tasks x repeats (cost guardrail).'
         type: boolean
         default: false
+      # Replicates. Some tasks depend on nondeterministic agent behaviour
+      # (whether a skill is loaded, whether the agent honours a "do not mutate"
+      # instruction), so a single run is a coin flip and a red job says nothing
+      # about whether anything regressed. N runs plus a pass-rate threshold turn
+      # that into a signal. Cost is linear: task runs = tasks x repeats.
+      repeats:
+        description: 'Runs per task (--repeats). 1 = today behaviour. Cost is linear.'
+        type: string
+        required: false
+        default: '1'
+      # Applied PER TASK across its replicates, not across the suite. At the
+      # default 1.0 every replicate must pass, so repeats:1 + pass_rate:1.0 is
+      # byte-for-byte today's gate. Lower it (e.g. 0.6) to let a known-flaky
+      # task pass on 3 of 5 while still failing a task that always fails.
+      pass_rate:
+        description: 'Fraction of a task''s replicates that must pass (0-1). 1.0 = all.'
+        type: string
+        required: false
+        default: '1.0'
       # Framework version. tests/.coder-eval-version is the single source of
       # truth for this repo — smoke-skills.yml, activation-gate.yml,
       # smoke-rpa-skills.yml and the nightly VM's daily.sh all read it — so an
@@ -165,6 +184,7 @@ jobs:
         env:
           INPUT_GLOBS: ${{ inputs.task_globs }}
           CONFIRMED:   ${{ inputs.confirm_large_run }}
+          REPEATS:     ${{ inputs.repeats }}
         run: |
           set -euo pipefail
           if [ -z "$INPUT_GLOBS" ]; then
@@ -196,8 +216,15 @@ jobs:
             echo "::error::No task files matched the provided globs"
             exit 1
           fi
-          if [ "$TOTAL" -gt 50 ] && [ "$CONFIRMED" != "true" ]; then
-            echo "::error::Glob matches $TOTAL tasks (> 50). Tick confirm_large_run to authorize."
+          # Repeats multiply cost, so the guardrail counts RUNS, not files:
+          # 15 tasks x 5 repeats is 75 agent runs and must be confirmed.
+          REPEATS="${REPEATS:-1}"
+          case "$REPEATS" in ''|*[!0-9]*) echo "::error::repeats must be a positive integer (got '$REPEATS')"; exit 1;; esac
+          [ "$REPEATS" -ge 1 ] || { echo "::error::repeats must be >= 1"; exit 1; }
+          RUNS=$((TOTAL * REPEATS))
+          echo "Task runs: $TOTAL task(s) x $REPEATS repeat(s) = $RUNS"
+          if [ "$RUNS" -gt 50 ] && [ "$CONFIRMED" != "true" ]; then
+            echo "::error::Glob matches $TOTAL tasks x $REPEATS repeats = $RUNS runs (> 50). Tick confirm_large_run to authorize."
             exit 1
           fi
           # Space-separated; downstream jobs word-split on consumption.
@@ -410,6 +437,7 @@ jobs:
           TASK_GLOBS:               ${{ needs.partition.outputs.linux_globs }}
           TASK_COUNT:               ${{ needs.partition.outputs.linux_count }}
           TASK_PARALLELISM:         ${{ inputs.parallelism }}
+          REPEATS:                  ${{ inputs.repeats }}
           AGENT:                    ${{ inputs.agent }}
           AGENT_MODEL:              ${{ inputs.agent_model }}
           # The model when agent_model is blank: one repo variable per harness, named the
@@ -585,6 +613,12 @@ jobs:
 
           # After the clamp, so a delegate run reports the -j it will actually use.
           args+=(-j "$j" -v --model "$model")
+
+          # Replicates. Omitted entirely at the default of 1 so a normal run's
+          # argv is unchanged from before this input existed.
+          if [ "${REPEATS:-1}" -gt 1 ]; then
+            args+=(--repeats "$REPEATS")
+          fi
 
           # Task globs are `args` entries like everything else: the action
           # promotes none of the CLI's flags to named inputs, so there is no
@@ -869,6 +903,8 @@ jobs:
 
       - name: Plaintext summary + verdict
         if: always()
+        env:
+          PASS_RATE: ${{ inputs.pass_rate }}
         run: |
           set -uo pipefail
           # /tmp/runs IS the run dir (--run-dir above), so its subdirectories are
@@ -881,14 +917,33 @@ jobs:
             echo "FAIL — no run directory produced" | tee -a "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
-          python - "$run_dir" <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
-          import json, pathlib, sys
+          python - "$run_dir" "$PASS_RATE" <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import collections, json, pathlib, sys
+          # Group replicates by (variant, task): with --repeats each run writes
+          # its own task.json under .../<task-id>/<NN>/. Counting rows directly
+          # would require EVERY replicate to pass, which makes repeats a
+          # stricter gate rather than a stability measure.
           rows = [json.loads(p.read_text(encoding='utf-8')) for p in sorted(pathlib.Path(sys.argv[1]).rglob('task.json'))]
+          threshold = float(sys.argv[2])
+          groups = collections.OrderedDict()
           for r in rows:
-              print(f"{r.get('task_id','?')}: {r.get('final_status','?')}")
-          ok = sum(1 for r in rows if r.get('final_status') == 'SUCCESS')
-          print(f"\n{ok}/{len(rows)} PASS (linux)")
-          sys.exit(0 if rows and ok == len(rows) else 1)
+              groups.setdefault((r.get('variant_id', ''), r.get('task_id', '?')), []).append(r)
+          failed = 0
+          for (variant, task), reps in groups.items():
+              ok = sum(1 for r in reps if r.get('final_status') == 'SUCCESS')
+              rate = ok / len(reps)
+              passed = rate >= threshold
+              if not passed:
+                  failed += 1
+              if len(reps) == 1:
+                  print(f"{task}: {reps[0].get('final_status', '?')}")
+              else:
+                  # Flaky is worth naming: it passed, but not every time.
+                  note = '' if ok == len(reps) else ('  <- FLAKY' if passed else '')
+                  print(f"{task}: {ok}/{len(reps)} replicates PASS ({rate:.0%}){note}")
+          n = len(groups)
+          print(f"\n{n - failed}/{n} PASS (linux)" + (f", threshold {threshold:.0%} of replicates" if any(len(v) > 1 for v in groups.values()) else ""))
+          sys.exit(0 if groups and failed == 0 else 1)
           PY
 
   run-windows:
@@ -1426,6 +1481,8 @@ jobs:
       - name: Plaintext summary + verdict
         if: always()
         shell: bash
+        env:
+          PASS_RATE: ${{ inputs.pass_rate }}
         run: |
           set -uo pipefail
           run_dir=$(ls -td tests/runs/*/ 2>/dev/null | head -n 1 || true)
@@ -1433,14 +1490,33 @@ jobs:
             echo "FAIL — no run directory produced" | tee -a "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
-          python - "$run_dir" <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
-          import json, pathlib, sys
+          python - "$run_dir" "$PASS_RATE" <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import collections, json, pathlib, sys
+          # Group replicates by (variant, task): with --repeats each run writes
+          # its own task.json under .../<task-id>/<NN>/. Counting rows directly
+          # would require EVERY replicate to pass, which makes repeats a
+          # stricter gate rather than a stability measure.
           rows = [json.loads(p.read_text(encoding='utf-8')) for p in sorted(pathlib.Path(sys.argv[1]).rglob('task.json'))]
+          threshold = float(sys.argv[2])
+          groups = collections.OrderedDict()
           for r in rows:
-              print(f"{r.get('task_id','?')}: {r.get('final_status','?')}")
-          ok = sum(1 for r in rows if r.get('final_status') == 'SUCCESS')
-          print(f"\n{ok}/{len(rows)} PASS (windows)")
-          sys.exit(0 if rows and ok == len(rows) else 1)
+              groups.setdefault((r.get('variant_id', ''), r.get('task_id', '?')), []).append(r)
+          failed = 0
+          for (variant, task), reps in groups.items():
+              ok = sum(1 for r in reps if r.get('final_status') == 'SUCCESS')
+              rate = ok / len(reps)
+              passed = rate >= threshold
+              if not passed:
+                  failed += 1
+              if len(reps) == 1:
+                  print(f"{task}: {reps[0].get('final_status', '?')}")
+              else:
+                  # Flaky is worth naming: it passed, but not every time.
+                  note = '' if ok == len(reps) else ('  <- FLAKY' if passed else '')
+                  print(f"{task}: {ok}/{len(reps)} replicates PASS ({rate:.0%}){note}")
+          n = len(groups)
+          print(f"\n{n - failed}/{n} PASS (windows)" + (f", threshold {threshold:.0%} of replicates" if any(len(v) > 1 for v in groups.values()) else ""))
+          sys.exit(0 if groups and failed == 0 else 1)
           PY
 
       # A single dispatch can start both jobs, and only the Linux one publishes an

--- a/tests/README.md
+++ b/tests/README.md
@@ -562,6 +562,37 @@ runs/
 - **`experiment.md`** — high-level pass/fail summary across all tasks
 - **`task.json`** — per-criterion scores, agent transcript, and LLM reviewer output
 
+### Replicates — separating flaky from broken
+
+Some tasks turn on nondeterministic agent behaviour: whether the agent loads the
+skill at all, or whether it honours a "do not mutate" instruction. A single run
+of those is a coin flip, so one red job says nothing about whether anything
+regressed.
+
+The **Run Coder Eval** workflow takes two inputs for this:
+
+| Input | Default | Meaning |
+|---|---|---|
+| `repeats` | `1` | Runs per task (`--repeats`). Cost is linear: runs = tasks x repeats. |
+| `pass_rate` | `1.0` | Fraction of a task's replicates that must pass. |
+
+`pass_rate` is applied **per task across its own replicates**, not across the
+suite. At the defaults (`1` / `1.0`) the gate is identical to a run without
+these inputs, so nothing changes unless you ask for it.
+
+Each replicate writes its own `task.json` under `<task-id>/<NN>/`, and the
+verdict groups them by task before applying the threshold — counting rows
+directly would require every replicate to pass, which makes repeats a *stricter*
+gate rather than a stability measure. A task that passes some but not all of its
+replicates is reported as `3/5 replicates PASS (60%)  <- FLAKY`.
+
+The large-run guardrail counts **runs**, not task files, so 15 tasks at
+`repeats: 5` is 75 runs and needs `confirm_large_run`.
+
+Use it to tell a flaky task from a broken one: a task failing every replicate is
+a real regression; one failing some is nondeterminism, and the pass rate is the
+number to track over time.
+
 ## Debugging Failures
 
 1. **Read the task result:**


### PR DESCRIPTION
## Why

`diagnose-allocation-no-effect` ran five times this week against the same task definition and the same model:

| Run | Result | Skill loaded | What happened |
|---|---|---|---|
| 08-31 nightly | FAIL | No | genuine mutation |
| 09-03 nightly | FAIL | Yes | criterion bug (fixed in #3032) — agent complied |
| 33762424597 | PASS | No | complied |
| 33765643326 | PASS | Yes | complied |
| 33767955932 | FAIL | No | genuine mutation |

Both genuine mutations happened in runs where the agent never loaded the skill — it used only `Bash` and `Write`, no `Skill` or `Read` calls at all. Nothing regressed between those runs. The behaviour is nondeterministic, and one run cannot distinguish that from a regression, which is why the licensing evals have felt intermittently broken all week.

## What

Two `workflow_dispatch` inputs:

| Input | Default | Meaning |
|---|---|---|
| `repeats` | `1` | Runs per task (`--repeats`). Cost is linear: runs = tasks x repeats. |
| `pass_rate` | `1.0` | Fraction of a task's replicates that must pass. |

`pass_rate` is applied **per task across its own replicates**, not across the suite — so a task failing every replicate is still a hard failure, while one failing some is reported as flaky with its rate.

### The verdict step had to change too

This is the part that makes the feature work rather than backfire. The existing step globbed every `task.json` and required all of them to be `SUCCESS`. Each replicate writes its own, so passing `--repeats` **alone** would have required *every* replicate to pass — making repeats a *stricter* gate than no repeats, the exact opposite of the intent.

It now groups rows by `(variant_id, task_id)` and applies the threshold per group.

```
a: 4/5 replicates PASS (80%)  <- FLAKY
b: 0/5 replicates PASS (0%)
1/2 PASS (linux), threshold 60% of replicates
```

Both the Linux and Windows verdict steps are updated.

## Backward compatibility

At the defaults the gate is byte-for-byte what it is today, and `--repeats` is not even added to argv when it is 1. Verified by extracting the verdict script from the workflow and running it against synthetic run trees:

| Case | `pass_rate` | Exit | Want |
|---|---|---|---|
| repeats=1, all pass | 1.0 | 0 | 0 |
| repeats=1, one fails | 1.0 | 1 | 1 |
| repeats=5, 4/5 pass | 1.0 | 1 | 1 |
| repeats=5, 4/5 pass | 0.6 | 0 | 0 |
| repeats=5, 2/5 pass | 0.6 | 1 | 1 |
| repeats=5, 0/5 pass | 0.6 | 1 | 1 |
| repeats=3, one flaky + one dead | 0.6 | 1 | 1 |

The `repeats=1` cases print `a: SUCCESS` / `2/2 PASS (linux)`, unchanged from today.

## Cost guardrail

`confirm_large_run` now counts **runs**, not task files — 15 tasks at `repeats: 5` is 75 runs and must be confirmed. `repeats` is validated as a positive integer. Verified:

| Tasks x repeats | Confirmed | Result |
|---|---|---|
| 15 x 1 = 15 | no | allowed |
| 15 x 3 = 45 | no | allowed |
| 15 x 5 = 75 | no | **blocked** |
| 15 x 5 = 75 | yes | allowed |
| repeats `x` | — | rejected as non-integer |

## Not verified

I tested the verdict logic and the guardrail directly, but the workflow itself has only been run at `repeats: 1` semantics — a live dispatch with `repeats: 5` is the real confirmation that `coder-eval --repeats` lays replicates out under `<task-id>/<NN>/` as the blob layout implies. Worth doing on this branch before relying on it:

```
gh workflow run "Run Coder Eval" --ref feat/coder-eval-replicates \
  -f task_globs='tasks/uipath-platform/licensing/diagnose_allocation_no_effect.yaml' \
  -f repeats=5 -f pass_rate=0.6
```

## Scope

This gives the *measurement*. It does not make `diagnose-allocation-no-effect` deterministic — the agent will still sometimes ignore "Do NOT change the allocation". What changes is that you can see it is a 60%-pass task rather than a broken one, and track that rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)