### PR TITLE
docs(uipath-maestro-flow): update child simulation docs for auto-resolved output schema

### DIFF
--- a/skills/uipath-maestro-flow/references/evaluate/commands-reference.md
+++ b/skills/uipath-maestro-flow/references/evaluate/commands-reference.md
@@ -145,7 +145,6 @@ Add or replace a simulation on a data point. If a simulation for `<component-id>
 | `--component-description <text>` | No | Human-readable label for the component |
 | `--simulation-instructions <text>` | No | LLM prompt describing what the component should return (for `Llm` strategy) |
 | `--mock-value <json>` | No | Static JSON output (for `Static` strategy) |
-| `--output-schema <json>` | No | JSON Schema describing the expected output shape; passed to the LLM to constrain its response. **Auto-resolved when omitted** — works for top-level simulations (from the `.flow` node outputs) and child simulations with `--parent` (from the `.flow` for inline agents, from `agent.json` for same-solution agents, or via the platform API for published agents when logged in). Pass explicitly only to override. |
 | `--parent <component-id>` | No | Parent agent node component ID. When set, the simulation is added as a child tool simulation nested inside the parent agent node's simulation. If no parent simulation exists yet, one is auto-created (type `agent`, strategy `Llm`). `--component-type` defaults to `Node`. |
 | `--path <path>` | No | (see Common Options) |
 
@@ -153,25 +152,19 @@ Add or replace a simulation on a data point. If a simulation for `<component-id>
 
 | Strategy | When to use | Key flags |
 |----------|-------------|-----------|
-| `Llm` | Output should be realistic but non-deterministic | `--simulation-instructions`, `--output-schema` (auto-resolved for all agent types) |
+| `Llm` | Output should be realistic but non-deterministic | `--simulation-instructions` (output schema auto-resolved) |
 | `Static` | Output is fixed and deterministic | `--mock-value` |
 
-**`--output-schema` auto-resolution:** When omitted, the CLI auto-resolves the output schema for both top-level and child (`--parent`) simulations:
+**Output schema auto-resolution:** The CLI always auto-resolves the output schema for both top-level and child (`--parent`) simulations:
 
 - **Top-level simulations:** reads the `.flow` file, finds the node by `<component-id>`, and derives the schema from the node's output definition (connector `outputJsonSchema`, agent `agentOutputVariables`, or `node.outputs`).
 - **Child simulations (inline canvas agents):** finds the child tool node via edges in the `.flow` file and extracts its output schema.
 - **Child simulations (same-solution agents):** reads the inline agent's `agent.json` and matches the tool by name in the `resources[]` array.
 - **Child simulations (published agents):** calls the platform API (`simulatableComponents`) using the current login session to fetch the tool's schema. Requires `uip login`.
 
-Fails with an actionable error if the node/tool is not found or has no outputs. Pass `--output-schema` explicitly to override. The JSON Schema is sent alongside `--simulation-instructions` to the LLM, telling it what shape the output must conform to. Without it the LLM generates free-form text.
+Fails with an actionable error if the node/tool is not found or has no outputs.
 
-**Static mock value validation:** When `--output-schema` is resolved (explicitly or auto) and `--strategy Static` is used with `--parent`, the CLI validates that the `--mock-value` keys match the schema properties, catching mismatches early.
-
-For a connector that returns `{ status, message }` you would pass:
-
-```bash
---output-schema '{"type":"object","properties":{"status":{"type":"string"},"message":{"type":"string"}}}'
-```
+**Static mock value validation:** For `Static` child simulations, the CLI validates that `--mock-value` keys match the auto-resolved schema properties, catching shape mismatches early.
 
 Example — LLM strategy:
 

