### PR TITLE
feat(uipath-maestro-flow): teach the native Data Fabric entity CRUD nodes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -137,6 +137,7 @@
 /skills/uipath-maestro-flow/references/author/plugins/connector-trigger/ @chandusailella @UiPath/maestro-cli-team
 /skills/uipath-maestro-flow/references/author/plugins/agent/ @UiPath/team-coded-agents @AlexandruCGhimisi @andreibalas-uipath @al3xanndru @UiPath/maestro-cli-team
 /skills/uipath-maestro-flow/references/author/plugins/inline-agent/ @AlexandruCGhimisi @andreibalas-uipath @al3xanndru @UiPath/maestro-cli-team
+/skills/uipath-maestro-flow/references/author/plugins/data-fabric/ @UiPath/DatafabricCodingAgent @UiPath/maestro-cli-team
 /tests/tasks/uipath-maestro-flow/connector_features/ @chandusailella @mukundbayyaram @UiPath/maestro-cli-team
 /tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector @UiPath/DatafabricCodingAgent @UiPath/maestro-cli-team
 

--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-maestro-flow
-description: "TRIGGER for `.flow` files, UiPath Flow / Maestro Flow build/edit requests, and adding or listing IXP model/document-extraction nodes for a Flow. Build, edit, run, debug, fix, evaluate a Maestro Flow (.flow): create/connect nodes (connector, approval, script, subflow, ixp, Data Fabric entity records), triggers, schedules, validate; upload, publish, manage runs/instances; diagnose errors, incidents, traces; design eval sets, evaluators, run Studio Web evals. `uip maestro flow` CLI. DO NOT TRIGGER for raw IXP project labelling/prediction review/prompt tuning outside Flow→uipath-ixp; C#/XAML→uipath-rpa; standalone agents→uipath-agents."
+description: "TRIGGER for `.flow` files, UiPath Flow / Maestro Flow build/edit requests, and adding or listing IXP model/document-extraction nodes for a Flow. Build, edit, run, debug, fix, evaluate a Maestro Flow (.flow): create/connect nodes (connector, approval, script, subflow, ixp, data fabric entity), triggers, schedules, validate; upload, publish, manage runs/instances; diagnose errors, incidents, traces; design eval sets, evaluators, run Studio Web evals. `uip maestro flow` CLI. DO NOT TRIGGER for raw IXP project labelling/prediction review/prompt tuning outside Flow→uipath-ixp; C#/XAML→uipath-rpa; standalone agents→uipath-agents."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
@@ -25,7 +25,7 @@ Guide for creating, editing, validating, debugging, publishing, diagnosing, and 
 
 ## Capabilities
 
-- **Author** — Build and edit `.flow` files; add nodes, edges, variables, subflows, transforms, and triggers; explore the registry; validate and format locally; apply node ownership; configure connectors, triggers, managed HTTP, inline-agent scaffolding, IxP/document-extraction nodes, IxP models, and Data Fabric entity record CRUD; plan complex flows first. Read [references/author/CAPABILITY.md](references/author/CAPABILITY.md).
+- **Author** — Build and edit `.flow` files; add nodes, edges, variables, subflows, transforms, and triggers; explore the registry; validate and format locally; apply node ownership; configure connectors, triggers, managed HTTP, inline-agent scaffolding, IxP/document-extraction nodes, IxP models, and Data Fabric entity nodes; plan complex flows first. Read [references/author/CAPABILITY.md](references/author/CAPABILITY.md).
 <!--skill-flavor:project-creation-scope:start-->
   - Create projects with `uip maestro flow init`.
 <!--skill-flavor:project-creation-scope:end-->

--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-maestro-flow
-description: "TRIGGER for `.flow` files, UiPath Flow / Maestro Flow build/edit requests, and adding or listing IXP model/document-extraction nodes for a Flow. Build, edit, run, debug, fix, evaluate a Maestro Flow (.flow): create/connect nodes (connector, approval, script, subflow, ixp), triggers, schedules, validate; upload, publish, manage runs/instances; diagnose errors, incidents, traces; design eval sets, evaluators, run Studio Web evals. `uip maestro flow` CLI. DO NOT TRIGGER for raw IXP project labelling/prediction review/prompt tuning outside Flow→uipath-ixp; C#/XAML→uipath-rpa; standalone agents→uipath-agents."
+description: "TRIGGER for `.flow` files, UiPath Flow / Maestro Flow build/edit requests, and adding or listing IXP model/document-extraction nodes for a Flow. Build, edit, run, debug, fix, evaluate a Maestro Flow (.flow): create/connect nodes (connector, approval, script, subflow, ixp, Data Fabric entity records), triggers, schedules, validate; upload, publish, manage runs/instances; diagnose errors, incidents, traces; design eval sets, evaluators, run Studio Web evals. `uip maestro flow` CLI. DO NOT TRIGGER for raw IXP project labelling/prediction review/prompt tuning outside Flow→uipath-ixp; C#/XAML→uipath-rpa; standalone agents→uipath-agents."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
@@ -25,7 +25,7 @@ Guide for creating, editing, validating, debugging, publishing, diagnosing, and 
 
 ## Capabilities
 
-- **Author** — Build and edit `.flow` files; add nodes, edges, variables, subflows, transforms, and triggers; explore the registry; validate and format locally; apply node ownership; configure connectors, triggers, managed HTTP, inline-agent scaffolding, IxP/document-extraction nodes, and IxP models; plan complex flows first. Read [references/author/CAPABILITY.md](references/author/CAPABILITY.md).
+- **Author** — Build and edit `.flow` files; add nodes, edges, variables, subflows, transforms, and triggers; explore the registry; validate and format locally; apply node ownership; configure connectors, triggers, managed HTTP, inline-agent scaffolding, IxP/document-extraction nodes, IxP models, and Data Fabric entity record CRUD; plan complex flows first. Read [references/author/CAPABILITY.md](references/author/CAPABILITY.md).
 <!--skill-flavor:project-creation-scope:start-->
   - Create projects with `uip maestro flow init`.
 <!--skill-flavor:project-creation-scope:end-->

