### PR TITLE
fix(maestro-flow): make the outlook trigger gate assert the resolve, not the command text

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
@@ -9,6 +9,8 @@ Two checks:
                           connection. Catches "agent resolved-but-reused a
                           stale ID" (the `command_executed` check in the YAML
                           catches "agent skipped the resolve entirely").
+                          Reports three causes separately: dead connection,
+                          displayName written instead of id, stale id.
 
 A `flow debug` check is intentionally omitted from this task — see the task
 YAML description for the infrastructure rationale.
@@ -27,8 +29,32 @@ TRIGGER_TYPE_MARKER = "uipath.connector.trigger.uipath-microsoft-outlook365.emai
 TEST_FOLDER_PATH = "Shared/uipath-maestro-flow"
 
 
+# Credential failures: the tenant's grant, not anything the agent built.
+_CONNECTION_DEAD_MARKERS = (
+    "invalid_grant",
+    "aadsts50173",  # grant revoked
+    "aadsts700082",  # refresh token expired
+    "reauthorize your account",
+)
+
+
+def _connection_is_dead(blob: str) -> bool:
+    lowered = blob.lower()
+    return any(marker in lowered for marker in _CONNECTION_DEAD_MARKERS)
+
+
 def _parse_uip_stdout(args: list[str], result: subprocess.CompletedProcess) -> dict:
     if result.returncode != 0:
+        blob = f"{result.stdout}\n{result.stderr}"
+        if _connection_is_dead(blob):
+            sys.exit(
+                f"FAIL (ENVIRONMENT, not a skill regression): {' '.join(args)} "
+                f"exit={result.returncode}. The tenant's Outlook connection cannot "
+                "authenticate, so no MailFolder ID can be resolved and this task's "
+                "assertion never ran. Reauthorize the connection in "
+                f"{TEST_FOLDER_PATH} and re-run; do not read this as the agent "
+                f"reusing or inventing an ID.\nstderr: {result.stderr}\nstdout: {result.stdout}"
+            )
         sys.exit(
             f"FAIL: {' '.join(args)} exit={result.returncode}\n"
             f"stderr: {result.stderr}\nstdout: {result.stdout}"
@@ -167,15 +193,32 @@ def check_folder_id_fresh():
             "FAIL: resources run/execute list MailFolder returned no folders on the bound connection"
         )
 
-    if flow_folder_id not in live_ids:
-        # Truncate the IDs in the error to avoid leaking full Exchange IDs while
-        # still giving enough signal to diagnose.
+    if flow_folder_id in live_ids:
+        print(f"OK: parentFolderId resolves on current connection ({len(live_ids)} folders checked)")
+        return
+
+    # describe declares Reference{LookupNames:["displayName"], LookupValue:"id"},
+    # so a display name here means the resolve was skipped, not a stale id.
+    live_names = {
+        name.lower()
+        for f in _extract_list_items(live)
+        if (name := (f.get("displayName") or f.get("DisplayName")))
+    }
+    if flow_folder_id.lower() in live_names:
         sys.exit(
-            f"FAIL (PR #348 regression): parentFolderId={flow_folder_id[:12]}... is NOT among "
-            f"the {len(live_ids)} MailFolder IDs on the current connection. The agent "
-            f"reused a reference ID from another connection or session."
+            "FAIL: parentFolderId holds a folder's displayName, not its id. The field "
+            "is a reference (LookupNames=[displayName], LookupValue=id), so the agent "
+            "must write the `id` returned by `resources run list MailFolder`. This is a "
+            "skipped or failed resolve, NOT the PR #348 stale-reference regression."
         )