--- a/skills/uipath-maestro-flow/references/evaluate/commands-reference.md
+++ b/skills/uipath-maestro-flow/references/evaluate/commands-reference.md
@@ -145,7 +145,7 @@ Add or replace a simulation on a data point. If a simulation for `<component-id>
 | `--component-description <text>` | No | Human-readable label for the component |
 | `--simulation-instructions <text>` | No | LLM prompt describing what the component should return (for `Llm` strategy) |
 | `--mock-value <json>` | No | Static JSON output (for `Static` strategy) |
-| `--output-schema <json>` | No | JSON Schema describing the expected output shape; passed to the LLM to constrain its response. **Auto-resolved from the `.flow` file when omitted for `Llm` strategy** (top-level simulations only; required when using `--parent`). |
+| `--output-schema <json>` | No | JSON Schema describing the expected output shape; passed to the LLM to constrain its response. **Auto-resolved when omitted** — works for top-level simulations (from the `.flow` node outputs) and child simulations with `--parent` (from the `.flow` for inline agents, from `agent.json` for same-solution agents, or via the platform API for published agents when logged in). Pass explicitly only to override. |
 | `--parent <component-id>` | No | Parent agent node component ID. When set, the simulation is added as a child tool simulation nested inside the parent agent node's simulation. If no parent simulation exists yet, one is auto-created (type `agent`, strategy `Llm`). `--component-type` defaults to `Node`. |
 | `--path <path>` | No | (see Common Options) |
 
@@ -153,10 +153,21 @@ Add or replace a simulation on a data point. If a simulation for `<component-id>
 
 | Strategy | When to use | Key flags |
 |----------|-------------|-----------|
-| `Llm` | Output should be realistic but non-deterministic | `--simulation-instructions`, `--output-schema` (auto-resolved) |
+| `Llm` | Output should be realistic but non-deterministic | `--simulation-instructions`, `--output-schema` (auto-resolved for all agent types) |
 | `Static` | Output is fixed and deterministic | `--mock-value` |
 
-**`--output-schema` auto-resolution for Llm simulations:** When omitted, the CLI reads the `.flow` file, finds the node by `<component-id>`, and derives the schema from the node's output definition (connector `outputJsonSchema`, agent `agentOutputVariables`, or `node.outputs`). Fails with an actionable error if the node is not found or has no outputs. Pass `--output-schema` explicitly to override. The JSON Schema is sent alongside `--simulation-instructions` to the LLM, telling it what shape the output must conform to. Without it the LLM generates free-form text. For a connector that returns `{ status, message }` you would pass:
+**`--output-schema` auto-resolution:** When omitted, the CLI auto-resolves the output schema for both top-level and child (`--parent`) simulations:
+
+- **Top-level simulations:** reads the `.flow` file, finds the node by `<component-id>`, and derives the schema from the node's output definition (connector `outputJsonSchema`, agent `agentOutputVariables`, or `node.outputs`).
+- **Child simulations (inline canvas agents):** finds the child tool node via edges in the `.flow` file and extracts its output schema.
+- **Child simulations (same-solution agents):** reads the inline agent's `agent.json` and matches the tool by name in the `resources[]` array.
+- **Child simulations (published agents):** calls the platform API (`simulatableComponents`) using the current login session to fetch the tool's schema. Requires `uip login`.
+
+Fails with an actionable error if the node/tool is not found or has no outputs. Pass `--output-schema` explicitly to override. The JSON Schema is sent alongside `--simulation-instructions` to the LLM, telling it what shape the output must conform to. Without it the LLM generates free-form text.
+
+**Static mock value validation:** When `--output-schema` is resolved (explicitly or auto) and `--strategy Static` is used with `--parent`, the CLI validates that the `--mock-value` keys match the schema properties, catching mismatches early.
+
+For a connector that returns `{ status, message }` you would pass:
 
 ```bash
 --output-schema '{"type":"object","properties":{"status":{"type":"string"},"message":{"type":"string"}}}'
@@ -189,14 +200,25 @@ uip maestro flow eval simulation add agent-lookup \
 Example — Child simulation (tool inside an agent node):
 
 ```bash
-# Add a child tool simulation. No separate parent simulation step needed —
-# --parent auto-creates the parent if it does not exist.
+# Add a child tool simulation (Static). No separate parent simulation step
+# needed — --parent auto-creates the parent if it does not exist.
+# --output-schema is auto-resolved from the agent's tool definitions.
 uip maestro flow eval simulation add Web_Search \
   --parent agent-lookup \
   --set "Smoke Tests" \
   --data-point "hello-test" \
   --strategy Static \
   --mock-value '{"results": [{"title": "Example", "url": "https://example.com"}]}' \