--- a/skills/uipath-maestro-flow/references/author/CAPABILITY.md
+++ b/skills/uipath-maestro-flow/references/author/CAPABILITY.md
@@ -160,7 +160,7 @@ If you find yourself hand-writing `inputs.detail`, a `=jsonString:` blob, or `bi
 - [planning-arch.md](planning-arch.md) — capability discovery, plugin index, topology design
 - [planning-impl.md](planning-impl.md) — registry lookups, connection binding, wiring rules
 - [plugins/](plugins/) — per-node-type planning + impl docs:
-  - [connector](plugins/connector/) — IS connector nodes (incl. the `uipath-uipath-dataservice` entity activities; cf. [data-fabric](plugins/data-fabric/))
+  - [connector](plugins/connector/) — IS connector nodes (incl. the `uipath-uipath-dataservice` entity activities; see [data-fabric](plugins/data-fabric/))
   - [connector-trigger](plugins/connector-trigger/)
   - [script](plugins/script/) — Jint ES2020 JavaScript
   - [http](plugins/http/) — `core.action.http.v2` (Managed HTTP Request)

--- a/skills/uipath-maestro-flow/references/author/CAPABILITY.md
+++ b/skills/uipath-maestro-flow/references/author/CAPABILITY.md
@@ -37,6 +37,7 @@ Every node in a `.flow` file has exactly one author. The validator enforces this
 | Resource nodes | `uipath.core.rpa-workflow.*`, `uipath.core.agent.*`, `uipath.core.flow.*`, `uipath.core.agentic-process.*`, `uipath.core.api-workflow.*`, `uipath.core.human-task.*` |
 | Document extraction | `uipath.ixp.*` — the extraction step must always land a node ([ixp/impl.md](plugins/ixp/impl.md#landing-the-node-when-you-cannot-fully-configure-it)) |
 | Queue | `core.action.queue.create`, `core.action.queue.create-and-wait` |
+| Data Fabric | `core.datafabric.read`, `core.datafabric.create`, `core.datafabric.update`, `core.datafabric.delete` — `inputs.entityConfig` is plain JSON, not an envelope ([data-fabric/impl.md](plugins/data-fabric/impl.md)) |
 
 **CLI-owned nodes (`uip maestro flow node add` + `uip maestro flow node configure`):**
 
@@ -116,6 +117,7 @@ If you find yourself hand-writing `inputs.detail`, a `=jsonString:` blob, or `bi
 | **Create a subflow** | [plugins/subflow/impl.md](plugins/subflow/impl.md) + [Edit/Write: Create a subflow](editing-operations-json.md#create-a-subflow) |
 | **Add a delay or scheduled trigger** | [plugins/delay/](plugins/delay/) or [plugins/scheduled-trigger/](plugins/scheduled-trigger/) |
 | **Use queue nodes** | [plugins/queue/impl.md](plugins/queue/impl.md) |
+| **Read or write Data Fabric entity records** | [plugins/data-fabric/impl.md](plugins/data-fabric/impl.md) — `core.datafabric.read` / `create` / `update` / `delete`, each gated by its own `canvas.nodes.*-entity` tenant flag |
 
 ## Anti-patterns
 
@@ -158,7 +160,7 @@ If you find yourself hand-writing `inputs.detail`, a `=jsonString:` blob, or `bi
 - [planning-arch.md](planning-arch.md) — capability discovery, plugin index, topology design
 - [planning-impl.md](planning-impl.md) — registry lookups, connection binding, wiring rules
 - [plugins/](plugins/) — per-node-type planning + impl docs:
-  - [connector](plugins/connector/) — IS connector nodes (incl. Data Fabric activities)
+  - [connector](plugins/connector/) — IS connector nodes (incl. the `uipath-uipath-dataservice` entity activities; prefer the native [data-fabric](plugins/data-fabric/) nodes when their flag is on)
   - [connector-trigger](plugins/connector-trigger/)
   - [script](plugins/script/) — Jint ES2020 JavaScript
   - [http](plugins/http/) — `core.action.http.v2` (Managed HTTP Request)
@@ -184,6 +186,7 @@ If you find yourself hand-writing `inputs.detail`, a `=jsonString:` blob, or `bi
   - [inline-voice-agent](plugins/inline-voice-agent/) — voice agent on a live phone call (inbound/outbound) + the trigger, create-call, and end-call nodes
   - [ixp](plugins/ixp/) — published IxP document-extraction models (PDFs, scanned forms, receipts, invoices, contracts)
   - [queue](plugins/queue/) — Orchestrator queue item creation
+  - [data-fabric](plugins/data-fabric/) — native Data Fabric entity record CRUD (`core.datafabric.*`), no Integration Service connection
 
 ### Cross-capability (shared)
 

--- a/skills/uipath-maestro-flow/references/author/CAPABILITY.md
+++ b/skills/uipath-maestro-flow/references/author/CAPABILITY.md
@@ -160,7 +160,7 @@ If you find yourself hand-writing `inputs.detail`, a `=jsonString:` blob, or `bi
 - [planning-arch.md](planning-arch.md) — capability discovery, plugin index, topology design
 - [planning-impl.md](planning-impl.md) — registry lookups, connection binding, wiring rules
 - [plugins/](plugins/) — per-node-type planning + impl docs:
-  - [connector](plugins/connector/) — IS connector nodes (incl. the `uipath-uipath-dataservice` entity activities; prefer the native [data-fabric](plugins/data-fabric/) nodes when their flag is on)
+  - [connector](plugins/connector/) — IS connector nodes (incl. the `uipath-uipath-dataservice` entity activities; the native [data-fabric](plugins/data-fabric/) nodes are the lighter path where the tenant has them enabled — their flags default to off, so confirm with `registry get` before choosing)
   - [connector-trigger](plugins/connector-trigger/)
   - [script](plugins/script/) — Jint ES2020 JavaScript
   - [http](plugins/http/) — `core.action.http.v2` (Managed HTTP Request)

--- a/skills/uipath-maestro-flow/references/author/CAPABILITY.md
+++ b/skills/uipath-maestro-flow/references/author/CAPABILITY.md
@@ -160,7 +160,7 @@ If you find yourself hand-writing `inputs.detail`, a `=jsonString:` blob, or `bi
 - [planning-arch.md](planning-arch.md) — capability discovery, plugin index, topology design
 - [planning-impl.md](planning-impl.md) — registry lookups, connection binding, wiring rules
 - [plugins/](plugins/) — per-node-type planning + impl docs:
-  - [connector](plugins/connector/) — IS connector nodes (incl. the `uipath-uipath-dataservice` entity activities; the native [data-fabric](plugins/data-fabric/) nodes are the lighter path where the tenant has them enabled — their flags default to off, so confirm with `registry get` before choosing)
+  - [connector](plugins/connector/) — IS connector nodes (incl. the `uipath-uipath-dataservice` entity activities; cf. [data-fabric](plugins/data-fabric/))
   - [connector-trigger](plugins/connector-trigger/)
   - [script](plugins/script/) — Jint ES2020 JavaScript
   - [http](plugins/http/) — `core.action.http.v2` (Managed HTTP Request)
@@ -186,7 +186,7 @@ If you find yourself hand-writing `inputs.detail`, a `=jsonString:` blob, or `bi
   - [inline-voice-agent](plugins/inline-voice-agent/) — voice agent on a live phone call (inbound/outbound) + the trigger, create-call, and end-call nodes
   - [ixp](plugins/ixp/) — published IxP document-extraction models (PDFs, scanned forms, receipts, invoices, contracts)
   - [queue](plugins/queue/) — Orchestrator queue item creation
-  - [data-fabric](plugins/data-fabric/) — native Data Fabric entity record CRUD (`core.datafabric.*`), no Integration Service connection
+  - [data-fabric](plugins/data-fabric/) — native Data Fabric entity record CRUD (`core.datafabric.*`); tenant flags default to off
 
 ### Cross-capability (shared)
 

--- a/skills/uipath-maestro-flow/references/author/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/author/planning-arch.md
@@ -169,7 +169,7 @@ Prefer, in order:
 2. `core.action.http.v2` connector mode when the connector lacks the activity, or manual mode for APIs without connectors ([http](plugins/http/planning.md)).
 3. An RPA workflow only when there is no API, such as a desktop app or terminal ([rpa](plugins/rpa/planning.md)).
 
-**Data Fabric is not on this ladder.** Entity records have two paths — the `uipath-uipath-dataservice` connector activities and the native `core.datafabric.*` nodes — and availability decides, not preference. See [data-fabric/planning.md — Native node vs Data Service connector](plugins/data-fabric/planning.md#native-node-vs-data-service-connector--availability-decides).
+**Data Fabric is not on this ladder.** Entity records have two paths — the `uipath-uipath-dataservice` connector activities and the native `core.datafabric.*` nodes — and availability decides, not preference. The native flags default to off, so **when `registry get core.datafabric.<op>` answers "Node not found", or search reports `AvailableOnTenant: false`, build with the connector activities**: do not retry, do not `uip tools update`, and never hand-write a `definitions[]` entry for a node the registry will not return. Rationale and the federated-entity case in [data-fabric/planning.md — Native node vs Data Service connector](plugins/data-fabric/planning.md#native-node-vs-data-service-connector--availability-decides).
 
 ## Standard Port Reference
 

--- a/skills/uipath-maestro-flow/references/author/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/author/planning-arch.md
@@ -169,9 +169,7 @@ Prefer, in order:
 2. `core.action.http.v2` connector mode when the connector lacks the activity, or manual mode for APIs without connectors ([http](plugins/http/planning.md)).
 3. An RPA workflow only when there is no API, such as a desktop app or terminal ([rpa](plugins/rpa/planning.md)).
 
-**Data Fabric has two paths, and availability decides which.** Entity records can be reached either through the `uipath-uipath-dataservice` connector activities ([connector](plugins/connector/planning.md)) or through the native `core.datafabric.*` nodes ([data-fabric](plugins/data-fabric/planning.md)).
-
-The native nodes are nicer when they are there — no Integration Service connection, no `node configure` — but **all four tenant flags default to off**, so on most tenants they do not exist. Decide by checking, not by preference: run `uip maestro flow registry get core.datafabric.read` (and the sibling type for the operation you need). If it returns the node, use the native node. If it answers "Node not found" or search reports `AvailableOnTenant: false`, **use the connector activities** and do not spend further turns on the native path. Also use the connector when the entity is federated — the native writes require a native entity — or when you need an operation the four nodes do not cover.
+**Data Fabric is not on this ladder.** Entity records have two paths — the `uipath-uipath-dataservice` connector activities and the native `core.datafabric.*` nodes — and availability decides, not preference. See [data-fabric/planning.md — Native node vs Data Service connector](plugins/data-fabric/planning.md#native-node-vs-data-service-connector--availability-decides).
 
 ## Standard Port Reference
 

--- a/skills/uipath-maestro-flow/references/author/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/author/planning-arch.md
@@ -110,7 +110,7 @@ Every flow has exactly one trigger, first in topology. IS connector triggers rep
 | `core.action.queue.create` | [queue](plugins/queue/planning.md) | Fire-and-forget robot work |
 | `core.action.queue.create-and-wait` | [queue](plugins/queue/planning.md) | Robot work with result wait |
 | `core.datafabric.read` | [data-fabric](plugins/data-fabric/planning.md) | Read one record or a filtered list from a Data Fabric entity; gated by `canvas.nodes.read-entity` |
-| `core.datafabric.create` | [data-fabric](plugins/data-fabric/planning.md) | Insert a record and return the stored row; gated by `canvas.nodes.create-entity` (needs engine >= 1.923.0) |
+| `core.datafabric.create` | [data-fabric](plugins/data-fabric/planning.md) | Insert a record and return the stored row; gated by `canvas.nodes.create-entity` |
 | `core.datafabric.update` | [data-fabric](plugins/data-fabric/planning.md) | Patch named columns on one record; gated by `canvas.nodes.update-entity` |
 | `core.datafabric.delete` | [data-fabric](plugins/data-fabric/planning.md) | Delete one record; gated by `canvas.nodes.delete-entity` |
 | `uipath.human-in-the-loop.quick-form` | [hitl](plugins/hitl/planning.md) | Inline human review, approval, or data entry |
@@ -168,6 +168,8 @@ Prefer, in order:
 1. A curated Integration Service connector ([connector](plugins/connector/planning.md)).
 2. `core.action.http.v2` connector mode when the connector lacks the activity, or manual mode for APIs without connectors ([http](plugins/http/planning.md)).
 3. An RPA workflow only when there is no API, such as a desktop app or terminal ([rpa](plugins/rpa/planning.md)).
+
+**Data Fabric is not on this ladder.** Reading or writing records in a UiPath Data Fabric entity is not an external-service call: use the native `core.datafabric.*` nodes ([data-fabric](plugins/data-fabric/planning.md)), which need no Integration Service connection. The `uipath-uipath-dataservice` connector activities are the fallback — take them only when the native node's tenant flag is off, when the entity is federated (the native writes require a native entity), or when you need an operation the four nodes do not cover.
 
 ## Standard Port Reference
 

--- a/skills/uipath-maestro-flow/references/author/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/author/planning-arch.md
@@ -169,7 +169,9 @@ Prefer, in order:
 2. `core.action.http.v2` connector mode when the connector lacks the activity, or manual mode for APIs without connectors ([http](plugins/http/planning.md)).
 3. An RPA workflow only when there is no API, such as a desktop app or terminal ([rpa](plugins/rpa/planning.md)).
 
-**Data Fabric is not on this ladder.** Reading or writing records in a UiPath Data Fabric entity is not an external-service call: use the native `core.datafabric.*` nodes ([data-fabric](plugins/data-fabric/planning.md)), which need no Integration Service connection. The `uipath-uipath-dataservice` connector activities are the fallback — take them only when the native node's tenant flag is off, when the entity is federated (the native writes require a native entity), or when you need an operation the four nodes do not cover.
+**Data Fabric has two paths, and availability decides which.** Entity records can be reached either through the `uipath-uipath-dataservice` connector activities ([connector](plugins/connector/planning.md)) or through the native `core.datafabric.*` nodes ([data-fabric](plugins/data-fabric/planning.md)).
+
+The native nodes are nicer when they are there — no Integration Service connection, no `node configure` — but **all four tenant flags default to off**, so on most tenants they do not exist. Decide by checking, not by preference: run `uip maestro flow registry get core.datafabric.read` (and the sibling type for the operation you need). If it returns the node, use the native node. If it answers "Node not found" or search reports `AvailableOnTenant: false`, **use the connector activities** and do not spend further turns on the native path. Also use the connector when the entity is federated — the native writes require a native entity — or when you need an operation the four nodes do not cover.
 
 ## Standard Port Reference
 

--- a/skills/uipath-maestro-flow/references/author/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/author/planning-arch.md
@@ -109,6 +109,10 @@ Every flow has exactly one trigger, first in topology. IS connector triggers rep
 | `core.logic.delay` | [delay](plugins/delay/planning.md) | Duration or date wait |
 | `core.action.queue.create` | [queue](plugins/queue/planning.md) | Fire-and-forget robot work |
 | `core.action.queue.create-and-wait` | [queue](plugins/queue/planning.md) | Robot work with result wait |
+| `core.datafabric.read` | [data-fabric](plugins/data-fabric/planning.md) | Read one record or a filtered list from a Data Fabric entity; gated by `canvas.nodes.read-entity` |
+| `core.datafabric.create` | [data-fabric](plugins/data-fabric/planning.md) | Insert a record and return the stored row; gated by `canvas.nodes.create-entity` (needs engine >= 1.923.0) |
+| `core.datafabric.update` | [data-fabric](plugins/data-fabric/planning.md) | Patch named columns on one record; gated by `canvas.nodes.update-entity` |
+| `core.datafabric.delete` | [data-fabric](plugins/data-fabric/planning.md) | Delete one record; gated by `canvas.nodes.delete-entity` |
 | `uipath.human-in-the-loop.quick-form` | [hitl](plugins/hitl/planning.md) | Inline human review, approval, or data entry |
 | `uipath.conversational.voice.create-outgoing-call` | [inline-voice-agent](plugins/inline-voice-agent/planning.md) | Dial an outbound phone call and emit its `callContext` (outbound voice topology) |
 | `uipath.conversational.voice.end-call` | [inline-voice-agent](plugins/inline-voice-agent/planning.md) | End the active call in a voice flow |
@@ -204,6 +208,10 @@ Every edge requires `sourcePort` and `targetPort`.
 | `uipath.connector.*` | `input` | `output`, `error` |
 | `core.action.queue.create` | `input` | `success` |
 | `core.action.queue.create-and-wait` | `input` | `success` |
+| `core.datafabric.read` | `input` | `output` |
+| `core.datafabric.create` | `input` | `output` |
+| `core.datafabric.update` | `input` | `output` |
+| `core.datafabric.delete` | `input` | `output` (sequencing only — the node produces no data) |
 | `uipath.human-in-the-loop.quick-form` | `input` | `completed` |
 | `uipath.core.human-task.{key}` | `input` | `output` |
 

--- a/skills/uipath-maestro-flow/references/author/planning-impl.md
+++ b/skills/uipath-maestro-flow/references/author/planning-impl.md
@@ -48,6 +48,7 @@ Use these plugin mappings:
 | `core.trigger.scheduled` | [scheduled-trigger/impl.md](plugins/scheduled-trigger/impl.md) |
 | `core.trigger.voice` | [inline-voice-agent/impl.md](plugins/inline-voice-agent/impl.md) |
 | `core.action.queue.*` | [queue/impl.md](plugins/queue/impl.md) |
+| `core.datafabric.*` | [data-fabric/impl.md](plugins/data-fabric/impl.md) |
 | `uipath.agent.autonomous` | [inline-agent/impl.md](plugins/inline-agent/impl.md) |
 | `uipath.agent.voice` | [inline-voice-agent/impl.md](plugins/inline-voice-agent/impl.md) |
 | `uipath.conversational.voice.create-outgoing-call` | [inline-voice-agent/impl.md](plugins/inline-voice-agent/impl.md) |

--- a/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
@@ -243,7 +243,7 @@ Illustrative supported activities (confirm against `registry get` for the specif
 | `uipath-sap-s4hanacloud` | `Entity` | Create Entity | POST | method |
 | `uipath-google-bigquery` | `projects::table` | List All Records | GET | method |
 
-> **`uipath-uipath-dataservice` is the fallback for Data Fabric, not the default.** Entity records have native nodes — `core.datafabric.read` / `create` / `update` / `delete` ([data-fabric/planning.md](../data-fabric/planning.md)) — which need no Integration Service connection and are authored with `Edit`/`Write` instead of `node configure`. Reach for these connector activities only when the native node's tenant flag is off, when the entity is federated (the native writes require a native entity), or when you need an operation the four nodes do not cover.
+> **Data Fabric also has native nodes — check whether they exist before choosing.** `core.datafabric.read` / `create` / `update` / `delete` ([data-fabric/planning.md](../data-fabric/planning.md)) need no Integration Service connection and are authored with `Edit`/`Write` instead of `node configure`, so they are the lighter path **when the tenant has them**. Their flags default to off, so confirm with `uip maestro flow registry get core.datafabric.read` first. If that answers "Node not found" — or search reports `AvailableOnTenant: false` — these `uipath-uipath-dataservice` activities are the correct path; stay here. Stay here too when the entity is federated, since the native writes require a native entity.
 
 Run Step 3a and use the matched action's `name` and `apiConfiguration.{url,body}` tokens. Match `source: field` or `source: method` according to metadata; for operation-scoped lookup use the node definition's `model.context[].method`.
 

--- a/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
@@ -243,6 +243,8 @@ Illustrative supported activities (confirm against `registry get` for the specif
 | `uipath-sap-s4hanacloud` | `Entity` | Create Entity | POST | method |
 | `uipath-google-bigquery` | `projects::table` | List All Records | GET | method |
 
+> **`uipath-uipath-dataservice` is the fallback for Data Fabric, not the default.** Entity records have native nodes — `core.datafabric.read` / `create` / `update` / `delete` ([data-fabric/planning.md](../data-fabric/planning.md)) — which need no Integration Service connection and are authored with `Edit`/`Write` instead of `node configure`. Reach for these connector activities only when the native node's tenant flag is off, when the entity is federated (the native writes require a native entity), or when you need an operation the four nodes do not cover.
+
 Run Step 3a and use the matched action's `name` and `apiConfiguration.{url,body}` tokens. Match `source: field` or `source: method` according to metadata; for operation-scoped lookup use the node definition's `model.context[].method`.
 
 Encode tokens longest-first: `:::` → `_sub_`; `[*]` → `_array`; `::` → `_sub_`; `.` → `_sub_`. Examples: `fields.project.key` → `fields_sub_project_sub_key`; `items[*]` → `items_array`; `tenantEntityName` → `tenantEntityName` (unchanged). Use camelCase keys and include every token from `apiConfiguration.url` and `body`:

--- a/skills/uipath-maestro-flow/references/author/plugins/data-fabric/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/data-fabric/impl.md
@@ -38,7 +38,9 @@ If `registry get` reports **"Node not found"**, the node is not available to you
 | `core.datafabric.update` | `canvas.nodes.update-entity` |
 | `core.datafabric.delete` | `canvas.nodes.delete-entity` |
 
-`registry search` is not a substitute for `registry get` here. A flag-gated node can still appear in search with `AvailableOnTenant: false` while `registry get` refuses it — and without `registry get` you cannot source the `definitions[]` entry, which must never be hand-written ([Author capability, rule 6](../../CAPABILITY.md#critical-rules)). Treat `AvailableOnTenant: false` as unavailable and stop.
+`registry search` is not a substitute for `registry get` here. A flag-gated node can still appear in search with `AvailableOnTenant: false` while `registry get` refuses it — and without `registry get` you cannot source the `definitions[]` entry, which must never be hand-written ([Author capability, rule 6](../../CAPABILITY.md#critical-rules)).
+
+**When the node is unavailable, switch to the connector and stop.** `AvailableOnTenant: false` is a decision, not an obstacle: build the flow with the `uipath-uipath-dataservice` activities ([connector/impl.md](../connector/impl.md)) and say in the final report that the native nodes were unavailable. Do not retry `registry get`, do not run `uip tools update` hoping for a newer manifest, and above all **do not hand-author a `definitions[]` entry from this doc's field list to stand in for the missing one** — a hand-written definition carries the wrong port schema, passes `flow validate`, and fails at runtime.
 
 ## Add or edit the node
 

--- a/skills/uipath-maestro-flow/references/author/plugins/data-fabric/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/data-fabric/impl.md
@@ -58,6 +58,8 @@ An invented id or column matches no record: every lookup returns empty and the r
 
 Node instances carry `inputs` only. Do **not** hand-write an `outputs` block, a `model` block, or a `ui` block — `flow format` owns layout, the definition owns the BPMN model, and the manifest's `outputDefinition` plus the `variables.nodes[]` entry that `flow format` regenerates own the output contract ([Author capability, rules 13–15](../../CAPABILITY.md#critical-rules)).
 
+> **Editing a node the canvas created: preserve the `_`-prefixed keys you do not recognize.** The entity panels snapshot the picked entity's schema onto `entityConfig` — `_entityFields`, `_relatedFields`, `_outputSchema` — and those snapshots are what resolve related-column paths and drive output IntelliSense. They are not required to author a node from scratch, and none of the examples below carry them, but stripping them from an existing node silently breaks any filter that addresses a related column (`customer.Name`), because a path that cannot resolve against the snapshot makes the serializer refuse the whole query. Change the keys you mean to change and leave the rest.
+
 ### Read — single record
 
 ```json
@@ -237,10 +239,33 @@ A **folder-scoped** entity carries `_folderKey` (the folder GUID). Its presence 
 
 ```json
 "bindings": [
-  { "id": "<bindingId1>", "resource": "Entity", "resourceKey": "<resourceKey>", "propertyAttribute": "name",      "name": "Orders" },
-  { "id": "<bindingId2>", "resource": "Entity", "resourceKey": "<resourceKey>", "propertyAttribute": "folderKey", "name": "<folder GUID>" }
+  {
+    "id": "<bindingId1>",
+    "name": "Orders",
+    "type": "string",
+    "resource": "Entity",
+    "resourceKey": "<resourceKey>",
+    "default": "Orders",
+    "propertyAttribute": "name"
+  },
+  {
+    "id": "<bindingId2>",
+    "name": "OrdersFolder",
+    "type": "string",
+    "resource": "Entity",
+    "resourceKey": "<resourceKey>",
+    "default": "<folder GUID>",
+    "propertyAttribute": "folderKey"
+  }
 ]
 ```
+
+Field-by-field, because three of these are easy to get wrong:
+
+- **The value lives in `default`, never in `name`.** `name` is a display label: the entity-name row uses the entity name for both, but the folder row's `name` is the literal convention `<entityName>Folder` while its `default` carries the folder GUID.
+- **`type` is `"string"` and is required** — the binding schema rejects a row without it.
+- **`resource` must be the capitalized `"Entity"`.** The BPMN engine matches it case-insensitively, but packaging requires the capital form; a lowercase row never becomes a binding resource, so the deploy side gets no override at all.
+- **`propertyAttribute` is what the serializer matches on**, not `name`.
 
 The folder token must come from the **`folderKey`** attribute, not `folderPath`: the platform's deploy-time override rewrites `folderPath` with the Orchestrator FQN, which breaks the query even in the source org.
 

--- a/skills/uipath-maestro-flow/references/author/plugins/data-fabric/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/data-fabric/impl.md
@@ -1,8 +1,13 @@
 # Data Fabric Entity Nodes — Implementation
 
-Four OOTB nodes that read and write records in a UiPath Data Fabric entity: `core.datafabric.read`, `core.datafabric.create`, `core.datafabric.update`, `core.datafabric.delete`. Each is a `bpmn:Task` host — the serializer attaches a `<uipath:output>` carrying a `=datafabric...` target, and the BPMN engine's activity postprocessor performs the query or write after the task runs. There is no Integration Service connection and no connector binding.
+Four OOTB nodes that read and write records in a UiPath Data Fabric entity: `core.datafabric.read`, `core.datafabric.create`, `core.datafabric.update`, `core.datafabric.delete`. Each is a `bpmn:Task` host with no `serviceType`, and the BPMN engine does the actual work — but by two different mechanisms:
 
-Shared action-node boilerplate — skeleton, ports, error port, add/edit mechanics — is in [shared/action-nodes.md](../../../shared/action-nodes.md). This file covers only what is specific to the entity nodes.
+- **Read** emits its compiled query as a `<uipath:input>`. The engine's **input preprocessor** resolves it *before* the task runs.
+- **Create / Update / Delete** emit a `<uipath:output>` carrying a `=datafabric...` target. The engine's **activity postprocessor** performs the write *after* the task runs.
+
+That split matters when reading generated BPMN: a Read node with no `<uipath:output>` action target is correct, not a serialization failure.
+
+Shared action-node boilerplate — skeleton, ports, add/edit mechanics — is in [shared/action-nodes.md](../../../shared/action-nodes.md), with one exception noted under [No error port](#no-error-port). This file covers only what is specific to the entity nodes.
 
 ## Registry validation
 
@@ -17,14 +22,21 @@ uip maestro flow registry get core.datafabric.delete --output json
 
 Confirm on `Data.Node`:
 
-- `handleConfiguration` — input port `input`, output port `output`. All four share this shape.
+- `handleConfiguration` — input port `input`, output port `output`. All four share this shape, and none has an `error` handle.
 - `model.type` — `bpmn:Task` (**not** `bpmn:ServiceTask`; these nodes carry no `serviceType`).
 - `inputDefinition.properties.entityConfig` — the single input container.
 - `outputDefinition.output.source` — `=response`, with `type: "jsonSchema"`. **Delete has no `outputDefinition` at all** — that absence is the contract, not an omission.
 - `runtimeConstraints.exclude` — contains `api-function`.
-- `version` — copy it verbatim into the instance's `typeVersion`. Read and Create are ahead of Update and Delete; do not assume one version across the family.
+- `version` — copy it verbatim into the instance's `typeVersion`. The four are versioned independently; do not assume one version across the family.
 
-If `registry get` reports **"Node not found"**, the node is not available to you. Run `uip tools update`, then `uip maestro flow registry pull --force`, and retry. If it still fails, the tenant feature flag is off — `canvas.nodes.read-entity`, `canvas.nodes.update-entity`, `canvas.nodes.delete-entity`, or `canvas.nodes.create-entity` respectively. Confirm with the UiPath admin.
+If `registry get` reports **"Node not found"**, the node is not available to you. Run `uip tools update`, then `uip maestro flow registry pull --force`, and retry. If it still fails, that node's tenant feature flag is off:
+
+| Node type | Flag to ask the admin about |
+| --- | --- |
+| `core.datafabric.read` | `canvas.nodes.read-entity` |
+| `core.datafabric.create` | `canvas.nodes.create-entity` |
+| `core.datafabric.update` | `canvas.nodes.update-entity` |
+| `core.datafabric.delete` | `canvas.nodes.delete-entity` |
 
 `registry search` is not a substitute for `registry get` here. A flag-gated node can still appear in search with `AvailableOnTenant: false` while `registry get` refuses it — and without `registry get` you cannot source the `definitions[]` entry, which must never be hand-written ([Author capability, rule 6](../../CAPABILITY.md#critical-rules)). Treat `AvailableOnTenant: false` as unavailable and stop.
 
@@ -34,31 +46,46 @@ These are OOTB nodes and therefore **user-owned**: author them with `Edit` / `Wr
 
 Every node type still needs its `definitions[]` entry copied verbatim from `registry get`.
 
-## Resolving the entity and its columns
+## No error port
 
-Entity and column names are **case-sensitive**, and an unmatched column is silently dropped rather than rejected — a wrong name yields a node that validates green and writes nothing. Resolve both from the tenant before authoring:
+These four nodes are the exception to the implicit-error-port rule in [shared/action-nodes.md](../../../shared/action-nodes.md). None of them declares `supportsErrorHandling`, so the canvas never injects an `error` handle and the properties panel offers no error-handling toggle.
+
+Do not set `inputs.errorHandlingEnabled`, and do not add an edge with `sourcePort: "error"`. Such an edge still serializes a boundary event — keyed purely on the handle name — but the node has no `outputDefinition.error` to map, so it emits with no error mapping and shows no handle the author can see or remove. Handle failure upstream (validate inputs before the node) or downstream (branch on the result), not with an error edge.
+
+## Resolving the entity, its scope, and its columns
+
+Entity and column names are **case-sensitive**, and an unmatched column is silently dropped rather than rejected — a wrong name yields a node that validates green and writes nothing. Resolve everything from the tenant before authoring.
+
+`uip df entities list` shows **tenant-level entities only** by default. A folder-scoped entity will not appear until you widen the scope:
 
 ```bash
+# Tenant-level only (default)
 uip df entities list --output json
-uip df entities get <entity-id> --output json
+
+# Tenant + every folder you can see
+uip df entities list --include-folders --output json
+
+# One folder (mutually exclusive with --include-folders)
+uip df entities list --folder-key <folder-uuid> --output json
+
+# Writable entities only — Create/Update/Delete need a native entity
+uip df entities list --native-only --include-folders --output json
 ```
 
-`entities list` gives the entity `Name` (what `entityName` takes) and its id; `entities get` gives the exact column names for `_filters`, `fieldValues`, `fieldUpdates`, and `_selectedFieldNames`.
+Each listed entity carries its `folderId`. That value is both the `--folder-key` for follow-up commands and the `_folderKey` you put on a folder-scoped `entityConfig`.
 
-When a step needs a real record id or a sample row — for a `byId` selector, or to sanity-check a filter — read one rather than inventing it:
+Column names and a live record follow the same scoping rule — a folder-scoped entity needs `--folder-key` on each:
 
 ```bash
-uip df records list <entity-id> --output json
-uip df records query <entity-id> --body '{"filterGroup":{...}}' --output json
+uip df entities get <entity-id> [--folder-key <folder-uuid>] --output json
+uip df records list <entity-id> [--folder-key <folder-uuid>] --output json
 ```
 
-An invented id or column matches no record: every lookup returns empty and the run faults on empty data.
+`entities get` gives the exact column names for `_filters`, `fieldValues`, `fieldUpdates`, and `_selectedFieldNames`, plus each column's type, nullability, and whether it is a system field. Read a real record before writing a `byId` selector — an invented id matches nothing, and a read that matches nothing does not fault.
 
 ## JSON structure
 
 Node instances carry `inputs` only. Do **not** hand-write an `outputs` block, a `model` block, or a `ui` block — `flow format` owns layout, the definition owns the BPMN model, and the manifest's `outputDefinition` plus the `variables.nodes[]` entry that `flow format` regenerates own the output contract ([Author capability, rules 13–15](../../CAPABILITY.md#critical-rules)).
-
-> **Editing a node the canvas created: preserve the `_`-prefixed keys you do not recognize.** The entity panels snapshot the picked entity's schema onto `entityConfig` — `_entityFields`, `_relatedFields`, `_outputSchema` — and those snapshots are what resolve related-column paths and drive output IntelliSense. They are not required to author a node from scratch, and none of the examples below carry them, but stripping them from an existing node silently breaks any filter that addresses a related column (`customer.Name`), because a path that cannot resolve against the snapshot makes the serializer refuse the whole query. Change the keys you mean to change and leave the rest.
 
 ### Read — single record
 
@@ -84,6 +111,8 @@ Node instances carry `inputs` only. Do **not** hand-write an `outputs` block, a 
 }
 ```
 
+A single-record read faults only on an **over**-match. Zero matches completes normally, leaving `$vars.readOrder.output` unresolved — so treat "not found" as a branch, not an error.
+
 ### Read — multiple records
 
 ```json
@@ -98,7 +127,7 @@ Node instances carry `inputs` only. Do **not** hand-write an `outputs` block, a 
       "resultMode": "multiple",
       "_recordLimit": 100,
       "_skip": 0,
-      "_sort": { "field": "CreatedAt", "direction": "desc" },
+      "_sort": { "field": "CreateTime", "direction": "desc" },
       "_selectedFieldNames": ["Id", "OrderNumber", "Status"],
       "_filters": {
         "logicalOperator": "AND",
@@ -112,7 +141,9 @@ Node instances carry `inputs` only. Do **not** hand-write an `outputs` block, a 
 
 The rows land at `$vars.listOpenOrders.output.results`, not `$vars.listOpenOrders.output`.
 
-Write `_recordLimit` explicitly, as the canvas does. Omitting it does not mean "no cap" — the engine applies its own default, which differs by the entity's composite shape, so the row count silently depends on the entity rather than on the flow. A `_sort` matters for the same reason: a limit without an order returns an arbitrary slice.
+The emitted query **always** carries an explicit `limit`: omitting `_recordLimit` resolves to **100**, and any value is clamped to 1–1000. 1000 is a hard ceiling, so the only way to cover a larger entity is to page with `_skip` — raising `_recordLimit` past 1000 silently truncates. Pair any limit with `_sort`, or the slice is arbitrary.
+
+`CreateTime` above is the real server-managed audit column. The audit columns are `Id`, `CreateTime`, `CreatedBy`, `UpdateTime`, `UpdatedBy` — there is no `CreatedAt`, and a sort on a non-existent column is not caught by `flow validate`.
 
 ### Create
 
@@ -127,7 +158,7 @@ Write `_recordLimit` explicitly, as the canvas does. Omitting it does not mean "
       "entityName": "Orders",
       "fieldValues": [
         { "field": "OrderNumber", "value": "=js:$vars.start.output.orderNumber" },
-        { "field": "Status", "value": "Open" }
+        { "field": "Notes", "value": "Created by flow" }
       ]
     }
   }
@@ -150,7 +181,7 @@ At least one row must carry a non-blank `value`. A blank value is **omitted** fr
       "recordSource": "fromRead",
       "readEntityNodeId": "readOrder",
       "fieldUpdates": [
-        { "field": "Status", "value": "Shipped" },
+        { "field": "Notes", "value": "Shipped by flow" },
         { "field": "ShippedAt", "value": "=js:new Date().toISOString()" }
       ]
     }
@@ -158,7 +189,7 @@ At least one row must carry a non-blank `value`. A blank value is **omitted** fr
 }
 ```
 
-An empty `value` in `fieldUpdates` is a **real write** that clears the column — unlike Create, it is never treated as "leave unset".
+`readEntityNodeId` must match the Read node's `id` exactly — see [Record selection](#record-selection) for what happens when it does not.
 
 ### Delete
 
@@ -178,7 +209,34 @@ An empty `value` in `fieldUpdates` is a **real write** that clears the column �
 }
 ```
 
-`recordSource` is **required** on Delete (unlike Update, which tolerates its absence on legacy configs). Without it both selector guards go inert, the serializer resolves no record, and a destructive node publishes and runs green having deleted nothing.
+## Write bodies
+
+Both write editors take `[{ field, value }]` rows, but what a value means differs by verb and by column type. The serializer coerces each value using the column's declared type from the `_outputSchema` snapshot; a value it cannot coerce is passed through as a string for the API to reject, **and that rejection is only logged** — it surfaces as an unchanged row, not a failed run.
+
+| Column kind | What the row's `value` must be |
+| --- | --- |
+| String | The text itself |
+| Integer / number | A clean numeric literal. `42.5` in an integer column is not coerced and is rejected |
+| Boolean | `true` or `false` |
+| **Choice set (single)** | The choice's numeric **`numberId`**, not its label — the column's SQL type is `INT` |
+| **Choice set (multi)** | A JSON array of those numeric ids |
+| **System columns** | Never writable — see below |
+| **Attachment columns** | Never writable |
+
+**System columns are `Id`, `CreateTime`, `CreatedBy`, `UpdateTime`, `UpdatedBy`.** Data Fabric assigns them. The canvas hides them from both write editors, but the serializer has no guard: a hand-authored `{ field: "Id", … }` or `{ field: "UpdatedBy", … }` satisfies the validator's "at least one field" rule, ships in the body, and is rejected and swallowed.
+
+**Blank values differ by verb.** On Create a blank value is omitted, letting the column default apply. On Update a blank value writes an explicit `null`, which **a non-nullable column rejects** — so "clear the column" only works on a nullable one. Nullability is not carried in the node's snapshot, so check it with `uip df entities get`.
+
+## Schema snapshots
+
+The entity panels persist snapshots of the picked entity onto `entityConfig`: `_entityFields`, `_relatedFields`, `_outputSchema`, `_choiceSets`, `_entityDisplayName`. When editing a node the canvas created, **preserve every one you are not deliberately changing.**
+
+They are not decoration, and two of them are load-bearing when authoring from scratch:
+
+- **`_entityFields` is mandatory for any dotted related path.** A filter on `customer.Name` resolves its first segment against this snapshot; without it the path is unresolvable, and the serializer refuses **the whole query** — the node emits nothing and every downstream `$vars` reference breaks. Related paths are capped at 3 segments, and a 3-segment path's last segment must literally be `Id`.
+- **`_outputSchema` is the only input to write-body type coercion.** Without it nothing is coerced: `{ field: "Quantity", value: "5" }` serializes as the string `"5"` on an integer column, is rejected, and is swallowed.
+
+So a from-scratch node is safe with plain scalar filters and string columns, and needs these snapshots as soon as it touches a related path, a typed column, or a choice set. When you cannot produce them, keep the config to columns on the entity itself and let the canvas fill the rest in on first open.
 
 ## Filters
 
@@ -208,12 +266,12 @@ Rows at the root and each group's rows join by that level's own `logicalOperator
 
 `in` takes a comma-separated `value` and is honoured **only** when `resultMode` is `"multiple"`. There is deliberately no `not in`, `not contains`, or null check — the serializer cannot emit them. `is any of` is the legacy spelling of `in` and is still read.
 
+A filter on a choice-set column compares against the numeric `numberId`, exactly as a write does — comparing against the label matches nothing.
+
 Filter values may be literals or `=js:` expressions. Two rules the serializer enforces by refusing the **entire** query — which leaves the node with no output and breaks every downstream reference:
 
 - **A filter value cannot reference `$self`,** and cannot use a value the engine's query bracket cannot carry. A query cannot wait on the record it is being run to fetch.
 - **An expression switched on and left blank is refused,** rather than dropped. Dropping it would silently widen the read past what was written.
-
-Keep filters narrow. A `multiple` read whose filters all compile away returns an arbitrary page, not an error.
 
 ## Record selection
 
@@ -226,13 +284,21 @@ Update and Delete name one record through `recordSource`:
 
 Both selectors are validated as **non-blank after trimming**, because the serializer trims before deciding a selector is usable. A whitespace-only `recordId` is not "empty enough" to be an obvious mistake but is exactly as inert.
 
-A `fromRead` pointing at a Read that matches more than one record faults the element at runtime — that over-match throw is the safety net, so do not disable it by widening the read.
+> **An absent `recordSource` does not mean the node is inert.** The validator requires the key, but the *serializer* infers the mode from whichever selector field is populated — `readEntityNodeId` wins, otherwise a non-blank `recordId` means `byId`. So a legacy or hand-edited config carrying `{ entityName, recordId }` and no `recordSource` compiles a **real** delete or update. Never read a missing `recordSource` in an existing file as dead code; resolve it explicitly.
+
+A `fromRead` target fails **silently** in three ways, none of which any validation rule catches, because each makes the serializer emit a plain no-op task:
+
+1. `readEntityNodeId` names a node that does not exist (a typo, or a node id that changed).
+2. The named Read is `resultMode: "multiple"` — a multi-record read is refused as a write target.
+3. The named Read's filters do not all compile.
+
+And at runtime, if the read matches more than one record, the engine re-runs the query as a single-record fetch and **swallows** the resulting over-match — the write is skipped and the run goes green. (The same over-match faults an ordinary read; only the write path swallows it.) A `fromRead` target must therefore be a genuinely single-record read, verified by you rather than by the runtime.
 
 ## Folder-scoped entities and bindings
 
 A **tenant-scoped** entity needs nothing beyond `entityName`; the target serializes as `=datafabric.<EntityName>`.
 
-A **folder-scoped** entity carries `_folderKey` (the folder GUID). Its presence switches the emitted target to the folder-qualified form, and for the flow to survive export to another org the entity's name and folder must serialize as binding tokens rather than source-org literals. That requires:
+A **folder-scoped** entity carries `_folderKey` (the entity's `folderId`). Its presence switches the emitted target to the folder-qualified form, and for the flow to survive export to another org the entity's name and folder must serialize as binding tokens rather than source-org literals. That requires:
 
 1. `_resourceKey` (preferred) or `_entityKey` on the `entityConfig`, and
 2. two top-level `bindings[]` rows for that key, with `resource: "Entity"` and `propertyAttribute` of `name` and `folderKey`.
@@ -303,7 +369,7 @@ Two wiring constraints unique to these nodes:
 uip maestro flow validate <ProjectName>.flow --output json
 ```
 
-The validator enforces the "green but inert" cases specifically, because for a write they are worse than a hard failure:
+The validator enforces the "green but inert" cases it can see structurally:
 
 | Message | Means |
 | --- | --- |
@@ -314,19 +380,29 @@ The validator enforces the "green but inert" cases specifically, because for a w
 | `Select a Read entity records node` | `recordSource: "fromRead"` with no `readEntityNodeId` |
 | `Choose how to identify the record` | Delete with `recordSource` missing or not one of `byId` / `fromRead` |
 
-It does **not** check that a column name exists — that is what `uip df entities get <entity-id>` is for.
+A separate rule refuses a query whose filter value the engine cannot carry, or whose related path cannot resolve.
+
+What it does **not** check — every one of these validates clean and fails silently at runtime:
+
+- whether a column name exists, or is writable, or has the type the value implies;
+- whether the entity is native (writes) or federated (write is rejected and swallowed);
+- whether `readEntityNodeId` names a real node, or names a multi-record read;
+- whether a `byId` record id matches any record.
+
+Use `uip df entities get` and `uip df records list` to close that gap before shipping.
 
 ## Debug
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| `Node not found: core.datafabric.*` on `registry get` | Tenant flag off, or CLI predates the node | `uip tools update`, then `uip maestro flow registry pull --force`; then confirm the matching `canvas.nodes.*-entity` flag with the admin |
-| Node runs green, nothing written | An inert selector or an all-blank write body | Re-run `flow validate` — every inert case above has a message. A node that validates clean but still no-ops is a folder/binding problem, not a selector one |
-| Create runs, but `output.Id` is empty and the row was updated instead of inserted | Runtime engine older than `1.923.0` — `GetDataFabricAction()` falls back to `update` | Upgrade the engine, or turn `canvas.nodes.create-entity` off until it is upgraded |
-| Downstream `$vars.<id>.output` is `undefined` | `variables.nodes[]` missing | Run `uip maestro flow format` |
+| `Node not found: core.datafabric.*` on `registry get` | Tenant flag off, or CLI predates the node | `uip tools update`, then `uip maestro flow registry pull --force`; then confirm that node's flag with the admin (see the table above) |
+| Node validates clean, runs green, nothing written | Most often a **selector** problem, not a binding one: `readEntityNodeId` names a missing node or a multi-record read, the read's filters do not compile, or the `fromRead` read matched more than one record at runtime | Check the Read node's `id` matches exactly and its `resultMode` is `single`; confirm the filter identifies exactly one record with `uip df records list` |
+| Write runs green, row unchanged | The body was rejected and the rejection swallowed — a federated entity, a system or attachment column, a choice-set label instead of its numeric id, an uncoercible value, or a null into a non-nullable column | Re-check the entity is native and each column against `uip df entities get` |
+| Downstream `$vars.<id>.output` is `undefined` | `variables.nodes[]` missing, or the read matched nothing | Run `uip maestro flow format`; if it persists, verify the filter matches a real record |
 | A Loop over a multi-record read iterates nothing | Wired `output` instead of `output.results` | Use `=js:$vars.<readId>.output.results` |
+| Multi-record read returns only some rows | The limit is always explicit and capped at 1000 | Page with `_skip`; raising `_recordLimit` past 1000 truncates silently |
 | `404 Entity <name> does not exist` | Folder-scoped entity queried without folder qualification, or a related-field join | Set `_folderKey` and its bindings. Joins across a folder-scoped entity are not supported — the join request carries a bare name with no folder qualifier |
-| Read returns every record | Filters compiled away — a blank expression row, or an `in` row in `single` mode | Check each row against [Filters](#filters); the validator's `entityQueryExpressionRule` blocks the publishable cases |
+| Read returns every record | Filters compiled away — a blank expression row, or an `in` row in `single` mode | Check each row against [Filters](#filters) |
 | Console warning `… has no name/folderKey binding — serializing a non-portable literal` | Folder-scoped entity missing a `bindings[]` row | Add both rows — see [Folder-scoped entities and bindings](#folder-scoped-entities-and-bindings) |
 
 ## What not to do
@@ -334,9 +410,13 @@ It does **not** check that a column name exists — that is what `uip df entitie
 - **Do not hand-write `definitions[]`** — copy verbatim from `registry get`. A flag-gated node you cannot `registry get` is a node you cannot author.
 - **Do not put a `model` block on the instance.** `bpmn:Task` and the debug runtime live in the definition.
 - **Do not add an instance `outputs` block.** The canvas writes none for these nodes; the manifest `outputDefinition` plus `flow format`'s `variables.nodes[]` carry the contract.
+- **Do not wire an `error` edge or set `errorHandlingEnabled`** — these four nodes have no error port. See [No error port](#no-error-port).
+- **Do not write to a federated entity.** Create, Update and Delete require a native entity; the rejection is swallowed, so the run looks successful.
+- **Do not write a system column** (`Id`, `CreateTime`, `CreatedBy`, `UpdateTime`, `UpdatedBy`) or an attachment column.
+- **Do not put a choice-set label in a value or a filter** — use the numeric `numberId`.
 - **Do not treat `AvailableOnTenant: false` as usable** because search returned the node.
 - **Do not use a Data Fabric node in an API workflow** — all four exclude the `api-function` runtime.
 - **Do not reference `$self` in a filter value,** and do not leave a filter expression blank — either refuses the whole query and strands every downstream reference.
 - **Do not add a placeholder value to satisfy Create's "at least one value" rule.** The rule exists because a blank-only insert writes nothing; a junk value writes junk.
+- **Do not strip `_entityFields` / `_outputSchema` / `_choiceSets` from an existing node** — related paths stop resolving and typed values stop coercing, both silently.
 - **Do not point `folderPath` at the folder token** for a folder-scoped entity — use `folderKey`.
-- **Do not wire an `error` edge back into the happy path.** A failed write that reaches the success End node reports `Completed` with success-shaped outputs ([Author capability, rule 16](../../CAPABILITY.md#critical-rules)).

--- a/skills/uipath-maestro-flow/references/author/plugins/data-fabric/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/data-fabric/impl.md
@@ -7,7 +7,7 @@ Four OOTB nodes that read and write records in a UiPath Data Fabric entity: `cor
 
 That split matters when reading generated BPMN: a Read node with no `<uipath:output>` action target is correct, not a serialization failure.
 
-Shared action-node boilerplate — skeleton, ports, add/edit mechanics — is in [shared/action-nodes.md](../../../shared/action-nodes.md), with one exception noted under [No error port](#no-error-port). This file covers only what is specific to the entity nodes.
+Shared action-node boilerplate — skeleton, ports, add/edit mechanics — is in [shared/action-nodes.md](../../../shared/action-nodes.md), which these nodes diverge from in **two** ways, both recorded in its Exceptions note: they have no `error` port (see [No error port](#no-error-port)), and they carry no instance `outputs` block at all (see [JSON structure](#json-structure)). This file covers only what is specific to the entity nodes.
 
 ## Registry validation
 
@@ -182,7 +182,7 @@ At least one row must carry a non-blank `value`. A blank value is **omitted** fr
       "readEntityNodeId": "readOrder",
       "fieldUpdates": [
         { "field": "Notes", "value": "Shipped by flow" },
-        { "field": "ShippedAt", "value": "=js:new Date().toISOString()" }
+        { "field": "ShippedAt", "value": "=js:$vars.start.output.shippedAt" }
       ]
     }
   }
@@ -190,6 +190,8 @@ At least one row must carry a non-blank `value`. A blank value is **omitted** fr
 ```
 
 `readEntityNodeId` must match the Read node's `id` exactly — see [Record selection](#record-selection) for what happens when it does not.
+
+Timestamps come in as ISO 8601 strings from a variable or an upstream [Script](../script/impl.md) node, as above. Do not reach for `new Date()` in a `=js:` value — the Jint runtime's `Date` support is limited ([variables-and-expressions.md](../../../shared/variables-and-expressions.md)), and here a value the serializer cannot coerce is rejected by Data Fabric and the rejection is swallowed, so the column simply stays unchanged.
 
 ### Delete
 
@@ -219,7 +221,7 @@ Both write editors take `[{ field, value }]` rows, but what a value means differ
 | Integer / number | A clean numeric literal. `42.5` in an integer column is not coerced and is rejected |
 | Boolean | `true` or `false` |
 | **Choice set (single)** | The choice's numeric **`numberId`**, not its label — the column's SQL type is `INT` |
-| **Choice set (multi)** | A JSON array of those numeric ids |
+| **Choice set (multi)** | A JSON array of those numeric ids, as a **string**: `{ "field": "Tags", "value": "[1,2]" }`. The column is `NVARCHAR`, so the text is written through uncoerced and Data Fabric parses the array itself — not a real JSON array in the `value` slot |
 | **System columns** | Never writable — see below |
 | **Attachment columns** | Never writable |
 
@@ -306,7 +308,7 @@ A **folder-scoped** entity carries `_folderKey` (the entity's `folderId`). Its p
 ```json
 "bindings": [
   {
-    "id": "<bindingId1>",
+    "id": "bOrdersEntityName",
     "name": "Orders",
     "type": "string",
     "resource": "Entity",
@@ -315,7 +317,7 @@ A **folder-scoped** entity carries `_folderKey` (the entity's `folderId`). Its p
     "propertyAttribute": "name"
   },
   {
-    "id": "<bindingId2>",
+    "id": "bOrdersEntityFolder",
     "name": "OrdersFolder",
     "type": "string",
     "resource": "Entity",
@@ -326,12 +328,14 @@ A **folder-scoped** entity carries `_folderKey` (the entity's `folderId`). Its p
 ]
 ```
 
-Field-by-field, because three of these are easy to get wrong:
+**Where `_resourceKey` comes from.** It is the key the entity's reference is registered under in the solution, written by the canvas entity picker when it registers the entity (`_entityKey`, the Data Fabric entity id from `uip df entities list`, is the older fallback and is only used when `_resourceKey` is absent). A registered entity reference surfaces under `uip solution resources list --kind Entity --output json`, but there is no CLI that mints one for a flow you are hand-authoring. **If you cannot resolve a `_resourceKey`, do not hand-author the folder-scoped form** — keep the entity tenant-scoped, or add the node and let the picker write `_folderKey`, `_resourceKey` and both binding rows on first open. A half-authored folder scope is worse than none: it serializes, and it breaks on deploy.
 
-- **The value lives in `default`, never in `name`.** `name` is a display label: the entity-name row uses the entity name for both, but the folder row's `name` is the literal convention `<entityName>Folder` while its `default` carries the folder GUID.
-- **`type` is `"string"` and is required** — the binding schema rejects a row without it.
+Field-by-field, because four of these differ from the Orchestrator-resource bindings documented in [file-format.md — Bindings](../../../shared/file-format.md#bindings--orchestrator-resource-bindings-top-level-bindings). That section's rules describe resource nodes; the `Entity` kind resolves differently, and the differences are tabulated in [file-format.md — Data Fabric entity bindings](../../../shared/file-format.md#data-fabric-entity-bindings):
+
+- **The value lives in `default`, never in `name`.** For a resource node `name` is the placeholder name (`name` / `folderPath`); for an entity it is a **display label** — the entity name, and `<entityName>Folder` for the folder row.
+- **`propertyAttribute` is what the serializer matches on**, not `name`. Entity bindings resolve by `(resourceKey, propertyAttribute)`, not the `(resourceKey, name)` rule resource nodes use, and there is no `<bindings.{name}>` placeholder to rewrite — the token is emitted straight into the `=datafabric[...]` expression.
 - **`resource` must be the capitalized `"Entity"`.** The BPMN engine matches it case-insensitively, but packaging requires the capital form; a lowercase row never becomes a binding resource, so the deploy side gets no override at all.
-- **`propertyAttribute` is what the serializer matches on**, not `name`.
+- **`type` is `"string"` and is required** — the binding schema rejects a row without it. There is no `resourceSubType`: an entity has no definition-side `model.bindings` to mirror.
 
 The folder token must come from the **`folderKey`** attribute, not `folderPath`: the platform's deploy-time override rewrites `folderPath` with the Orchestrator FQN, which breaks the query even in the source org.
 
@@ -386,6 +390,7 @@ What it does **not** check — every one of these validates clean and fails sile
 
 - whether a column name exists, or is writable, or has the type the value implies;
 - whether the entity is native (writes) or federated (write is rejected and swallowed);
+- whether an **Update** names a `recordSource` — only Delete's is in the required list, so an Update without one validates clean and the serializer infers the mode from whichever selector is populated;
 - whether `readEntityNodeId` names a real node, or names a multi-record read;
 - whether a `byId` record id matches any record.
 

--- a/skills/uipath-maestro-flow/references/author/plugins/data-fabric/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/data-fabric/impl.md
@@ -1,0 +1,317 @@
+# Data Fabric Entity Nodes — Implementation
+
+Four OOTB nodes that read and write records in a UiPath Data Fabric entity: `core.datafabric.read`, `core.datafabric.create`, `core.datafabric.update`, `core.datafabric.delete`. Each is a `bpmn:Task` host — the serializer attaches a `<uipath:output>` carrying a `=datafabric...` target, and the BPMN engine's activity postprocessor performs the query or write after the task runs. There is no Integration Service connection and no connector binding.
+
+Shared action-node boilerplate — skeleton, ports, error port, add/edit mechanics — is in [shared/action-nodes.md](../../../shared/action-nodes.md). This file covers only what is specific to the entity nodes.
+
+## Registry validation
+
+Run `registry get` for each node type you intend to use:
+
+```bash
+uip maestro flow registry get core.datafabric.read --output json
+uip maestro flow registry get core.datafabric.create --output json
+uip maestro flow registry get core.datafabric.update --output json
+uip maestro flow registry get core.datafabric.delete --output json
+```
+
+Confirm on `Data.Node`:
+
+- `handleConfiguration` — input port `input`, output port `output`. All four share this shape.
+- `model.type` — `bpmn:Task` (**not** `bpmn:ServiceTask`; these nodes carry no `serviceType`).
+- `inputDefinition.properties.entityConfig` — the single input container.
+- `outputDefinition.output.source` — `=response`, with `type: "jsonSchema"`. **Delete has no `outputDefinition` at all** — that absence is the contract, not an omission.
+- `runtimeConstraints.exclude` — contains `api-function`.
+- `version` — copy it verbatim into the instance's `typeVersion`. Read and Create are ahead of Update and Delete; do not assume one version across the family.
+
+If `registry get` reports **"Node not found"**, the node is not available to you. Run `uip tools update`, then `uip maestro flow registry pull --force`, and retry. If it still fails, the tenant feature flag is off — `canvas.nodes.read-entity`, `canvas.nodes.update-entity`, `canvas.nodes.delete-entity`, or `canvas.nodes.create-entity` respectively. Confirm with the UiPath admin.
+
+`registry search` is not a substitute for `registry get` here. A flag-gated node can still appear in search with `AvailableOnTenant: false` while `registry get` refuses it — and without `registry get` you cannot source the `definitions[]` entry, which must never be hand-written ([Author capability, rule 6](../../CAPABILITY.md#critical-rules)). Treat `AvailableOnTenant: false` as unavailable and stop.
+
+## Add or edit the node
+
+These are OOTB nodes and therefore **user-owned**: author them with `Edit` / `Write` directly against the `.flow` file. `inputs.entityConfig` is a plain JSON object, not a `=jsonString:` envelope, so none of the CLI-owned node rules apply. See [Author capability — Node ownership](../../CAPABILITY.md#node-ownership--who-authors-the-node) and [editing-operations.md](../../editing-operations.md).
+
+Every node type still needs its `definitions[]` entry copied verbatim from `registry get`.
+
+## Resolving the entity and its columns
+
+Entity and column names are **case-sensitive**, and an unmatched column is silently dropped rather than rejected — a wrong name yields a node that validates green and writes nothing. Resolve both from the tenant before authoring:
+
+```bash
+uip df entities list --output json
+uip df entities get <entity-id> --output json
+```
+
+`entities list` gives the entity `Name` (what `entityName` takes) and its id; `entities get` gives the exact column names for `_filters`, `fieldValues`, `fieldUpdates`, and `_selectedFieldNames`.
+
+When a step needs a real record id or a sample row — for a `byId` selector, or to sanity-check a filter — read one rather than inventing it:
+
+```bash
+uip df records list <entity-id> --output json
+uip df records query <entity-id> --body '{"filterGroup":{...}}' --output json
+```
+
+An invented id or column matches no record: every lookup returns empty and the run faults on empty data.
+
+## JSON structure
+
+Node instances carry `inputs` only. Do **not** hand-write an `outputs` block, a `model` block, or a `ui` block — `flow format` owns layout, the definition owns the BPMN model, and the manifest's `outputDefinition` plus the `variables.nodes[]` entry that `flow format` regenerates own the output contract ([Author capability, rules 13–15](../../CAPABILITY.md#critical-rules)).
+
+### Read — single record
+
+```json
+{
+  "id": "readOrder",
+  "type": "core.datafabric.read",
+  "typeVersion": "<from registry get>",
+  "display": { "label": "Read order" },
+  "inputs": {
+    "entityConfig": {
+      "entityName": "Orders",
+      "resultMode": "single",
+      "_filters": {
+        "logicalOperator": "AND",
+        "rows": [
+          { "field": "OrderNumber", "operator": "=", "value": "=js:$vars.start.output.orderNumber" }
+        ],
+        "groups": []
+      }
+    }
+  }
+}
+```
+
+### Read — multiple records
+
+```json
+{
+  "id": "listOpenOrders",
+  "type": "core.datafabric.read",
+  "typeVersion": "<from registry get>",
+  "display": { "label": "List open orders" },
+  "inputs": {
+    "entityConfig": {
+      "entityName": "Orders",
+      "resultMode": "multiple",
+      "_recordLimit": 100,
+      "_skip": 0,
+      "_sort": { "field": "CreatedAt", "direction": "desc" },
+      "_selectedFieldNames": ["Id", "OrderNumber", "Status"],
+      "_filters": {
+        "logicalOperator": "AND",
+        "rows": [{ "field": "Status", "operator": "=", "value": "Open" }],
+        "groups": []
+      }
+    }
+  }
+}
+```
+
+The rows land at `$vars.listOpenOrders.output.results`, not `$vars.listOpenOrders.output`.
+
+Write `_recordLimit` explicitly, as the canvas does. Omitting it does not mean "no cap" — the engine applies its own default, which differs by the entity's composite shape, so the row count silently depends on the entity rather than on the flow. A `_sort` matters for the same reason: a limit without an order returns an arbitrary slice.
+
+### Create
+
+```json
+{
+  "id": "createOrder",
+  "type": "core.datafabric.create",
+  "typeVersion": "<from registry get>",
+  "display": { "label": "Create order" },
+  "inputs": {
+    "entityConfig": {
+      "entityName": "Orders",
+      "fieldValues": [
+        { "field": "OrderNumber", "value": "=js:$vars.start.output.orderNumber" },
+        { "field": "Status", "value": "Open" }
+      ]
+    }
+  }
+}
+```
+
+At least one row must carry a non-blank `value`. A blank value is **omitted** from the insert so the column default applies — so an all-blank `fieldValues` serializes to an empty body, emits no output, and runs green having inserted nothing. The validator rejects that case; do not work around it by adding a placeholder value.
+
+### Update
+
+```json
+{
+  "id": "markShipped",
+  "type": "core.datafabric.update",
+  "typeVersion": "<from registry get>",
+  "display": { "label": "Mark shipped" },
+  "inputs": {
+    "entityConfig": {
+      "entityName": "Orders",
+      "recordSource": "fromRead",
+      "readEntityNodeId": "readOrder",
+      "fieldUpdates": [
+        { "field": "Status", "value": "Shipped" },
+        { "field": "ShippedAt", "value": "=js:new Date().toISOString()" }
+      ]
+    }
+  }
+}
+```
+
+An empty `value` in `fieldUpdates` is a **real write** that clears the column — unlike Create, it is never treated as "leave unset".
+
+### Delete
+
+```json
+{
+  "id": "removeDraft",
+  "type": "core.datafabric.delete",
+  "typeVersion": "<from registry get>",
+  "display": { "label": "Remove draft" },
+  "inputs": {
+    "entityConfig": {
+      "entityName": "Orders",
+      "recordSource": "byId",
+      "recordId": "=js:$vars.start.output.orderId"
+    }
+  }
+}
+```
+
+`recordSource` is **required** on Delete (unlike Update, which tolerates its absence on legacy configs). Without it both selector guards go inert, the serializer resolves no record, and a destructive node publishes and runs green having deleted nothing.
+
+## Filters
+
+`_filters` uses a grouped query model:
+
+```json
+{
+  "logicalOperator": "AND",
+  "rows": [{ "field": "Status", "operator": "=", "value": "Open" }],
+  "groups": [
+    {
+      "logicalOperator": "OR",
+      "rows": [
+        { "field": "Priority", "operator": "=", "value": "High" },
+        { "field": "Amount", "operator": ">", "value": "1000" }
+      ]
+    }
+  ]
+}
+```
+
+Rows at the root and each group's rows join by that level's own `logicalOperator`. A bare array of rows is the legacy form and is still read, but author the grouped object.
+
+**Supported operators**, exactly as spelled in the file:
+
+`=` · `!=` · `>` · `>=` · `<` · `<=` · `contains` · `starts with` · `ends with` · `in`
+
+`in` takes a comma-separated `value` and is honoured **only** when `resultMode` is `"multiple"`. There is deliberately no `not in`, `not contains`, or null check — the serializer cannot emit them. `is any of` is the legacy spelling of `in` and is still read.
+
+Filter values may be literals or `=js:` expressions. Two rules the serializer enforces by refusing the **entire** query — which leaves the node with no output and breaks every downstream reference:
+
+- **A filter value cannot reference `$self`,** and cannot use a value the engine's query bracket cannot carry. A query cannot wait on the record it is being run to fetch.
+- **An expression switched on and left blank is refused,** rather than dropped. Dropping it would silently widen the read past what was written.
+
+Keep filters narrow. A `multiple` read whose filters all compile away returns an arbitrary page, not an error.
+
+## Record selection
+
+Update and Delete name one record through `recordSource`:
+
+| `recordSource` | Required key | Resolves to |
+| --- | --- | --- |
+| `"byId"` | `recordId` | The record with that `Id`. A literal, or a `=js:` reference such as `=js:$vars.createOrder.output.Id` |
+| `"fromRead"` | `readEntityNodeId` | The record the named Read node's query identifies — the query is recompiled, with `Id` forced into the selected fields |
+
+Both selectors are validated as **non-blank after trimming**, because the serializer trims before deciding a selector is usable. A whitespace-only `recordId` is not "empty enough" to be an obvious mistake but is exactly as inert.
+
+A `fromRead` pointing at a Read that matches more than one record faults the element at runtime — that over-match throw is the safety net, so do not disable it by widening the read.
+
+## Folder-scoped entities and bindings
+
+A **tenant-scoped** entity needs nothing beyond `entityName`; the target serializes as `=datafabric.<EntityName>`.
+
+A **folder-scoped** entity carries `_folderKey` (the folder GUID). Its presence switches the emitted target to the folder-qualified form, and for the flow to survive export to another org the entity's name and folder must serialize as binding tokens rather than source-org literals. That requires:
+
+1. `_resourceKey` (preferred) or `_entityKey` on the `entityConfig`, and
+2. two top-level `bindings[]` rows for that key, with `resource: "Entity"` and `propertyAttribute` of `name` and `folderKey`.
+
+```json
+"bindings": [
+  { "id": "<bindingId1>", "resource": "Entity", "resourceKey": "<resourceKey>", "propertyAttribute": "name",      "name": "Orders" },
+  { "id": "<bindingId2>", "resource": "Entity", "resourceKey": "<resourceKey>", "propertyAttribute": "folderKey", "name": "<folder GUID>" }
+]
+```
+
+The folder token must come from the **`folderKey`** attribute, not `folderPath`: the platform's deploy-time override rewrites `folderPath` with the Orchestrator FQN, which breaks the query even in the source org.
+
+When `_folderKey` is set but a binding is missing, serialization still succeeds — it falls back to a source-org literal and logs a warning. That partial state (name token + literal folder GUID) looks portable and breaks on cross-org deploy, so treat the warning as a defect rather than noise.
+
+The entity picker writes these bindings automatically. When hand-authoring a folder-scoped entity, add them yourself or leave the entity tenant-scoped.
+
+## Output wiring
+
+Reference the output through `=js:$vars.<nodeId>.output` per the canonical rule ([node-output-wiring.md](../../../shared/node-output-wiring.md)):
+
+```json
+{
+  "id": "end",
+  "type": "core.control.end",
+  "typeVersion": "<from registry get>",
+  "outputs": {
+    "status":   { "source": "=js:$vars.readOrder.output.Status" },
+    "orderId":  { "source": "=js:$vars.createOrder.output.Id" },
+    "openRows": { "source": "=js:$vars.listOpenOrders.output.results" }
+  }
+}
+```
+
+Run `uip maestro flow format <ProjectName>.flow` after adding nodes. Format regenerates `variables.nodes[]`, which is what makes `$vars.<nodeId>.output` resolve at runtime; skipping it produces a flow that validates but resolves the reference to `undefined` ([Author capability, rule 14](../../CAPABILITY.md#critical-rules)).
+
+Two wiring constraints unique to these nodes:
+
+- **Delete produces nothing.** There is no `$vars.<deleteNodeId>.output`.
+- **An Update node's output cannot feed a collection.** Each downstream reference is rewritten into its own re-read of the written record; [Loop](../loop/impl.md) and data-transform collections are excluded from that rewriting and have no snapshot to fall back on. Wire the Read node's output into the collection instead.
+
+## Validate
+
+```bash
+uip maestro flow validate <ProjectName>.flow --output json
+```
+
+The validator enforces the "green but inert" cases specifically, because for a write they are worse than a hard failure:
+
+| Message | Means |
+| --- | --- |
+| `An entity must be selected` | `entityName` missing or empty |
+| `Set a value for at least one field` | Create's `fieldValues` has no row with a non-blank value |
+| `Select a field to update` | Update's `fieldUpdates` has no row naming a field |
+| `A record ID is required` | `recordSource: "byId"` with a blank or whitespace-only `recordId` |
+| `Select a Read entity records node` | `recordSource: "fromRead"` with no `readEntityNodeId` |
+| `Choose how to identify the record` | Delete with `recordSource` missing or not one of `byId` / `fromRead` |
+
+It does **not** check that a column name exists — that is what `uip df entities get <entity-id>` is for.
+
+## Debug
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Node not found: core.datafabric.*` on `registry get` | Tenant flag off, or CLI predates the node | `uip tools update`, then `uip maestro flow registry pull --force`; then confirm the matching `canvas.nodes.*-entity` flag with the admin |
+| Node runs green, nothing written | An inert selector or an all-blank write body | Re-run `flow validate` — every inert case above has a message. A node that validates clean but still no-ops is a folder/binding problem, not a selector one |
+| Create runs, but `output.Id` is empty and the row was updated instead of inserted | Runtime engine older than `1.923.0` — `GetDataFabricAction()` falls back to `update` | Upgrade the engine, or turn `canvas.nodes.create-entity` off until it is upgraded |
+| Downstream `$vars.<id>.output` is `undefined` | `variables.nodes[]` missing | Run `uip maestro flow format` |
+| A Loop over a multi-record read iterates nothing | Wired `output` instead of `output.results` | Use `=js:$vars.<readId>.output.results` |
+| `404 Entity <name> does not exist` | Folder-scoped entity queried without folder qualification, or a related-field join | Set `_folderKey` and its bindings. Joins across a folder-scoped entity are not supported — the join request carries a bare name with no folder qualifier |
+| Read returns every record | Filters compiled away — a blank expression row, or an `in` row in `single` mode | Check each row against [Filters](#filters); the validator's `entityQueryExpressionRule` blocks the publishable cases |
+| Console warning `… has no name/folderKey binding — serializing a non-portable literal` | Folder-scoped entity missing a `bindings[]` row | Add both rows — see [Folder-scoped entities and bindings](#folder-scoped-entities-and-bindings) |
+
+## What not to do
+
+- **Do not hand-write `definitions[]`** — copy verbatim from `registry get`. A flag-gated node you cannot `registry get` is a node you cannot author.
+- **Do not put a `model` block on the instance.** `bpmn:Task` and the debug runtime live in the definition.
+- **Do not add an instance `outputs` block.** The canvas writes none for these nodes; the manifest `outputDefinition` plus `flow format`'s `variables.nodes[]` carry the contract.
+- **Do not treat `AvailableOnTenant: false` as usable** because search returned the node.
+- **Do not use a Data Fabric node in an API workflow** — all four exclude the `api-function` runtime.
+- **Do not reference `$self` in a filter value,** and do not leave a filter expression blank — either refuses the whole query and strands every downstream reference.
+- **Do not add a placeholder value to satisfy Create's "at least one value" rule.** The rule exists because a blank-only insert writes nothing; a junk value writes junk.
+- **Do not point `folderPath` at the folder token** for a folder-scoped entity — use `folderKey`.
+- **Do not wire an `error` edge back into the happy path.** A failed write that reaches the success End node reports `Completed` with success-shaped outputs ([Author capability, rule 16](../../CAPABILITY.md#critical-rules)).

--- a/skills/uipath-maestro-flow/references/author/plugins/data-fabric/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/data-fabric/impl.md
@@ -330,14 +330,12 @@ A **folder-scoped** entity carries `_folderKey` (the entity's `folderId`). Its p
 
 **Where `_resourceKey` comes from.** It is the key the entity's reference is registered under in the solution, written by the canvas entity picker when it registers the entity (`_entityKey`, the Data Fabric entity id from `uip df entities list`, is the older fallback and is only used when `_resourceKey` is absent). A registered entity reference surfaces under `uip solution resources list --kind Entity --output json`, but there is no CLI that mints one for a flow you are hand-authoring. **If you cannot resolve a `_resourceKey`, do not hand-author the folder-scoped form** — keep the entity tenant-scoped, or add the node and let the picker write `_folderKey`, `_resourceKey` and both binding rows on first open. A half-authored folder scope is worse than none: it serializes, and it breaks on deploy.
 
-Field-by-field, because four of these differ from the Orchestrator-resource bindings documented in [file-format.md — Bindings](../../../shared/file-format.md#bindings--orchestrator-resource-bindings-top-level-bindings). That section's rules describe resource nodes; the `Entity` kind resolves differently, and the differences are tabulated in [file-format.md — Data Fabric entity bindings](../../../shared/file-format.md#data-fabric-entity-bindings):
+Two values are easy to get wrong, and both are things you type by hand:
 
-- **The value lives in `default`, never in `name`.** For a resource node `name` is the placeholder name (`name` / `folderPath`); for an entity it is a **display label** — the entity name, and `<entityName>Folder` for the folder row.
-- **`propertyAttribute` is what the serializer matches on**, not `name`. Entity bindings resolve by `(resourceKey, propertyAttribute)`, not the `(resourceKey, name)` rule resource nodes use, and there is no `<bindings.{name}>` placeholder to rewrite — the token is emitted straight into the `=datafabric[...]` expression.
-- **`resource` must be the capitalized `"Entity"`.** The BPMN engine matches it case-insensitively, but packaging requires the capital form; a lowercase row never becomes a binding resource, so the deploy side gets no override at all.
-- **`type` is `"string"` and is required** — the binding schema rejects a row without it. There is no `resourceSubType`: an entity has no definition-side `model.bindings` to mirror.
+- **`resource` is the capitalized `"Entity"`.** The BPMN engine matches case-insensitively, but packaging requires the capital form; a lowercase row never becomes a binding resource, so the deploy side gets no override at all.
+- **`propertyAttribute` is `name` and `folderKey`** — never `folderPath`, and it is what the serializer matches on rather than the row's `name`.
 
-The folder token must come from the **`folderKey`** attribute, not `folderPath`: the platform's deploy-time override rewrites `folderPath` with the Orchestrator FQN, which breaks the query even in the source org.
+Entity bindings differ from the Orchestrator-resource form in several other ways — what `name` holds, the matching key, the absent `resourceSubType`. Those are tabulated once in [file-format.md — Bindings — Data Fabric entity bindings](../../../shared/file-format.md#bindings--data-fabric-entity-bindings); read it before hand-authoring a pair.
 
 When `_folderKey` is set but a binding is missing, serialization still succeeds — it falls back to a source-org literal and logs a warning. That partial state (name token + literal folder GUID) looks portable and breaks on cross-org deploy, so treat the warning as a defect rather than noise.
 

--- a/skills/uipath-maestro-flow/references/author/plugins/data-fabric/planning.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/data-fabric/planning.md
@@ -51,16 +51,20 @@ Use these nodes when the record lives in **Data Fabric** and the flow itself is 
 | Bulk-load a CSV into an entity | No — that is a data-loading job, not a flow step; use `uip df records import` out of band |
 | Read a record from a non-UiPath system | No — use [connector](../connector/planning.md) or [http](../http/planning.md) |
 
-### Native node vs Data Service connector — pick the native node
+### Native node vs Data Service connector — availability decides
 
-The `uipath-uipath-dataservice` Integration Service connector also exposes entity operations (`QueryEntityRecordsCurated`, `CreateEntityRecordCurated`, …), and `registry search` surfaces both. **Prefer the native `core.datafabric.*` node**, because it:
+The `uipath-uipath-dataservice` Integration Service connector also exposes entity operations (`query-entity-records`, `create-entity-record`, `update-entity-record`, `get-entity-record-by-id`, `delete-entity-record`, …), and `registry search` surfaces both families.
+
+**Check availability before you choose — do not default to the native node.** All four tenant flags default to off, so on a tenant that has not enabled them the connector activities are the only working path. Run `uip maestro flow registry get core.datafabric.<op>` for the operation you need: if it answers "Node not found", or search reports `AvailableOnTenant: false`, build with the [connector](../connector/planning.md) and stop pursuing the native node. Use the connector too when the entity is federated, since the native writes require a native entity.
+
+Where the tenant *does* have them, the native node is the better build, because it:
 
 - needs **no Integration Service connection** — nothing to create, bind, or keep healthy, and no `bindings[]` connection row;
 - is **user-owned** — author it with `Edit`/`Write` instead of the CLI's `node add` + `node configure` envelope (see [Author capability — Node ownership](../../CAPABILITY.md#node-ownership--who-authors-the-node));
 - gives downstream expressions the **record shape** (`$vars.readOrder1.output.Status`) with autocomplete, because the picked entity's schema is merged into the node's output definition;
 - carries **portable entity bindings**, so a folder-scoped entity survives export to another org.
 
-Choose the connector when the native node is unavailable (flag off), when the entity is federated, or when you need an operation the native nodes do not cover. Record that choice in **Open Questions** rather than making it silently.
+Whichever way the check sends you, record it in **Open Questions** rather than leaving the reader to guess why the flow took that path.
 
 ### Anti-Patterns
 

--- a/skills/uipath-maestro-flow/references/author/plugins/data-fabric/planning.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/data-fabric/planning.md
@@ -1,0 +1,170 @@
+# Data Fabric Entity Nodes — Planning
+
+The Data Fabric entity nodes read and write **records inside a UiPath Data Fabric entity** natively — no Integration Service connection, no HTTP call. They live in the **Data Fabric** section of the add-node panel. Four nodes cover the CRUD surface, and they share one entity picker, one filter grammar, and one `inputs.entityConfig` container.
+
+Use them whenever the flow's own data lives in Data Fabric: a case record, a lookup table, a status the flow advances, an audit row the flow appends.
+
+## Node Types
+
+| Node Type | Canvas label | Does |
+| --- | --- | --- |
+| `core.datafabric.read` | Read entity records | Read one record, or a filtered list of records |
+| `core.datafabric.create` | Create entity record | Insert one record and return the stored row |
+| `core.datafabric.update` | Update entity record | Patch named columns on one record |
+| `core.datafabric.delete` | Delete entity record | Delete one record (no output) |
+
+These are fixed OOTB node types — no registry suffix, no connector key. Each is gated by its own tenant feature flag, so a tenant can have Read without Create:
+
+| Node Type | Tenant flag |
+| --- | --- |
+| `core.datafabric.read` | `canvas.nodes.read-entity` |
+| `core.datafabric.update` | `canvas.nodes.update-entity` |
+| `core.datafabric.delete` | `canvas.nodes.delete-entity` |
+| `core.datafabric.create` | `canvas.nodes.create-entity` |
+
+A node whose flag is off is filtered out of the manifest entirely: `registry search` may still list it with `AvailableOnTenant: false`, but `registry get` answers **"Node not found"** and you cannot source its `definitions[]` entry. Confirm availability before planning around one — see [impl.md — Registry validation](impl.md#registry-validation).
+
+`canvas.nodes.create-entity` additionally requires a runtime engine `>= 1.923.0`. On an older engine the insert silently becomes a PATCH, so treat a Create node on an unverified engine as an **Open Questions** item rather than a built step.
+
+## When to Use
+
+Use these nodes when the record lives in **Data Fabric** and the flow itself is the thing reading or writing it.
+
+### Selection Heuristics
+
+| Situation | Use a Data Fabric entity node? |
+| --- | --- |
+| Look up a record by key to drive a decision or fill a downstream input | Yes — Read, `resultMode: "single"` |
+| Fetch a filtered set of rows to iterate over | Yes — Read, `resultMode: "multiple"`, then [Loop](../loop/planning.md) |
+| Advance a status, stamp a result, write back an outcome | Yes — Update |
+| Append a new row (case, audit entry, request) | Yes — Create |
+| Remove a row the flow has finished with | Yes — Delete |
+| React to a record being created/updated **elsewhere** | No — that is a trigger; use [connector-trigger](../connector-trigger/planning.md) (`uipath.connector.trigger.uipath-uipath-dataservice.record-created` / `record-updated`) |
+| Aggregate, group, or reshape rows already in memory | No — use [Transform](../transform/planning.md) |
+| Bulk-load a CSV into an entity | No — that is a data-loading job, not a flow step; use `uip df records import` out of band |
+| Read a record from a non-UiPath system | No — use [connector](../connector/planning.md) or [http](../http/planning.md) |
+
+### Native node vs Data Service connector — pick the native node
+
+The `uipath-uipath-dataservice` Integration Service connector also exposes entity operations (`QueryEntityRecordsCurated`, `CreateEntityRecordCurated`, …), and `registry search` surfaces both. **Prefer the native `core.datafabric.*` node**, because it:
+
+- needs **no Integration Service connection** — nothing to create, bind, or keep healthy, and no `bindings[]` connection row;
+- is **user-owned** — author it with `Edit`/`Write` instead of the CLI's `node add` + `node configure` envelope (see [Author capability — Node ownership](../../CAPABILITY.md#node-ownership--who-authors-the-node));
+- gives downstream expressions the **record shape** (`$vars.readOrder1.output.Status`) with autocomplete, because the picked entity's schema is merged into the node's output definition;
+- carries **portable entity bindings**, so a folder-scoped entity survives export to another org.
+
+Choose the connector only when the native node is unavailable (flag off) and the work cannot wait, or when you need an operation the native nodes do not cover. Record that choice in **Open Questions** rather than making it silently.
+
+### Anti-Patterns
+
+- **Do not use Delete to "clear" a field.** Delete removes the whole record. To blank a column, use Update with an empty `value` — an empty update value writes `null` deliberately.
+- **Do not chain Read → Update by re-typing the record id.** Use `recordSource: "fromRead"` and point at the Read node; it reuses that node's query, so the two can never drift apart.
+- **Do not read a whole entity to find one row.** Push the constraint into `_filters` — a `resultMode: "multiple"` read with no filter returns an arbitrary page, not "everything".
+- **Do not use these nodes inside an API workflow runtime.** All four declare `runtimeConstraints.exclude: ["api-function"]`; the write/read is dispatched by the BPMN engine's element postprocessor, which no other runtime implements.
+- **Do not feed an Update node's output into a [Loop](../loop/planning.md) collection or a [Transform](../transform/planning.md).** That output is re-read per consumer, and collection consumers are excluded from the rewriting — see [Output Variables](#output-variables).
+
+## Ports
+
+| Node Type | Input | Output(s) |
+| --- | --- | --- |
+| `core.datafabric.read` | `input` | `output` |
+| `core.datafabric.create` | `input` | `output` |
+| `core.datafabric.update` | `input` | `output` |
+| `core.datafabric.delete` | `input` | `output` |
+
+`error` is the implicit source port every action node has, off by default. Wire it only when the requirements state what a failed read or write should do — otherwise let the node fault the flow ([Author capability, rule 16](../../CAPABILITY.md#critical-rules)).
+
+Delete's `output` port exists for **sequencing only** — it carries no data (see below).
+
+## Output Variables
+
+| Node Type | `$vars.{nodeId}.output` |
+| --- | --- |
+| `core.datafabric.read` (`single`) | The record itself — address columns directly: `$vars.readOrder1.output.Status` |
+| `core.datafabric.read` (`multiple`) | `{ results: [...] }` — the rows are under `output.results`, never `output` itself |
+| `core.datafabric.create` | The **stored** record, including the generated `Id` and server-applied defaults |
+| `core.datafabric.update` | The record **after** the write |
+| `core.datafabric.delete` | Nothing — the node declares no output definition |
+
+Three consequences worth planning around:
+
+- **A multi-record read is not an array.** `=js:$vars.listOrders1.output` is an object; the collection is `=js:$vars.listOrders1.output.results`. Wiring the former into a Loop iterates nothing.
+- **Create's `Id` is real, but only on a new enough engine.** `$vars.createOrder1.output.Id` is the generated key on engine `>= 1.923.0`. Below that floor the node did not insert at all.
+- **Update's output is a re-read, not the write's response.** The engine discards the write response; the serializer rewrites each downstream `$vars.<updateId>.output` reference into its own query for the record just written. That is why it cannot be consumed as a Loop or Transform collection — those are excluded from the rewriting and have no snapshot to fall back on.
+
+Delete has no output at all, so plan any post-delete signalling (a count, a status) as a separate [Script](../script/planning.md) or End-node mapping.
+
+## Key Inputs
+
+Every node takes exactly one input object, `inputs.entityConfig`. Its contents differ per node.
+
+### Shared by all four
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `entityName` | Yes | The Data Fabric entity's name. Resolve it with `uip df entities list --output json` — never invent it |
+| `_folderKey` | Folder-scoped entities only | Folder GUID. Its presence switches the emitted target to the folder-qualified form and makes `bindings[]` entries necessary for portability — see [impl.md — Folder-scoped entities](impl.md#folder-scoped-entities-and-bindings) |
+| `_resourceKey` / `_entityKey` | With `_folderKey` | Key the entity's `bindings[]` rows are scoped to |
+
+### `core.datafabric.read`
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `resultMode` | No | `"single"` (default) or `"multiple"` |
+| `_filters` | No | The query. Grouped filter model — see [impl.md — Filters](impl.md#filters) |
+| `_selectedFieldNames` | No | Columns to return. Omit for all |
+| `_recordLimit` | `multiple` only | Row cap, clamped 1–1000. **Always write it explicitly** — the canvas does (100), and omitting it hands the row count to the engine's own default, which varies by the entity's shape |
+| `_skip` | `multiple` only | Rows to pass over first |
+| `_sort` | `multiple` only | `{ field, direction: "asc" \| "desc" }`. A limit without an order returns arbitrary rows |
+
+### `core.datafabric.create`
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `fieldValues` | Yes | `[{ field, value }]`. **At least one row must carry a non-blank `value`** — blank values are omitted so the column default applies, so an all-blank config inserts nothing and still runs green |
+
+### `core.datafabric.update`
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `recordSource` | Yes in practice | `"byId"` or `"fromRead"` — how the target record is identified |
+| `recordId` | `byId` | The record's `Id` — a literal or a `=js:` reference |
+| `readEntityNodeId` | `fromRead` | The upstream Read node whose query identifies the record |
+| `fieldUpdates` | Yes | `[{ field, value }]`. An **empty `value` is a real write** — it clears the column |
+
+### `core.datafabric.delete`
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `recordSource` | Yes | `"byId"` or `"fromRead"`. Required — without it the node publishes green and deletes nothing |
+| `recordId` | `byId` | The record's `Id` |
+| `readEntityNodeId` | `fromRead` | The upstream Read node identifying the record |
+
+## Record selection — `byId` vs `fromRead`
+
+Update and Delete both need to name exactly one record, and offer the same two ways:
+
+| Mode | Use when | Cost of getting it wrong |
+| --- | --- | --- |
+| `byId` | The id is already in hand — a trigger payload, a Create node's `output.Id`, a flow input | A blank or whitespace-only id resolves to nothing; the node runs green having written nothing |
+| `fromRead` | An upstream Read already located the record by business key | Pointing at a Read that matches more than one record faults the element |
+
+Prefer `fromRead` when a Read node is already there — it reuses that node's compiled query, so a later change to the filter automatically follows through to the write.
+
+## Common Pattern — read, branch, write back
+
+```text
+Trigger -> Read entity records (single, filter by business key)
+        -> Decision (on a column)
+             -> true:  Update entity record (fromRead) -> End
+             -> false: Create entity record            -> End
+```
+
+## Planning Annotation
+
+In the architectural plan:
+
+- `datafabric: <verb> <EntityName> — <one-line purpose>`, naming the entity and, for a read, whether it is single or multiple.
+- Name the **selector** for every Update and Delete (`byId` from `<source>`, or `fromRead` from `<readNodeId>`). An unnamed selector is the single most common way these nodes ship silently doing nothing.
+- Put the entity in **Open Questions** when the requirements name a business concept ("the order", "the case") but no entity is confirmed by `uip df entities list`. Do not guess an entity or column name — they are case-sensitive and unmatched names are dropped rather than rejected.
+- Flag any Create node in **Open Questions** when the target engine version is unknown.

--- a/skills/uipath-maestro-flow/references/author/plugins/data-fabric/planning.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/data-fabric/planning.md
@@ -18,13 +18,19 @@ These are fixed OOTB node types — no registry suffix, no connector key. Each i
 | Node Type | Tenant flag |
 | --- | --- |
 | `core.datafabric.read` | `canvas.nodes.read-entity` |
+| `core.datafabric.create` | `canvas.nodes.create-entity` |
 | `core.datafabric.update` | `canvas.nodes.update-entity` |
 | `core.datafabric.delete` | `canvas.nodes.delete-entity` |
-| `core.datafabric.create` | `canvas.nodes.create-entity` |
 
 A node whose flag is off is filtered out of the manifest entirely: `registry search` may still list it with `AvailableOnTenant: false`, but `registry get` answers **"Node not found"** and you cannot source its `definitions[]` entry. Confirm availability before planning around one — see [impl.md — Registry validation](impl.md#registry-validation).
 
-`canvas.nodes.create-entity` additionally requires a runtime engine `>= 1.923.0`. On an older engine the insert silently becomes a PATCH, so treat a Create node on an unverified engine as an **Open Questions** item rather than a built step.
+## Writes require a native entity
+
+Create, Update and Delete work only against **native** Data Fabric entities. A federated entity (one projecting an external system) can be read but never written through these nodes.
+
+Nothing enforces this outside the canvas: the three write panels filter their picker to native entities, but there is **no validation rule**. A hand-authored write against a federated entity passes `flow validate`, serializes, is rejected by Data Fabric, and the rejection is swallowed — a green run that changed nothing. Reads against the same entity keep working, which makes it read like a write bug rather than an entity-class one.
+
+Resolve the class up front with `uip df entities list --native-only --output json` and plan writes only against entities in that list.
 
 ## When to Use
 
@@ -36,9 +42,10 @@ Use these nodes when the record lives in **Data Fabric** and the flow itself is 
 | --- | --- |
 | Look up a record by key to drive a decision or fill a downstream input | Yes — Read, `resultMode: "single"` |
 | Fetch a filtered set of rows to iterate over | Yes — Read, `resultMode: "multiple"`, then [Loop](../loop/planning.md) |
-| Advance a status, stamp a result, write back an outcome | Yes — Update |
-| Append a new row (case, audit entry, request) | Yes — Create |
-| Remove a row the flow has finished with | Yes — Delete |
+| Advance a status, stamp a result, write back an outcome | Yes — Update (native entity) |
+| Append a new row (case, audit entry, request) | Yes — Create (native entity) |
+| Remove a row the flow has finished with | Yes — Delete (native entity) |
+| Write to a federated entity | No — these nodes cannot; use [connector](../connector/planning.md) or [http](../http/planning.md) |
 | React to a record being created/updated **elsewhere** | No — that is a trigger; use [connector-trigger](../connector-trigger/planning.md) (`uipath.connector.trigger.uipath-uipath-dataservice.record-created` / `record-updated`) |
 | Aggregate, group, or reshape rows already in memory | No — use [Transform](../transform/planning.md) |
 | Bulk-load a CSV into an entity | No — that is a data-loading job, not a flow step; use `uip df records import` out of band |
@@ -53,26 +60,26 @@ The `uipath-uipath-dataservice` Integration Service connector also exposes entit
 - gives downstream expressions the **record shape** (`$vars.readOrder1.output.Status`) with autocomplete, because the picked entity's schema is merged into the node's output definition;
 - carries **portable entity bindings**, so a folder-scoped entity survives export to another org.
 
-Choose the connector only when the native node is unavailable (flag off) and the work cannot wait, or when you need an operation the native nodes do not cover. Record that choice in **Open Questions** rather than making it silently.
+Choose the connector when the native node is unavailable (flag off), when the entity is federated, or when you need an operation the native nodes do not cover. Record that choice in **Open Questions** rather than making it silently.
 
 ### Anti-Patterns
 
-- **Do not use Delete to "clear" a field.** Delete removes the whole record. To blank a column, use Update with an empty `value` — an empty update value writes `null` deliberately.
+- **Do not use Delete to "clear" a field.** Delete removes the whole record. To blank a column, use Update with an empty `value` — but see the nullability caveat in [impl.md — Write bodies](impl.md#write-bodies).
 - **Do not chain Read → Update by re-typing the record id.** Use `recordSource: "fromRead"` and point at the Read node; it reuses that node's query, so the two can never drift apart.
-- **Do not read a whole entity to find one row.** Push the constraint into `_filters` — a `resultMode: "multiple"` read with no filter returns an arbitrary page, not "everything".
-- **Do not use these nodes inside an API workflow runtime.** All four declare `runtimeConstraints.exclude: ["api-function"]`; the write/read is dispatched by the BPMN engine's element postprocessor, which no other runtime implements.
+- **Do not read a whole entity to find one row.** Push the constraint into `_filters` — a `resultMode: "multiple"` read with no filter returns the first 100 rows in arbitrary order, not "everything".
+- **Do not use these nodes inside an API workflow runtime.** All four declare `runtimeConstraints.exclude: ["api-function"]`; the read/write is dispatched by the BPMN engine, which no other runtime implements.
 - **Do not feed an Update node's output into a [Loop](../loop/planning.md) collection or a [Transform](../transform/planning.md).** That output is re-read per consumer, and collection consumers are excluded from the rewriting — see [Output Variables](#output-variables).
 
 ## Ports
 
-| Node Type | Input | Output(s) |
+| Node Type | Input | Output |
 | --- | --- | --- |
 | `core.datafabric.read` | `input` | `output` |
 | `core.datafabric.create` | `input` | `output` |
 | `core.datafabric.update` | `input` | `output` |
 | `core.datafabric.delete` | `input` | `output` |
 
-`error` is the implicit source port every action node has, off by default. Wire it only when the requirements state what a failed read or write should do — otherwise let the node fault the flow ([Author capability, rule 16](../../CAPABILITY.md#critical-rules)).
+**These four nodes have no `error` port.** Unlike most action nodes, none of them declares `supportsErrorHandling`, so no error handle is ever injected and the properties panel offers no error-handling toggle. Do not set `inputs.errorHandlingEnabled` and do not add an edge with `sourcePort: "error"` — the serializer will still emit a boundary event for it, but with no error mapping, and the canvas shows no handle the author can see or remove. Plan failure handling upstream or downstream instead.
 
 Delete's `output` port exists for **sequencing only** — it carries no data (see below).
 
@@ -89,8 +96,8 @@ Delete's `output` port exists for **sequencing only** — it carries no data (se
 Three consequences worth planning around:
 
 - **A multi-record read is not an array.** `=js:$vars.listOrders1.output` is an object; the collection is `=js:$vars.listOrders1.output.results`. Wiring the former into a Loop iterates nothing.
-- **Create's `Id` is real, but only on a new enough engine.** `$vars.createOrder1.output.Id` is the generated key on engine `>= 1.923.0`. Below that floor the node did not insert at all.
 - **Update's output is a re-read, not the write's response.** The engine discards the write response; the serializer rewrites each downstream `$vars.<updateId>.output` reference into its own query for the record just written. That is why it cannot be consumed as a Loop or Transform collection — those are excluded from the rewriting and have no snapshot to fall back on.
+- **A read that matches nothing does not fault.** Only an *over*-match faults a single-record read. Zero matches completes normally and leaves `$vars.<readId>.output` unresolved, so a downstream Decision silently takes its falsy branch. If "not found" is a real business case, branch on it explicitly.
 
 Delete has no output at all, so plan any post-delete signalling (a count, a status) as a separate [Script](../script/planning.md) or End-node mapping.
 
@@ -102,9 +109,11 @@ Every node takes exactly one input object, `inputs.entityConfig`. Its contents d
 
 | Key | Required | Description |
 | --- | --- | --- |
-| `entityName` | Yes | The Data Fabric entity's name. Resolve it with `uip df entities list --output json` — never invent it |
-| `_folderKey` | Folder-scoped entities only | Folder GUID. Its presence switches the emitted target to the folder-qualified form and makes `bindings[]` entries necessary for portability — see [impl.md — Folder-scoped entities](impl.md#folder-scoped-entities-and-bindings) |
+| `entityName` | Yes | The entity's technical name. Resolve it with `uip df entities list` — never invent it |
+| `_folderKey` | Folder-scoped entities only | The entity's `folderId`. Its presence switches the emitted target to the folder-qualified form and makes `bindings[]` entries necessary for portability — see [impl.md — Folder-scoped entities](impl.md#folder-scoped-entities-and-bindings) |
 | `_resourceKey` / `_entityKey` | With `_folderKey` | Key the entity's `bindings[]` rows are scoped to |
+
+The canvas also persists schema snapshots (`_entityFields`, `_relatedFields`, `_outputSchema`, `_choiceSets`). They are not decoration — see [impl.md — Schema snapshots](impl.md#schema-snapshots) for when authoring without them silently breaks.
 
 ### `core.datafabric.read`
 
@@ -113,9 +122,9 @@ Every node takes exactly one input object, `inputs.entityConfig`. Its contents d
 | `resultMode` | No | `"single"` (default) or `"multiple"` |
 | `_filters` | No | The query. Grouped filter model — see [impl.md — Filters](impl.md#filters) |
 | `_selectedFieldNames` | No | Columns to return. Omit for all |
-| `_recordLimit` | `multiple` only | Row cap, clamped 1–1000. **Always write it explicitly** — the canvas does (100), and omitting it hands the row count to the engine's own default, which varies by the entity's shape |
-| `_skip` | `multiple` only | Rows to pass over first |
-| `_sort` | `multiple` only | `{ field, direction: "asc" \| "desc" }`. A limit without an order returns arbitrary rows |
+| `_recordLimit` | `multiple` only | Row cap, clamped 1–1000. Omitted resolves to **100** — the emitted query always carries an explicit limit |
+| `_skip` | `multiple` only | Rows to pass over first. The only way past the 1000-row ceiling |
+| `_sort` | `multiple` only | `{ field, direction: "asc" \| "desc" }`. A limit without an order returns an arbitrary slice |
 
 ### `core.datafabric.create`
 
@@ -127,16 +136,16 @@ Every node takes exactly one input object, `inputs.entityConfig`. Its contents d
 
 | Key | Required | Description |
 | --- | --- | --- |
-| `recordSource` | Yes in practice | `"byId"` or `"fromRead"` — how the target record is identified |
+| `recordSource` | Yes | `"byId"` or `"fromRead"` — how the target record is identified |
 | `recordId` | `byId` | The record's `Id` — a literal or a `=js:` reference |
 | `readEntityNodeId` | `fromRead` | The upstream Read node whose query identifies the record |
-| `fieldUpdates` | Yes | `[{ field, value }]`. An **empty `value` is a real write** — it clears the column |
+| `fieldUpdates` | Yes | `[{ field, value }]`. An **empty `value` writes an explicit null**, which a non-nullable column rejects |
 
 ### `core.datafabric.delete`
 
 | Key | Required | Description |
 | --- | --- | --- |
-| `recordSource` | Yes | `"byId"` or `"fromRead"`. Required — without it the node publishes green and deletes nothing |
+| `recordSource` | Yes | `"byId"` or `"fromRead"`. The validator requires it — but do not read its absence as "inert" ([impl.md — Record selection](impl.md#record-selection)) |
 | `recordId` | `byId` | The record's `Id` |
 | `readEntityNodeId` | `fromRead` | The upstream Read node identifying the record |
 
@@ -147,9 +156,9 @@ Update and Delete both need to name exactly one record, and offer the same two w
 | Mode | Use when | Cost of getting it wrong |
 | --- | --- | --- |
 | `byId` | The id is already in hand — a trigger payload, a Create node's `output.Id`, a flow input | A blank or whitespace-only id resolves to nothing; the node runs green having written nothing |
-| `fromRead` | An upstream Read already located the record by business key | Pointing at a Read that matches more than one record faults the element |
+| `fromRead` | An upstream Read already located the record by business key | The write is **skipped silently** if the read matches more than one record, names a node that does not exist, or is itself multi-record |
 
-Prefer `fromRead` when a Read node is already there — it reuses that node's compiled query, so a later change to the filter automatically follows through to the write.
+Prefer `fromRead` when a Read node is already there — it reuses that node's compiled query, so a later change to the filter automatically follows through to the write. But note the asymmetry: on the **read** path an over-match faults the element, while on the **write** path the engine swallows that same over-match and skips the write. A `fromRead` target must therefore be a genuinely single-record read; there is no runtime safety net telling you it was not.
 
 ## Common Pattern — read, branch, write back
 
@@ -160,11 +169,13 @@ Trigger -> Read entity records (single, filter by business key)
              -> false: Create entity record            -> End
 ```
 
+The Decision is doing real work here: a read that matches nothing completes with an unresolved output, so the false branch is also the not-found branch.
+
 ## Planning Annotation
 
 In the architectural plan:
 
 - `datafabric: <verb> <EntityName> — <one-line purpose>`, naming the entity and, for a read, whether it is single or multiple.
 - Name the **selector** for every Update and Delete (`byId` from `<source>`, or `fromRead` from `<readNodeId>`). An unnamed selector is the single most common way these nodes ship silently doing nothing.
+- Record the entity's **class and scope** — native vs federated, tenant vs folder — because writes need native, and a folder-scoped entity needs `_folderKey` plus bindings.
 - Put the entity in **Open Questions** when the requirements name a business concept ("the order", "the case") but no entity is confirmed by `uip df entities list`. Do not guess an entity or column name — they are case-sensitive and unmatched names are dropped rather than rejected.
-- Flag any Create node in **Open Questions** when the target engine version is unknown.

--- a/skills/uipath-maestro-flow/references/author/plugins/data-fabric/planning.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/data-fabric/planning.md
@@ -61,7 +61,7 @@ Where the tenant *does* have them, the native node is the better build, because 
 
 - needs **no Integration Service connection** — nothing to create, bind, or keep healthy, and no `bindings[]` connection row;
 - is **user-owned** — author it with `Edit`/`Write` instead of the CLI's `node add` + `node configure` envelope (see [Author capability — Node ownership](../../CAPABILITY.md#node-ownership--who-authors-the-node));
-- gives downstream expressions the **record shape** (`$vars.readOrder1.output.Status`) with autocomplete, because the picked entity's schema is merged into the node's output definition;
+- gives downstream expressions the **record shape** (`$vars.readOrder.output.Status`) with autocomplete, because the picked entity's schema is merged into the node's output definition;
 - carries **portable entity bindings**, so a folder-scoped entity survives export to another org.
 
 Whichever way the check sends you, record it in **Open Questions** rather than leaving the reader to guess why the flow took that path.
@@ -91,7 +91,7 @@ Delete's `output` port exists for **sequencing only** — it carries no data (se
 
 | Node Type | `$vars.{nodeId}.output` |
 | --- | --- |
-| `core.datafabric.read` (`single`) | The record itself — address columns directly: `$vars.readOrder1.output.Status` |
+| `core.datafabric.read` (`single`) | The record itself — address columns directly: `$vars.readOrder.output.Status` |
 | `core.datafabric.read` (`multiple`) | `{ results: [...] }` — the rows are under `output.results`, never `output` itself |
 | `core.datafabric.create` | The **stored** record, including the generated `Id` and server-applied defaults |
 | `core.datafabric.update` | The record **after** the write |
@@ -99,7 +99,7 @@ Delete's `output` port exists for **sequencing only** — it carries no data (se
 
 Three consequences worth planning around:
 
-- **A multi-record read is not an array.** `=js:$vars.listOrders1.output` is an object; the collection is `=js:$vars.listOrders1.output.results`. Wiring the former into a Loop iterates nothing.
+- **A multi-record read is not an array.** `=js:$vars.listOpenOrders.output` is an object; the collection is `=js:$vars.listOpenOrders.output.results`. Wiring the former into a Loop iterates nothing.
 - **Update's output is a re-read, not the write's response.** The engine discards the write response; the serializer rewrites each downstream `$vars.<updateId>.output` reference into its own query for the record just written. That is why it cannot be consumed as a Loop or Transform collection — those are excluded from the rewriting and have no snapshot to fall back on.
 - **A read that matches nothing does not fault.** Only an *over*-match faults a single-record read. Zero matches completes normally and leaves `$vars.<readId>.output` unresolved, so a downstream Decision silently takes its falsy branch. If "not found" is a real business case, branch on it explicitly.
 
@@ -140,7 +140,7 @@ The canvas also persists schema snapshots (`_entityFields`, `_relatedFields`, `_
 
 | Key | Required | Description |
 | --- | --- | --- |
-| `recordSource` | Yes | `"byId"` or `"fromRead"` — how the target record is identified |
+| `recordSource` | Always author it | `"byId"` or `"fromRead"`. **The validator does not require it on Update** (unlike Delete) — the serializer infers the mode from whichever selector is populated, so leaving it out is silent |
 | `recordId` | `byId` | The record's `Id` — a literal or a `=js:` reference |
 | `readEntityNodeId` | `fromRead` | The upstream Read node whose query identifies the record |
 | `fieldUpdates` | Yes | `[{ field, value }]`. An **empty `value` writes an explicit null**, which a non-nullable column rejects |

--- a/skills/uipath-maestro-flow/references/author/plugins/data-fabric/planning.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/data-fabric/planning.md
@@ -55,7 +55,7 @@ Use these nodes when the record lives in **Data Fabric** and the flow itself is 
 
 The `uipath-uipath-dataservice` Integration Service connector also exposes entity operations (`query-entity-records`, `create-entity-record`, `update-entity-record`, `get-entity-record-by-id`, `delete-entity-record`, …), and `registry search` surfaces both families.
 
-**Check availability before you choose — do not default to the native node.** All four tenant flags default to off, so on a tenant that has not enabled them the connector activities are the only working path. Run `uip maestro flow registry get core.datafabric.<op>` for the operation you need: if it answers "Node not found", or search reports `AvailableOnTenant: false`, build with the [connector](../connector/planning.md) and stop pursuing the native node. Use the connector too when the entity is federated, since the native writes require a native entity.
+**Check availability before you choose — do not default to the native node.** All four tenant flags default to off, so the connector is the working path until `registry get core.datafabric.<op>` proves otherwise. On "Node not found" or `AvailableOnTenant: false`, build with the [connector](../connector/planning.md) and stop pursuing the native path — as you should when the entity is federated, since the native writes require a native entity.
 
 Where the tenant *does* have them, the native node is the better build, because it:
 
@@ -140,7 +140,7 @@ The canvas also persists schema snapshots (`_entityFields`, `_relatedFields`, `_
 
 | Key | Required | Description |
 | --- | --- | --- |
-| `recordSource` | Always author it | `"byId"` or `"fromRead"`. **The validator does not require it on Update** (unlike Delete) — the serializer infers the mode from whichever selector is populated, so leaving it out is silent |
+| `recordSource` | Yes (not enforced) | `"byId"` or `"fromRead"`. **The validator does not require it on Update** (unlike Delete) — the serializer infers the mode from whichever selector is populated, so leaving it out is silent |
 | `recordId` | `byId` | The record's `Id` — a literal or a `=js:` reference |
 | `readEntityNodeId` | `fromRead` | The upstream Read node whose query identifies the record |
 | `fieldUpdates` | Yes | `[{ field, value }]`. An **empty `value` writes an explicit null**, which a non-nullable column rejects |

--- a/skills/uipath-maestro-flow/references/shared/action-nodes.md
+++ b/skills/uipath-maestro-flow/references/shared/action-nodes.md
@@ -65,6 +65,8 @@ For action nodes, the instance `outputs` block is documentation, not the runtime
 
 **Exceptions:** Orchestrator-job nodes (api-workflow, rpa-workflow, agent, agentic-process, function) have their instance `outputs` read by the converter, which copies each `source` verbatim. A wrong `source` (for example, `=result.response`) breaks `$vars.{nodeId}.output`; declare `error` only there. End / terminate nodes also have their instance `outputs` consumed to map workflow-level `out` variables.
 
+**Data Fabric entity nodes (`core.datafabric.*`) carry no instance `outputs` block at all** — the canvas writes none, so author `inputs` only and let `flow format` regenerate `variables.nodes[]`. They are also the one action-node family with **no `error` port**: none declares `supportsErrorHandling`, so the skeleton's `outputs.error` and the implicit error port in [Standard ports](#standard-ports) do not apply to them. See [data-fabric/impl.md](../author/plugins/data-fabric/impl.md#no-error-port).
+
 `uip maestro flow format` regenerates `variables.nodes[]` from the current node graph, so running format after structural edits self-heals an omitted entry.
 
 ## Standard ports
@@ -73,7 +75,7 @@ For action nodes, the instance `outputs` block is documentation, not the runtime
 | --- | --- | --- |
 | Input (target) | `input` | Every action node accepts one input edge on `input`. |
 | Output (success, source) | `output`, `default`, or `success` | The name varies by plugin; `registry get` is authoritative. |
-| Output (error, source) | `error` | Implicit on every action node via `outputs.error`. |
+| Output (error, source) | `error` | Implicit on action nodes that declare `supportsErrorHandling`, via `outputs.error`. The `core.datafabric.*` family does not — it has no `error` port. |
 
 Plugins may add dynamic source ports, such as HTTP `branch-{id}` from `inputs.branches`; document these in the plugin's `impl.md`.
 

--- a/skills/uipath-maestro-flow/references/shared/file-format.md
+++ b/skills/uipath-maestro-flow/references/shared/file-format.md
@@ -16,6 +16,7 @@ The `.flow` file is a JSON document at `<ProjectName>.flow` in the project root.
 - [Minimal working example — dice roller](#minimal-working-example--dice-roller)
 - [entry-points.json — auto-generated, do not edit](#entry-pointsjson--auto-generated-do-not-edit)
 - [Bindings — Orchestrator resource bindings (top-level `bindings[]`)](#bindings--orchestrator-resource-bindings-top-level-bindings)
+- [Bindings — Data Fabric entity bindings](#bindings--data-fabric-entity-bindings)
 - [Bindings — connector connection binding](#bindings--connector-connection-binding)
 
 ## Top-level structure
@@ -294,7 +295,7 @@ uip maestro flow registry search <keyword>
 | `core.control.end` | — | `input` |
 | `core.logic.terminate` | — | `input` |
 
-Connector activities, agent nodes, and RPA nodes follow the same pattern as the generic action nodes above: a primary source port plus an implicit `error` port.
+Connector activities, agent nodes, and RPA nodes follow the same pattern as the generic action nodes above: a primary source port plus an implicit `error` port. The `core.datafabric.*` nodes are the exception — `input` and `output` only.
 
 Verify exact ports for any node type:
 ```bash
@@ -305,7 +306,7 @@ uip maestro flow registry get <node-type> --output json
 
 ## Implicit error port on action nodes
 
-Any node with `supportsErrorHandling: true` in the registry exposes an implicit `error` source port for catching node-level failures. This applies to HTTP, Script, Transform (all variants), connector activities, agent nodes, and RPA nodes — essentially every action node.
+Any node with `supportsErrorHandling: true` in the registry exposes an implicit `error` source port for catching node-level failures. This applies to HTTP, Script, Transform (all variants), connector activities, agent nodes, and RPA nodes — most action nodes, but not all: the `core.datafabric.*` family does not declare it and has no `error` port ([data-fabric/impl.md](../author/plugins/data-fabric/impl.md#no-error-port)). Check the registry rather than assuming.
 
 The port is **not** listed in the registry's `handleConfiguration`. Studio Web only exposes it when the source node has `inputs.errorHandlingEnabled: true`; when the flow contains an outgoing edge with `sourcePort: "error"` from that node, the serializer emits a BPMN boundary error event attached to the node. Because of this gate, `uip maestro flow validate` reports an error when a node has an outgoing `sourcePort: "error"` edge but `inputs.errorHandlingEnabled` is not `true` — so the inconsistency is caught before publish rather than surfacing as a hidden edge in Studio Web.
 
@@ -514,7 +515,7 @@ The packaging/debug step derives `entry-points.json` from these variable declara
 
 The top-level `bindings` array (a sibling of `nodes`, `edges`, `definitions`, `variables`, `layout`) holds resource-reference indirections for **Orchestrator resource nodes** — RPA workflows, agents, flows, agentic processes, API workflows, and HITL apps.
 
-Folder-scoped Data Fabric entities also write rows into this same array, but resolve them by a **different rule**. Everything in this section describes the Orchestrator-resource form; see [Data Fabric entity bindings](#data-fabric-entity-bindings) below for how the `Entity` kind differs.
+Folder-scoped Data Fabric entities also write rows into this same array, but resolve them by a **different rule**. Everything in this section describes the Orchestrator-resource form; see [Bindings — Data Fabric entity bindings](#bindings--data-fabric-entity-bindings) below for how the `Entity` kind differs.
 
 Each resource node needs two binding entries (one for `name`, one for `folderPath`). The node instance itself has no binding or context data — just `inputs`. The definition (copied verbatim from the registry) carries `model.context[]` templates like `<bindings.name>` and `<bindings.folderPath>`. At BPMN emit time the runtime rewrites those placeholders to `=bindings.<id>` by matching the placeholder name against a workflow-level binding, scoped by the definition's `model.bindings.resourceKey`.
 
@@ -558,9 +559,11 @@ Each resource node needs two binding entries (one for `name`, one for `folderPat
 
 See each resource plugin's `impl.md` for the full JSON per node type: [rpa](../author/plugins/rpa/impl.md), [agent](../author/plugins/agent/impl.md), [flow](../author/plugins/flow/impl.md), [agentic-process](../author/plugins/agentic-process/impl.md), [api-workflow](../author/plugins/api-workflow/impl.md), [hitl](../author/plugins/hitl/impl.md).
 
-### Data Fabric entity bindings
+**Not to be confused with `bindings_v2.json`.** That file holds connector connection bindings for Integration Service nodes — a separate system. A flow may have both: a top-level `bindings[]` for resource references and a `bindings_v2.json` file for connector connections.
 
-A **folder-scoped** Data Fabric entity (`core.datafabric.*` nodes) writes two rows into this same `bindings[]` array, but they are not Orchestrator resource bindings and four of the rules above do not carry over:
+## Bindings — Data Fabric entity bindings
+
+A **folder-scoped** Data Fabric entity (`core.datafabric.*` nodes) writes two rows into the same top-level `bindings[]` array, but they are not Orchestrator resource bindings and most of the rules in the section above do not carry over:
 
 | Aspect | Orchestrator resource nodes | Data Fabric `Entity` |
 | --- | --- | --- |
@@ -575,8 +578,6 @@ The value is in `default` for both forms. There is also no `<bindings.{name}>` p
 `folderKey` rather than `folderPath` is load-bearing. The platform's deploy-time override for an `Entity` resource carries `{ name, folderPath, folderKey }` and rewrites binding defaults by `propertyAttribute`; a `folderPath` row receives the Orchestrator FQN, which the Data Fabric query rejects even in the source org.
 
 Tenant-scoped entities need no bindings at all — they serialize as a dotted literal. See [data-fabric/impl.md — Folder-scoped entities and bindings](../author/plugins/data-fabric/impl.md#folder-scoped-entities-and-bindings) for the full JSON and when to hand-author it.
-
-**Not to be confused with `bindings_v2.json`.** That file holds connector connection bindings for Integration Service nodes — a separate system. A flow may have both: a top-level `bindings[]` for resource references and a `bindings_v2.json` file for connector connections.
 
 ## Bindings — connector connection binding
 

--- a/skills/uipath-maestro-flow/references/shared/file-format.md
+++ b/skills/uipath-maestro-flow/references/shared/file-format.md
@@ -514,6 +514,8 @@ The packaging/debug step derives `entry-points.json` from these variable declara
 
 The top-level `bindings` array (a sibling of `nodes`, `edges`, `definitions`, `variables`, `layout`) holds resource-reference indirections for **Orchestrator resource nodes** — RPA workflows, agents, flows, agentic processes, API workflows, and HITL apps.
 
+Folder-scoped Data Fabric entities also write rows into this same array, but resolve them by a **different rule**. Everything in this section describes the Orchestrator-resource form; see [Data Fabric entity bindings](#data-fabric-entity-bindings) below for how the `Entity` kind differs.
+
 Each resource node needs two binding entries (one for `name`, one for `folderPath`). The node instance itself has no binding or context data — just `inputs`. The definition (copied verbatim from the registry) carries `model.context[]` templates like `<bindings.name>` and `<bindings.folderPath>`. At BPMN emit time the runtime rewrites those placeholders to `=bindings.<id>` by matching the placeholder name against a workflow-level binding, scoped by the definition's `model.bindings.resourceKey`.
 
 ```json
@@ -555,6 +557,24 @@ Each resource node needs two binding entries (one for `name`, one for `folderPat
 **Definitions stay verbatim.** Do NOT rewrite `<bindings.*>` placeholders inside the `definitions` entry — the definition is the authoring template. See "Every node type needs a `definitions` entry" in [author/CAPABILITY.md](../author/CAPABILITY.md).
 
 See each resource plugin's `impl.md` for the full JSON per node type: [rpa](../author/plugins/rpa/impl.md), [agent](../author/plugins/agent/impl.md), [flow](../author/plugins/flow/impl.md), [agentic-process](../author/plugins/agentic-process/impl.md), [api-workflow](../author/plugins/api-workflow/impl.md), [hitl](../author/plugins/hitl/impl.md).
+
+### Data Fabric entity bindings
+
+A **folder-scoped** Data Fabric entity (`core.datafabric.*` nodes) writes two rows into this same `bindings[]` array, but they are not Orchestrator resource bindings and four of the rules above do not carry over:
+
+| Aspect | Orchestrator resource nodes | Data Fabric `Entity` |
+| --- | --- | --- |
+| `resource` | `process`, `agent`, … | `Entity` — capitalized; a lowercase row is ignored by packaging, so deploy emits no override |
+| Matched by | `(resourceKey, name)` | `(resourceKey, propertyAttribute)`, falling back to `name` only when `propertyAttribute` is absent |
+| `name` holds | the placeholder name (`name` / `folderPath`) | a **display label** — the entity name, and `<entityName>Folder` for the folder row |
+| `propertyAttribute` | `name` / `folderPath` | `name` / **`folderKey`** — never `folderPath` |
+| `resourceSubType` | required, mirrors the definition | **absent** — Entity bindings have no definition-side `model.bindings` |
+
+The value is in `default` for both forms. There is also no `<bindings.{name}>` placeholder to rewrite: the entity has no definition-side `model.context[]`, and the serializer emits `bindings.<id>` tokens directly into the `=datafabric[...]` expression it builds.
+
+`folderKey` rather than `folderPath` is load-bearing. The platform's deploy-time override for an `Entity` resource carries `{ name, folderPath, folderKey }` and rewrites binding defaults by `propertyAttribute`; a `folderPath` row receives the Orchestrator FQN, which the Data Fabric query rejects even in the source org.
+
+Tenant-scoped entities need no bindings at all — they serialize as a dotted literal. See [data-fabric/impl.md — Folder-scoped entities and bindings](../author/plugins/data-fabric/impl.md#folder-scoped-entities-and-bindings) for the full JSON and when to hand-author it.
 
 **Not to be confused with `bindings_v2.json`.** That file holds connector connection bindings for Integration Service nodes — a separate system. A flow may have both: a top-level `bindings[]` for resource references and a `bindings_v2.json` file for connector connections.
 


### PR DESCRIPTION
## What

Adds coding-agent support to `uipath-maestro-flow` for the four **native Data Fabric entity nodes**:

| Node | Canvas label | Tenant flag |
| --- | --- | --- |
| `core.datafabric.read` | Read entity records | `canvas.nodes.read-entity` |
| `core.datafabric.create` | Create entity record | `canvas.nodes.create-entity` |
| `core.datafabric.update` | Update entity record | `canvas.nodes.update-entity` |
| `core.datafabric.delete` | Delete entity record | `canvas.nodes.delete-entity` |

Until now the skill covered Data Fabric only as `uipath-uipath-dataservice` Integration Service activities. The native nodes need no IS connection, are user-owned (plain-JSON `inputs.entityConfig`, not a `=jsonString:` envelope), and give downstream expressions the picked entity's record shape.

All four tenant flags **default to off**, so the guide makes node choice availability-first: check `registry get`, and build with the connector when the native node is not there.

## New — `references/author/plugins/data-fabric/`

Follows the established plugin pair, modelled on the flag-gated `batch-transform` / `summarize` plugins.

**`planning.md`** — node types and flags, the native-entity requirement for writes, selection heuristics, the availability check, ports, per-node output semantics, `entityConfig` keys, `byId` vs `fromRead`, planning annotation.

**`impl.md`** — registry validation, ownership, entity/scope/column resolution via `uip df`, per-node JSON, write bodies, schema snapshots, the filter grammar, record selection, folder-scoped bindings, output wiring, validator coverage, debug table, what-not-to-do.

### The failure mode this plugin is built around

Almost every way these nodes go wrong is **silent**: Data Fabric rejects the write, the engine logs it and moves on, and the run reports Completed having changed nothing. `flow validate` catches the structural cases and nothing else. So the guide is organised around what validates clean and still does nothing:

- **Writes require a native entity.** No validation rule enforces it — the canvas filters its picker, a hand-authored flow does not.
- **System columns** (`Id`, `CreateTime`, `CreatedBy`, `UpdateTime`, `UpdatedBy`) and attachment columns are never writable; the serializer has no guard.
- **Choice-set columns take the numeric `numberId`, not the label**, and the multi-valued form is a JSON array *as a string* (`"[1,2]"`).
- **`fromRead` fails silently four ways** — missing node id, multi-record target, non-compiling filters (all emit a no-op task), and a runtime over-match, which the write path *swallows* even though the read path faults on it.
- **An absent `recordSource` is not inert** — the serializer infers the mode from whichever selector is populated. The validator requires it on Delete but **not** on Update.
- **Create vs Update blank-value asymmetry** — blank applies the column default on insert, but asserts `null` on update, which a non-nullable column rejects.

Plus the mechanical contracts an agent can't infer: Read emits a `<uipath:input>` for the engine's preprocessor while the writes emit a `<uipath:output>` for the postprocessor; a multi-record read lands under `output.results`; Update's output is a re-read that can't feed a Loop or Transform collection; Delete produces nothing; and these four are the one action-node family with **no error port** and no instance `outputs` block.

## Routing and shared-doc updates

- `SKILL.md` — capability line + description enumeration
- `author/CAPABILITY.md` — node-ownership table (user-owned), common tasks, plugin list
- `author/planning-arch.md` — Plugin Index, Standard Port Reference, Data Fabric carve-out on the external-service ladder
- `author/planning-impl.md` — Step-1a node-type router
- `plugins/connector/impl.md` — the `uipath-uipath-dataservice` activity rows point back, so the availability check is visible *before* the connector is chosen
- `shared/file-format.md` — new **Data Fabric entity bindings** subsection. The `Entity` kind resolves by `(resourceKey, propertyAttribute)`, has no `<bindings.{name}>` placeholder, puts a display label in `name`, uses `folderKey` not `folderPath`, and has no `resourceSubType`. The existing H2 anchor is untouched (five sibling plugins link to it).
- `shared/action-nodes.md` — Exceptions note and Standard-ports table record that `core.datafabric.*` has no error port and no instance `outputs` block
- `CODEOWNERS` — plugin dir under `@UiPath/DatafabricCodingAgent` + `@UiPath/maestro-cli-team`

## Verification

Every behavioural claim was checked against `flow-workbench@develop` — node manifests under `flow-core/src/manifest/data/ootb-nodes/core-datafabric-*`, `manifest-client.ts`, `services/src/serialization/entity-vdo.ts`, `uipath-extension.ts`, `expression-model`, `flow-schema` validation rules, and the canvas entity panels — not inferred from node names.

Two correction passes are folded in. `1ab64a31` fixed claims an internal review found (a faulting `fromRead` over-match, an inert `recordSource`, an implicit error port, an invented `CreatedAt` column, an engine-derived row cap). `69386f79` fixed a **real regression this branch caused**: the first framing read as an unconditional "prefer the native node", and `skill-flow-datafabric-smoke-update` — which builds against the connector — switched to native nodes and failed its verifier. Making the choice availability-first restored it; that task and `smoke-error` are now SUCCESS and the tier passes at 96%.

`.maintenance/check-all.sh`: links 898/0, link-text 571/0, anchors 286 checked / 1 bad (pre-existing, reproduces on `main`), depth 84/84, orphans 0, plugin-pairs 27/0, template 0 missing, versions 0 violations. `npm run skills:validate` OK (27 skills, both flavors). `check-skill-verbs.py` clean on all new and edited files.

## Notes for reviewers

1. **Eval task deferred — tenant flags are the blocker, not the CLI.** Correcting my earlier note: on `uip` 1.202.0 all four node types are returned by `registry search` with `AvailableOnTenant: false`. (My local 1.201.0-dev.8247 returns only `core.datafabric.read`, which is what the stale claim was based on.) Either way `registry get` answers *Node not found* until a tenant enables the flags, so a task cannot instantiate these nodes yet. Worth tracking as a follow-up rather than a blocker here — `queue`, `batch-transform`, `summarize` and `delay` also ship without a task dir.
2. **`check-uip-commands.sh` crashes on Python 3.9** (`TypeError: unsupported operand type(s) for |`) — pre-existing, reproduces on `main`. Clean under 3.14. Left alone to keep this PR scoped; the CLI Verb Gate covers the same ground in CI and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151VobGkRGo2Ym4j6s67kem