-    print(f"OK: parentFolderId resolves on current connection ({len(live_ids)} folders checked)")
+
+    # Truncate the IDs in the error to avoid leaking full Exchange IDs while
+    # still giving enough signal to diagnose.
+    sys.exit(
+        f"FAIL (PR #348 regression): parentFolderId={flow_folder_id[:12]}... is NOT among "
+        f"the {len(live_ids)} MailFolder IDs on the current connection. The agent "
+        f"reused a reference ID from another connection or session."
+    )
 
 
 DISPATCH = {

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
@@ -15,7 +15,8 @@ Two checks:
 A `flow debug` check is intentionally omitted from this task — see the task
 YAML description for the infrastructure rationale.
 
-Privacy: never logs folder display names. Only counts + truncated IDs.
+Privacy: never logs folder display names, nor the configured reference value
+(which may itself be a name). Only counts and lengths.
 """
 
 import glob
@@ -43,17 +44,33 @@ def _connection_is_dead(blob: str) -> bool:
     return any(marker in lowered for marker in _CONNECTION_DEAD_MARKERS)
 
 
+def _dead_credential_remedy(args: list[str]) -> str:
+    """Which credential to reauthorize. The MailFolder resolve runs on the
+    Outlook connection's grant; every other call in this checker (`or folders
+    get`, `is connections list`) runs on the CLI's own session. Both are
+    environment failures, but they are fixed in different places, so a dead CLI
+    login must not be reported as a dead Outlook connection."""
+    if "resources" in args:
+        return (
+            "The tenant's Outlook connection cannot authenticate, so no MailFolder ID "
+            "can be resolved and this task's assertion never ran. Reauthorize the "
+            f"connection in {TEST_FOLDER_PATH} and re-run"
+        )
+    return (
+        "The CLI's own session cannot authenticate, so this checker never reached the "
+        "MailFolder resolve. Re-run `uip login` and re-run this task"
+    )
+
+
 def _parse_uip_stdout(args: list[str], result: subprocess.CompletedProcess) -> dict:
     if result.returncode != 0:
         blob = f"{result.stdout}\n{result.stderr}"
         if _connection_is_dead(blob):
             sys.exit(
                 f"FAIL (ENVIRONMENT, not a skill regression): {' '.join(args)} "
-                f"exit={result.returncode}. The tenant's Outlook connection cannot "
-                "authenticate, so no MailFolder ID can be resolved and this task's "
-                "assertion never ran. Reauthorize the connection in "
-                f"{TEST_FOLDER_PATH} and re-run; do not read this as the agent "
-                f"reusing or inventing an ID.\nstderr: {result.stderr}\nstdout: {result.stdout}"
+                f"exit={result.returncode}. {_dead_credential_remedy(args)}; do not "
+                "read this as the agent reusing or inventing an ID.\n"
+                f"stderr: {result.stderr}\nstdout: {result.stdout}"
             )
         sys.exit(
             f"FAIL: {' '.join(args)} exit={result.returncode}\n"
@@ -116,6 +133,17 @@ def _find_test_folder_key() -> str:
     return key
 
 
+def _bound_connection_id(trigger: dict) -> str:
+    """The connection the trigger is actually bound to, from its persisted
+    ``inputs.detail.connectionId``. `node configure` requires the field, so it
+    is present on any flow that validated. Falling back to the folder's default
+    connection would validate the ID against the wrong grant whenever the two
+    differ — a dead default would then mask a healthy bound connection."""
+    detail = trigger.get("inputs", {}).get("detail", {}) or {}
+    conn_id = detail.get("connectionId")
+    return conn_id if isinstance(conn_id, str) and conn_id.strip() else ""
+
+
 def _find_default_outlook_connection() -> tuple[str, str, str]:
     """Return (connection_id, folder_key, connection_name) for the default
     enabled Outlook connection in the test folder."""
@@ -176,7 +204,9 @@ def check_folder_id_fresh():
             "The agent did not configure the required reference field."
         )
 
-    conn_id, _folder_key, _conn_name = _find_default_outlook_connection()
+    # Prefer the trigger's own binding; fall back to the folder default only
+    # when the flow never persisted one.
+    conn_id = _bound_connection_id(trigger) or _find_default_outlook_connection()[0]
     live = _uip_resources_run(
         ["list", CONNECTOR_KEY, "MailFolder", "--connection-id", conn_id, "--output", "json"]
     )
@@ -212,12 +242,15 @@ def check_folder_id_fresh():
             "skipped or failed resolve, NOT the PR #348 stale-reference regression."
         )
 
-    # Truncate the IDs in the error to avoid leaking full Exchange IDs while
-    # still giving enough signal to diagnose.
+    # The configured value is never echoed, not even truncated: reaching here
+    # means it matched no live id AND no live display name, so it can still BE a
+    # display name (a renamed or deleted folder, or one past the returned page).
+    # Report its shape instead.
     sys.exit(
-        f"FAIL (PR #348 regression): parentFolderId={flow_folder_id[:12]}... is NOT among "
-        f"the {len(live_ids)} MailFolder IDs on the current connection. The agent "
-        f"reused a reference ID from another connection or session."
+        f"FAIL (PR #348 regression): the configured parentFolderId ({len(flow_folder_id)} chars) "
+        f"is not among the {len(live_ids)} MailFolder IDs on the bound connection, and is not "
+        "one of their display names either. The agent reused a reference ID from another "
+        "connection or session."
     )
 
 

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -68,7 +68,7 @@ success_criteria:
     pass_threshold: 0
 
   - type: command_executed
-    description: "Agent resolved MailFolder against the current --connection-id (PR #348 regression)"
+    description: "Agent resolved MailFolder against the current --connection-id, and the resolve succeeded (PR #348 regression)"
     tool_name: "Bash"
     # `[\s\S]` matches across newlines — agents often split `uip` commands with
     # backslash line-continuation, which `.*` would miss.
@@ -76,6 +76,10 @@ success_criteria:
     # and the legacy "execute" verb that older CLIs in the sandbox PATH may
     # still expose (MST-9674).
     command_pattern: 'uip\s+is\s+resources\s+(?:run|execute)\s+list[\s\S]+?MailFolder[\s\S]+?--connection-id'
+    # Without this the gate matches command text alone and scores green on a
+    # resolve that returned nothing (seen 2026-09-03: lookup 403'd, agent wrote
+    # the display name "Inbox" into the id field, criterion still passed).
+    require_success: true
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -68,7 +68,7 @@ success_criteria:
     pass_threshold: 0
 
   - type: command_executed
-    description: "Agent resolved MailFolder against the current --connection-id, and the resolve succeeded (PR #348 regression)"
+    description: "Agent ran the MailFolder resolve against the current --connection-id (PR #348 regression). Outcome is proven by check_folder_id_fresh below, not here"
     tool_name: "Bash"
     # `[\s\S]` matches across newlines — agents often split `uip` commands with
     # backslash line-continuation, which `.*` would miss.
@@ -76,9 +76,18 @@ success_criteria:
     # and the legacy "execute" verb that older CLIs in the sandbox PATH may
     # still expose (MST-9674).
     command_pattern: 'uip\s+is\s+resources\s+(?:run|execute)\s+list[\s\S]+?MailFolder[\s\S]+?--connection-id'
-    # Without this the gate matches command text alone and scores green on a
-    # resolve that returned nothing (seen 2026-09-03: lookup 403'd, agent wrote
-    # the display name "Inbox" into the id field, criterion still passed).
+    # Narrows, does NOT close, the hole seen 2026-09-03 (lookup 403'd, agent
+    # wrote the display name "Inbox" into the id field, criterion still scored
+    # 1.0). `require_success` reads the *wrapper's* exit status
+    # (codex_agent.py: `result_status = "success" if exit_code == 0`), so a
+    # batched `bash -lc` script whose MailFolder lookup fails but whose last
+    # command exits 0 still counts — the same limitation
+    # tests/tasks/uipath-review/_shared/check_review_cli_provenance.py:13-15
+    # documents. It does close the unbatched case, which is the shape the
+    # 2026-09-03 run took. Ground truth for whether the resolve SUCCEEDED is
+    # the `check_folder_id_fresh` criterion below: it re-resolves MailFolder on
+    # the trigger's bound connection and requires the written parentFolderId to
+    # be a live id there, which no skipped or failed resolve can produce.
     require_success: true
     min_count: 1
     weight: 2.5

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
@@ -149,3 +149,120 @@ def test_folder_id_mismatch_fails_with_pr348_signature(monkeypatch) -> None:
         assert "PR #348 regression" in str(message)
     else:
         raise AssertionError("expected SystemExit on a stale folder id")
+
+
+# ── failure classification ──────────────────────────────────────────────────
+
+
+def _aadsts_403() -> str:
+    """The 2026-09-03 envelope: the connection's grant was revoked."""
+    return json.dumps(
+        {
+            "Result": "Failure",
+            "Message": "403 Forbidden",
+            "Instructions": json.dumps(
+                {
+                    "providerErrorMessage": (
+                        "error - invalid_grant, error_description - AADSTS50173: The provided "
+                        "grant has expired due to it being revoked, a fresh auth token is needed."
+                    ),
+                    "message": "We couldn't connect your account. Please reauthorize your account.",
+                }
+            ),
+        }
+    )
+
+
+def test_dead_connection_is_reported_as_environment(monkeypatch) -> None:
+    """A revoked grant never ran the assertion, so it must not read as a regression."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker)
+    monkeypatch.setattr(checker.subprocess, "run", lambda _a, **_k: _fake_proc(1, stdout=_aadsts_403()))
+
+    try:
+        checker.check_folder_id_fresh()
+    except SystemExit as exc:
+        message = str(exc.code)
+        assert "ENVIRONMENT, not a skill regression" in message
+        assert "Reauthorize the connection" in message
+        assert "PR #348" not in message
+    else:
+        raise AssertionError("expected SystemExit on a dead connection")
+
+
+def test_unrelated_cli_failure_is_not_labelled_environment(monkeypatch) -> None:
+    """Only credential markers earn the label, so it keeps its meaning."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker)
+    monkeypatch.setattr(
+        checker.subprocess, "run", lambda _a, **_k: _fake_proc(1, stdout="", stderr="403 Forbidden")
+    )
+
+    try:
+        checker.check_folder_id_fresh()
+    except SystemExit as exc:
+        assert "ENVIRONMENT" not in str(exc.code)
+    else:
+        raise AssertionError("expected SystemExit on a 403")
+
+
+def test_display_name_is_not_reported_as_the_pr348_regression(monkeypatch) -> None:
+    """The 2026-09-03 shape: a skipped resolve, not a stale reference."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker, folder_id="Inbox")
+
+    def fake_run(_args, **_kwargs):
+        return _fake_proc(
+            0, stdout=json.dumps({"Data": [{"id": "AAMkAGI2...", "displayName": "Inbox"}]})
+        )
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    try:
+        checker.check_folder_id_fresh()
+    except SystemExit as exc:
+        message = str(exc.code)
+        assert "displayName, not its id" in message
+        assert "PR #348 regression" not in message
+    else:
+        raise AssertionError("expected SystemExit on a display name in an id field")
+
+
+def test_display_name_match_is_case_insensitive(monkeypatch) -> None:
+    """Graph well-known names arrive lowercased; same mistake."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker, folder_id="inbox")
+
+    def fake_run(_args, **_kwargs):
+        return _fake_proc(
+            0, stdout=json.dumps({"Data": [{"Id": "AAMkAGI2...", "DisplayName": "Inbox"}]})
+        )
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    try:
+        checker.check_folder_id_fresh()
+    except SystemExit as exc:
+        assert "displayName, not its id" in str(exc.code)
+    else:
+        raise AssertionError("expected SystemExit on a lowercased display name")
+
+
+def test_error_never_echoes_a_folder_display_name(monkeypatch) -> None:
+    """Privacy (module docstring): this branch reads real folder names."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker, folder_id="Quarterly Board Minutes")
+
+    def fake_run(_args, **_kwargs):
+        return _fake_proc(
+            0,
+            stdout=json.dumps(
+                {"Data": [{"id": "AAMkAGI2...", "displayName": "Quarterly Board Minutes"}]}
+            ),
+        )
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    try:
+        checker.check_folder_id_fresh()
+    except SystemExit as exc:
+        assert "Quarterly Board Minutes" not in str(exc.code)
+    else:
+        raise AssertionError("expected SystemExit on a display name in an id field")

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
@@ -27,16 +27,15 @@ def _load_checker():
     return module
 
 
-def _patch_static(monkeypatch, checker, folder_id: str = "mail-folder-1") -> None:
+def _patch_static(
+    monkeypatch, checker, folder_id: str = "mail-folder-1", bound_connection: str | None = None
+) -> None:
     """Stub the non-CLI dependencies so we can focus on the verb path."""
+    detail: dict[str, Any] = {"eventParameters": {"parentFolderId": folder_id}}
+    if bound_connection is not None:
+        detail["connectionId"] = bound_connection
     monkeypatch.setattr(checker, "_read_flow", lambda: ({}, "OutlookTriggerInbox.flow"))
-    monkeypatch.setattr(
-        checker,
-        "_find_trigger_node",
-        lambda _flow: {
-            "inputs": {"detail": {"eventParameters": {"parentFolderId": folder_id}}}
-        },
-    )
+    monkeypatch.setattr(checker, "_find_trigger_node", lambda _flow: {"inputs": {"detail": detail}})
     monkeypatch.setattr(
         checker,
         "_find_default_outlook_connection",
@@ -266,3 +265,87 @@ def test_error_never_echoes_a_folder_display_name(monkeypatch) -> None:
         assert "Quarterly Board Minutes" not in str(exc.code)
     else:
         raise AssertionError("expected SystemExit on a display name in an id field")
+
+
+# ── connection binding ──────────────────────────────────────────────────────
+
+
+def test_resolves_against_the_triggers_bound_connection(monkeypatch) -> None:
+    """The flow's own `inputs.detail.connectionId` wins over the folder default:
+    validating against a different connection checks the wrong grant."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker, bound_connection="connection-bound")
+    monkeypatch.setattr(
+        checker,
+        "_find_default_outlook_connection",
+        lambda: (_ for _ in ()).throw(AssertionError("must not fall back to the folder default")),
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        return _fake_proc(0, stdout=_success_payload())
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    checker.check_folder_id_fresh()
+
+    assert "connection-bound" in calls[0]
+
+
+def test_falls_back_to_default_connection_when_unbound(monkeypatch) -> None:
+    """A flow that never persisted a connectionId still gets checked."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker)
+    calls: list[list[str]] = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        return _fake_proc(0, stdout=_success_payload())
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    checker.check_folder_id_fresh()
+
+    assert "connection-1" in calls[0]
+
+
+def test_dead_cli_session_does_not_blame_the_outlook_connection() -> None:
+    """`or folders get` / `is connections list` run on the CLI's own session,
+    not the Outlook grant. A dead credential there is still ENVIRONMENT, but
+    reauthorizing the Outlook connection would not fix it."""
+    checker = _load_checker()
+
+    try:
+        checker._parse_uip_stdout(
+            ["uip", "or", "folders", "get", "Shared/uipath-maestro-flow", "--output", "json"],
+            _fake_proc(1, stdout=_aadsts_403()),
+        )
+    except SystemExit as exc:
+        message = str(exc.code)
+        assert "ENVIRONMENT, not a skill regression" in message
+        assert "uip login" in message
+        assert "Reauthorize the connection" not in message
+    else:
+        raise AssertionError("expected SystemExit on a dead CLI session")
+
+
+def test_stale_id_error_never_echoes_the_configured_value(monkeypatch) -> None:
+    """The PR #348 branch is reached when the value matched no id AND no name,
+    so the value can still BE a name (renamed/deleted folder, or off-page)."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker, folder_id="Quarterly Board Minutes")
+
+    def fake_run(_args, **_kwargs):
+        return _fake_proc(
+            0, stdout=json.dumps({"Data": [{"id": "AAMkAGI2...", "displayName": "Inbox"}]})
+        )
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    try:
+        checker.check_folder_id_fresh()
+    except SystemExit as exc:
+        message = str(exc.code)
+        assert "PR #348 regression" in message
+        assert "Quarterly" not in message
+        assert "Quarterly Board Minutes"[:12] not in message
+    else:
+        raise AssertionError("expected SystemExit on an unmatched parentFolderId")


### PR DESCRIPTION
## What

The PR #348 regression gate now requires the MailFolder resolve to have **succeeded**, not merely to have been typed. Plus two reporting fixes in the checker so its three failure causes stop looking identical.

## Why

From the 2026-09-03 batch. The gate:

```yaml
- type: command_executed
  description: "Agent resolved MailFolder against the current --connection-id (PR #348 regression)"
  command_pattern: 'uip\s+is\s+resources\s+(?:run|execute)\s+list[\s\S]+?MailFolder[\s\S]+?--connection-id'
```

matches the command string and nothing else. What actually happened:

```
#9   uip is triggers describe ... EMAIL_RECEIVED Message   -> success
#10  uip is resources run list ... MailFolder --connection-id ...
                                                            -> 403 AADSTS50173
#11  (reads skill docs)
#12  node add   <outlook email-received trigger>
#13  node configure ... '{"eventParameters":{"parentFolderId":"Inbox"}}'
```

The lookup returned nothing. The agent wrote the display name into the id-typed field. **The gate scored 1.0.**

Its own description says it "catches the skip-the-resolve pathology". It catches "did not type the command". An agent can run the lookup, ignore the output, hardcode anything, and stay green.

`require_success: true` is already supported by `CommandExecutedCriterion` and fixes it. Replayed against that run's real telemetry:

```
require_success=False -> matches=1  score=1.0  PASS
require_success=True  -> matches=0  score=0.0  FAIL
```

## The two reporting fixes

Every failure in this checker exited through one generic message, so a dead credential and a real regression were indistinguishable.

**Environment vs regression.** A revoked or expired grant now exits as `FAIL (ENVIRONMENT, not a skill regression)` and says to reauthorize. The run scored 0.667 FAILURE, which reads as "the skill regressed", when the assertion never executed. Only credential markers (`invalid_grant`, `AADSTS50173`, `AADSTS700082`, `reauthorize your account`) earn the label; a bare 403 stays a plain fail, so the label keeps its meaning.

**displayName vs stale id.** `describe → EventParameters` declares the field as:

```json
"Reference": { "ObjectName": "MailFolder",
               "LookupNames": ["displayName"],
               "LookupValue": "id" }
```

You look a folder up *by* display name and write its `id`. Writing the name back is a skipped resolve, not a stale reference. The old message said "The agent reused a reference ID from another connection or session", which is simply not what happened and points the reader at the wrong bug. Display names are never echoed, per the module's privacy note (there's a test for that).

## The dead credential was hiding a second defect

Replaying the real `.flow` against a **healthy** connection stubbed in:

```
REAL FLOW + dead connection:
    FAIL (ENVIRONMENT, not a skill regression): ... Reauthorize the connection in Shared/uipath-maestro-flow ...

REAL FLOW + healthy connection:
    FAIL: parentFolderId holds a folder's displayName, not its id. ...
```

This task fails either way. `"Inbox"` is not an id. Fixing the connection alone would not have turned it green, and before this change the report would have blamed PR #348 for it.

The underlying agent behaviour — substituting a plausible value after a hard failure and reporting it as resolved — is a skill gap, not a test bug. `resources.md` covers diagnose-and-retry-twice but says nothing about what to do when a resolve *cannot* succeed. Tracking separately; out of scope here.

## Verification

- `pytest tests/tasks/uipath-maestro-flow/` 768 passed
- checker suite 10 passed (5 existing, 5 new)
- `python3 scripts/check-task-driver.py tests/tasks` OK
- criterion validates against `CommandExecutedCriterion`
- gate replayed against the real 21-command telemetry from the failed run (above)
- both checker branches replayed against the real `.flow` artifact (above)

No prompt, weight, threshold or `run_limits` change.

## Review follow-ups (625f823)

**`require_success` is wrapper-scoped, not per-subcommand.** Confirmed in `coder_eval/agents/codex_agent.py:2179` — `result_status` is `"success" if exit_code == 0` for the whole Bash record. A batched `bash -lc` whose MailFolder lookup 403s but whose last command exits 0 still counts. `tests/tasks/uipath-review/_shared/check_review_cli_provenance.py:13-15` already documents this.

It closes the **unbatched** case, which is the shape the 2026-09-03 run took, and nothing more. So the criterion no longer claims the resolve succeeded — the description now says outcome is proven by `check_folder_id_fresh`, and the comment carries the limitation plus the citation. Ground truth stays where it can be established: the flow's `parentFolderId` must be a live id on the bound connection, which no skipped or failed resolve produces.

**The freshness check validated the wrong connection.** It called `_find_default_outlook_connection()` and ignored the trigger's persisted `inputs.detail.connectionId`. When the two differ, a dead default masked a healthy bound connection. Now reads the binding off the trigger; falls back to the default only when the flow never persisted one.

**The ENVIRONMENT branch is shared.** `_parse_uip_stdout` also serves `or folders get` and `is connections list`, which run on the CLI's own session — an `invalid_grant` there told you to reauthorize Outlook. Both stay ENVIRONMENT; the remedy is now picked from the failing command (`uip login` vs. reauthorize the connection in `Shared/uipath-maestro-flow`).

**The stale-id message still leaked 12 chars.** That branch is reached only when the value matched no live id *and* no live display name — so it can still be a display name (renamed, deleted, or off-page). The value is now never echoed; the message reports its length.

4 new tests (14 total in the checker suite): bound-connection preference, unbound fallback, dead CLI session vs. dead connection, and no-echo on the stale branch.

## Not run

**The live eval task.** It needs an Outlook connection that can authenticate, which is the condition this PR exists to report on. `skill-flow-outlook-trigger-inbox` stays red until the alpha tenant's connection is reauthorized — currently blocked by `AADSTS50173` (grant revoked) on the `Shared/uipath-maestro-flow` Outlook connection. It will pass once that connection is reauthorized. The difference is that it should now say why instead of implying a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