+  --path ./MySolution/MyFlow --output json
+
+# Add a child tool simulation (Llm). Output schema auto-resolved —
+# works for inline, same-solution, and published agents.
+uip maestro flow eval simulation add Send_Email \
+  --parent agent-lookup \
+  --set "Smoke Tests" \
+  --data-point "hello-test" \
+  --strategy Llm \
+  --simulation-instructions "Return a success status with a generated messageId." \
   --path ./MySolution/MyFlow --output json
 ```
 

--- a/skills/uipath-maestro-flow/references/evaluate/commands-reference.md
+++ b/skills/uipath-maestro-flow/references/evaluate/commands-reference.md
@@ -195,7 +195,7 @@ Example — Child simulation (tool inside an agent node):
 ```bash
 # Add a child tool simulation (Static). No separate parent simulation step
 # needed — --parent auto-creates the parent if it does not exist.
-# --output-schema is auto-resolved from the agent's tool definitions.
+# Output schema is auto-resolved from the agent's tool definitions.
 uip maestro flow eval simulation add Web_Search \
   --parent agent-lookup \
   --set "Smoke Tests" \

--- a/skills/uipath-maestro-flow/references/evaluate/eval-sets-guide.md
+++ b/skills/uipath-maestro-flow/references/evaluate/eval-sets-guide.md
@@ -133,7 +133,6 @@ uip maestro flow eval simulation add <component-id> \
   --strategy Llm \
   --component-type connector \
   --simulation-instructions "Pretend to send the email and return success." \
-  --output-schema '{"type":"object","properties":{"status":{"type":"string"},"messageId":{"type":"string"}}}' \
   --path <flow_project> --output json
 
 uip maestro flow eval simulation add <component-id> \
@@ -157,10 +156,10 @@ uip maestro flow eval simulation remove <component-id> \
 
 | Strategy | Use | Required or relevant flags |
 |---|---|---|
-| `Llm` | Plausible, non-deterministic output | `--simulation-instructions`, `--output-schema` (auto-resolved for all agent types) |
+| `Llm` | Plausible, non-deterministic output | `--simulation-instructions` (output schema auto-resolved) |
 | `Static` | Identical output every run | `--mock-value <json>` |
 
-For `Llm`, `--output-schema` is auto-resolved when omitted — for both top-level and child (`--parent`) simulations. Top-level reads the `.flow` node outputs; child simulations resolve from the `.flow` edges (inline agents), `agent.json` resources (same-solution agents), or the platform API (published agents, requires `uip login`). Pass it explicitly only to override.
+The output schema is always auto-resolved — for both top-level and child (`--parent`) simulations. Top-level reads the `.flow` node outputs; child simulations resolve from the `.flow` edges (inline agents), `agent.json` resources (same-solution agents), or the platform API (published agents, requires `uip login`).
 
 Simulations are stored inline in the data point's `simulations` array. Adding one for an existing `<component-id>` and data point replaces the existing simulation.
 

--- a/skills/uipath-maestro-flow/references/evaluate/eval-sets-guide.md
+++ b/skills/uipath-maestro-flow/references/evaluate/eval-sets-guide.md
@@ -180,7 +180,7 @@ uip maestro flow eval simulation add Web_Search \
   --path <flow_project> --output json
 
 # Add a child tool simulation (Llm — prompt-guided).
-# --output-schema is auto-resolved from the agent's tool definitions
+# Output schema is auto-resolved from the agent's tool definitions
 # (inline, same-solution, or published agents).
 uip maestro flow eval simulation add Send_Email \
   --parent <agent-node-id> \
@@ -209,7 +209,7 @@ No separate parent simulation step is needed — passing `--parent` auto-creates
 
 When `--parent` is used, `--component-type` defaults to `Node` (the convention for child tool simulations). You can override it if needed.
 
-`--output-schema` is auto-resolved for child simulations on all agent types:
+The output schema is auto-resolved for child simulations on all agent types:
 - **Inline canvas agents** (`uipath.agent.*`): resolved from the child tool node's outputs in the `.flow` file.
 - **Same-solution agents** (with `inputs.source`): resolved from the inline agent's `agent.json` resources.
 - **Published agents** (`uipath.core.agent.*`): resolved via the platform API (`simulatableComponents`). Requires `uip login`.

--- a/skills/uipath-maestro-flow/references/evaluate/eval-sets-guide.md
+++ b/skills/uipath-maestro-flow/references/evaluate/eval-sets-guide.md
@@ -157,10 +157,10 @@ uip maestro flow eval simulation remove <component-id> \
 
 | Strategy | Use | Required or relevant flags |
 |---|---|---|
-| `Llm` | Plausible, non-deterministic output | `--simulation-instructions`, `--output-schema` (auto-resolved) |
+| `Llm` | Plausible, non-deterministic output | `--simulation-instructions`, `--output-schema` (auto-resolved for all agent types) |
 | `Static` | Identical output every run | `--mock-value <json>` |
 
-For `Llm`, `--output-schema` is auto-resolved from the `.flow` file: connector `outputJsonSchema`, agent `agentOutputVariables`, or `node.outputs`. Pass it explicitly only to override the derived schema or when no outputs are declared.
+For `Llm`, `--output-schema` is auto-resolved when omitted — for both top-level and child (`--parent`) simulations. Top-level reads the `.flow` node outputs; child simulations resolve from the `.flow` edges (inline agents), `agent.json` resources (same-solution agents), or the platform API (published agents, requires `uip login`). Pass it explicitly only to override.
 
 Simulations are stored inline in the data point's `simulations` array. Adding one for an existing `<component-id>` and data point replaces the existing simulation.
 
@@ -180,14 +180,15 @@ uip maestro flow eval simulation add Web_Search \
   --mock-value '{"results": [{"title": "Example", "url": "https://example.com"}]}' \
   --path <flow_project> --output json
 
-# Add a child tool simulation (Llm — prompt-guided)
+# Add a child tool simulation (Llm — prompt-guided).
+# --output-schema is auto-resolved from the agent's tool definitions
+# (inline, same-solution, or published agents).
 uip maestro flow eval simulation add Send_Email \
   --parent <agent-node-id> \
   --set "<set_name>" \
   --data-point "<data_point_name>" \
   --strategy Llm \
   --simulation-instructions "Return a success status with a generated messageId." \
-  --output-schema '{"type":"object","properties":{"status":{"type":"string"},"messageId":{"type":"string"}}}' \
   --path <flow_project> --output json
 
 # List child simulations on an agent node
@@ -208,6 +209,13 @@ uip maestro flow eval simulation remove Web_Search \
 No separate parent simulation step is needed — passing `--parent` auto-creates the parent simulation (type `agent`, strategy `Llm`) if it does not exist yet. This means a single command is enough to add a child tool simulation.
 
 When `--parent` is used, `--component-type` defaults to `Node` (the convention for child tool simulations). You can override it if needed.
+
+`--output-schema` is auto-resolved for child simulations on all agent types:
+- **Inline canvas agents** (`uipath.agent.*`): resolved from the child tool node's outputs in the `.flow` file.
+- **Same-solution agents** (with `inputs.source`): resolved from the inline agent's `agent.json` resources.
+- **Published agents** (`uipath.core.agent.*`): resolved via the platform API (`simulatableComponents`). Requires `uip login`.
+
+For `Static` strategy, the CLI also validates that `--mock-value` keys match the resolved schema properties, catching shape mismatches before the eval run.
 
 Child simulations are stored in the parent's `childSimulations` array in the eval set JSON. Running `simulation add` with `--parent` twice for the same child `<component-id>` replaces the existing child simulation.
 


### PR DESCRIPTION
## Summary

- Updates `commands-reference.md` and `eval-sets-guide.md` to reflect that `--output-schema` is now auto-resolved for child simulations (`--parent`) on all agent types: inline canvas, same-solution, and published.
- Removes `--output-schema` from the Llm child simulation examples.
- Adds note about Static mock value validation against the resolved schema.

Companion to UiPath/cli#3998.

## Test plan

- [x] Docs-only change — reviewed for accuracy against the CLI implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)