### PR TITLE
fix(maestro-flow): address #2756 review (pagination gate, rotation cleanup, node_modules prune)

### DIFF
--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -333,6 +333,7 @@ jobs:
             --build-arg CODER_EVAL_IMAGE="ghcr.io/uipath/coder-eval-agent:${CE_IMAGE_TAG}" \
             --secret id=npm_auth_token,env=NPM_AUTH_TOKEN \
             --build-arg CLI_VERSION="${{ inputs.cli_version }}" \
+            --build-arg FLOW_SDK_VERSION="${{ vars.FLOW_SDK_VERSION || 'latest' }}" \
             -t skills-image:latest \
             -f tests/docker/Dockerfile \
             .

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,7 +19,7 @@
 
 # preview skills
 /preview/uipath-maestro-flow/ @UiPath/maestro-cli-team
-/preview/uipath-maestro-case/ @UiPath/maestro-cli-team
+/preview/uipath-maestro-case/ @dmetzgar @tmatup
 /preview/uipath-maestro-bpmn/ @UiPath/maestro-cli-team
 
 # Activity references (bundled inside uipath-rpa skill)

--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -293,7 +293,7 @@ and honestly surfaced to the user as gaps when asked.
    `uipath:event` / `uipath:mapping` templates declare their type as a nested
    `<uipath:type value="<Type>" version="v1" />`. Some runtime-authored
    templates use the payload's `type` attribute instead; notably,
-   `Orchestrator.StartAgentJob` is a direct child of `bpmn:serviceTask` with
+   `Orchestrator.StartAgentJob` is a direct child of `bpmn:ServiceTask` with
    `<uipath:activity type="Orchestrator.StartAgentJob" version="v1">`. Both
    declarations are supported. Paste the selected registry template literally
    and do not normalize one form into the other.

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -170,7 +170,6 @@ RUN cd "$PREVIEW_FLOW_SDK_ROOT" && \
     uip maestro registry pull --force --output json && \
     if [ -f "$UIP_MAESTRO_REGISTRY_HOME/current.json" ]; then \
       registry_snapshot="$(jq -er '.snapshotPath' "$UIP_MAESTRO_REGISTRY_HOME/current.json")"; \
-      registry_connectors="$registry_snapshot/connectors"; \
     else \
       library_json="$(readlink -f "$(uip maestro registry path --library-json)")" && \
       registry_snapshot="$(dirname "$library_json")" && \
@@ -179,20 +178,16 @@ RUN cd "$PREVIEW_FLOW_SDK_ROOT" && \
       mkdir -p "$UIP_MAESTRO_REGISTRY_HOME" && \
       jq -n --arg libraryHash "$library_hash" --arg snapshotPath "$registry_snapshot" \
         '{libraryHash: $libraryHash, snapshotPath: $snapshotPath}' \
-        > "$UIP_MAESTRO_REGISTRY_HOME/current.json" && \
-      registry_connectors="$PREVIEW_FLOW_SDK_ROOT/connectors" && \
-      mkdir -p "$registry_connectors"; \
+        > "$UIP_MAESTRO_REGISTRY_HOME/current.json"; \
     fi && \
     test -f "$registry_snapshot/library-json/index.json" && \
     test -f "$registry_snapshot/library-md/index.json" && \
     mkdir -p "$PREVIEW_FLOW_SDK_ASSETS_ROOT" && \
     ln -s "$registry_snapshot/library-json" "$PREVIEW_FLOW_SDK_ASSETS_ROOT/library-json" && \
-    ln -s "$registry_snapshot/library-md" "$PREVIEW_FLOW_SDK_ASSETS_ROOT/library-md" && \
-    ln -s "$registry_connectors" "$PREVIEW_FLOW_SDK_ASSETS_ROOT/connectors"
+    ln -s "$registry_snapshot/library-md" "$PREVIEW_FLOW_SDK_ASSETS_ROOT/library-md"
 
 ENV FLOW_SDK_LIBRARY_JSON=/opt/preview-flow-sdk-assets/library-json \
-    FLOW_SDK_LIBRARY_MD=/opt/preview-flow-sdk-assets/library-md \
-    FLOW_SDK_CONNECTORS_DIR=/opt/preview-flow-sdk-assets/connectors
+    FLOW_SDK_LIBRARY_MD=/opt/preview-flow-sdk-assets/library-md
 
 # Prove that the installed SDK resolves without registry credentials and that
 # the product CLI can check real source against it.

--- a/tests/scripts/stage_shared.sh
+++ b/tests/scripts/stage_shared.sh
@@ -28,16 +28,17 @@ if [ -n "$manifest" ]; then
 fi
 
 search_root=${STAGE_SHARED_ROOT:-tests/tasks}
-if [[ "$search_root" = "$PWD"/* ]]; then
-  search_root=${search_root#"$PWD"/}
-fi
-case "$search_root" in
-  tests/tasks | tests/tasks/*) ;;
+# Compare resolved paths so `tests/tasks/../../etc` cannot pass the guard.
+resolved_root=$(realpath -m -- "$search_root")
+tasks_root=$(realpath -m -- "$PWD/tests/tasks")
+case "$resolved_root" in
+  "$tasks_root" | "$tasks_root"/*) ;;
   *)
     echo "stage_shared: STAGE_SHARED_ROOT must be under tests/tasks: $search_root" >&2
     exit 2
     ;;
 esac
+search_root=${resolved_root#"$PWD"/}
 
 count=0
 while IFS= read -r f; do

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -61,7 +61,7 @@ success_criteria:
 
   - type: run_command
     description: "Package operate metadata was created"
-    command: "python3 -c \"from pathlib import Path; import sys; sys.exit(0 if any(Path('.').rglob('operate.json')) else 'operate.json missing')\""
+    command: "python3 -c \"from pathlib import Path; import sys; b=next(Path('.').rglob('WikiPageviews.bpmn'), None); sys.exit(0 if b and (b.parent / 'operate.json').is_file() else 'operate.json missing beside WikiPageviews.bpmn')\""
     timeout: 30
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -63,7 +63,10 @@ def find_caseplan(pattern: str = "**/caseplan.json") -> str:
             for _, plan in candidates
         }
         if len(signatures) == 1:
-            return min((path for path, _ in candidates), key=lambda path: (path.count(os.sep), len(path), path))
+            return min(
+                (path for path, _ in candidates),
+                key=lambda path: (path.count(os.sep), len(path), path),
+            )
 
     joined = "\n  - ".join(matches)
     _fail(f"Multiple distinct caseplan.json files match {pattern!r}:\n  - {joined}")

--- a/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
@@ -4,7 +4,9 @@
 Wired in via ``post_run`` in flow e2e task YAMLs. Runs from the sandbox CWD
 after evaluation completes; finds every ``.uipx`` file under it, reads
 ``SolutionId``, and best-effort deletes each via ``uip solution delete``.
-``.uipx`` files without a ``SolutionId`` are skipped.
+``.uipx`` files without a ``SolutionId`` are skipped. Ids that the INTERIM
+Overwrite rotation in ``flow_check.py`` moved away from are read from the
+``.rotated-solution-ids`` sidecar beside each ``.uipx`` and deleted too.
 
 Cleanup policy is controlled by the ``FLOW_E2E_CLEANUP`` env var:
 
@@ -27,6 +29,29 @@ import sys
 
 logging.basicConfig(level=logging.INFO, format="cleanup_solutions: %(message)s")
 logger = logging.getLogger(__name__)
+
+ROTATED_SOLUTION_IDS_SIDECAR = ".rotated-solution-ids"  # written by flow_check.py
+
+
+def _solution_ids(uipx_path: str) -> list[tuple[str, str]]:
+    """``(solution_id, source)`` pairs for one ``.uipx``: its current id plus any
+    ids the Overwrite rotation left on the tenant (sidecar, one per line)."""
+    ids: list[tuple[str, str]] = []
+    with open(uipx_path) as f:
+        data = json.load(f)
+    sid = data.get("SolutionId")
+    if sid:
+        ids.append((sid, uipx_path))
+    else:
+        logger.info("no SolutionId in %s", uipx_path)
+    sidecar = os.path.join(os.path.dirname(uipx_path), ROTATED_SOLUTION_IDS_SIDECAR)
+    if os.path.isfile(sidecar):
+        with open(sidecar) as f:
+            for line in f:
+                rotated = line.strip()
+                if rotated and all(rotated != known for known, _ in ids):
+                    ids.append((rotated, sidecar))
+    return ids
 
 
 def _resolve_policy() -> str:
@@ -53,21 +78,19 @@ def main() -> int:
     not_uploaded: list[str] = []
     failed: list[str] = []
 
-    for path in paths:
+    targets: list[tuple[str, str]] = []
+    for uipx_path in paths:
         try:
-            with open(path) as f:
-                data = json.load(f)
+            ids = _solution_ids(uipx_path)
         except (OSError, json.JSONDecodeError) as e:
-            logger.warning("could not read %s: %s", path, e)
-            skipped.append(path)
+            logger.warning("could not read %s: %s", uipx_path, e)
+            skipped.append(uipx_path)
             continue
+        if not ids:
+            skipped.append(uipx_path)
+        targets.extend(ids)
 
-        sid = data.get("SolutionId")
-        if not sid:
-            logger.info("no SolutionId in %s, skipping", path)
-            skipped.append(path)
-            continue
-
+    for sid, path in targets:
         if policy == "never":
             logger.info(
                 "FLOW_E2E_CLEANUP=never; preserving %s (delete later with: uip solution delete %s)",

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -113,17 +113,10 @@ _INCIDENTS_TIMEOUT_SECONDS = 60
 _DEFAULT_RETRIES = 2
 _DEFAULT_BACKOFF_SECONDS = 5.0
 
-# A run that reports ``finalStatus: Completed`` but whose ``Data`` carries no
-# ``variables`` key at all did NOT produce "no outputs": the CLI's
-# post-completion GET of ``/debug-instances/{id}/variables`` failed and (before
-# UiPath/cli fixed it) the failure was reduced to a stderr warning. A flow that
-# genuinely declares no outputs still returns ``variables`` (with an empty
-# ``globals`` map), so "key absent" is exact, not heuristic. Newer CLIs keep the
-# key absent and add ``variablesError`` explaining why. Both shapes mean
-# "outputs UNREADABLE" — an infrastructure failure to retry, never a flow
-# result to grade. Observed live on coder-eval ``skill-flow-move-node`` (v2,
-# 2026-08-31 and 2026-09-01): every element Completed, ``Outputs: []``, task
-# graded as a flow defect.
+# ``finalStatus: Completed`` with NO ``variables`` key (or a ``variablesError``)
+# means the CLI's post-completion outputs fetch failed — infrastructure to retry,
+# not an empty result to grade (a flow with no outputs still returns the key).
+# Retries and the CLI-side fix: UiPath/cli#3929.
 _VARIABLES_UNREADABLE_ATTEMPTS = 2
 _STDERR_CAPTURE_TAIL_CHARS = 4000
 
@@ -143,48 +136,45 @@ _DEBUG_RETRY_MARKERS = (
 )
 
 
+def _rglob_pruned(pattern: str) -> list[str]:
+    """``glob.glob(pattern, recursive=True)`` from the CWD, but never descending
+    into ``node_modules`` (the preview workspace symlinks the baked SDK tree
+    there, and ``glob`` follows directory symlinks under ``**``)."""
+    if "**" not in pattern:
+        return sorted(glob.glob(pattern, recursive=True))
+    prefix, _, suffix = pattern.partition("**")
+    root = prefix.rstrip("/") or "."
+    suffix = suffix.lstrip("/")
+    matches: list[str] = []
+    for dirpath, dirnames, _ in os.walk(root, followlinks=True):
+        dirnames[:] = [d for d in dirnames if d != "node_modules"]
+        matches.extend(glob.glob(os.path.join(glob.escape(dirpath), suffix)))
+    if root == ".":
+        matches = [m[2:] if m.startswith("./") else m for m in matches]
+    return sorted(set(matches))
+
+
 def _output_blob(result: subprocess.CompletedProcess) -> str:
     """Both streams, lowercased, for case-insensitive marker matching."""
     return f"{result.stdout}\n{result.stderr}".lower()
 
 
-# INTERIM — Studio Web `Solution/{id}/Overwrite` regression (UiPath/cli#3938).
-#
-# Since 2026-09-02 (last known good: 2026-09-01 07:30Z) Studio Web answers
-# `400 {"code":"1001","message":"An argument had an invalid value."}` when a
-# solution that EXISTS is overwritten. `uip maestro flow debug` imports the
-# project on its first run and writes the server's solution id back into the
-# `.uipx`, so every LATER debug of the same project is an overwrite — and the
-# CLI treats any non-404 Overwrite as fatal. Result: the second seeded case of
-# every multi-case checker died at solution upload, in all three arms
-# (orchestrator_paths, escalation_slack_alert, billing_invoice_lookup,
-# decision, wiki_pageviews, canary). Reproduced on the host with two CLI
-# vintages and with `uip solution upload --force`; a fresh bundled SolutionId
-# imports as new and Completes (Slack message posted), so ONLY overwrite is
-# broken. The only earlier archived Overwrite 400 (2026-08-26) was code 20001, a
-# content error that must still fail.
-#
-# So: on exactly that signature, rotate the bundled SolutionId to a fresh uuid4
-# and retry ONCE — the retry is a new import. Self-limiting: once Overwrite
-# recovers the signature never fires and nothing here runs. Cost while it does:
-# one extra tenant solution per affected case, which `cleanup_solutions.py`
-# cannot see (it reads the `.uipx`'s CURRENT id) — the ids are printed so they
-# are not lost. The platform fix and a CLI-side fallback are asked for in the
-# issue above; delete this block when Overwrite works again.
+# INTERIM — Studio Web answers 400/1001 when an EXISTING solution is overwritten
+# (UiPath/cli#3938 has the evidence). `flow debug` #2 of a project is an
+# overwrite, so on exactly that signature the bundled SolutionId is rotated and
+# the debug retried ONCE as a new import. Delete this block when Overwrite works.
 _OVERWRITE_STUCK_ISSUE = "UiPath/cli#3938"
 _OVERWRITE_STUCK_MARKER = "overwrite failed (400)"
 _OVERWRITE_STUCK_CODE = re.compile(r'\\?"code\\?":\s*\\?"1001\\?"')
-# Since UiPath/cli#3951 (main 2026-09-02, `016231474`) the CLI reports a refused
-# upload against its stage instead of echoing the raw body:
-#   Message: "Failed during overwrite-solution: HTTP 400 on POST …/Overwrite — An argument had an invalid value."
-#   Context: {"HttpStatus": 400, "Stage": "overwrite-solution", "ErrorCode": "1001"}
-# The rotation must recognise both envelopes: an image whose CLI carries #3951
-# but whose checker knows only the legacy text fails every second debug of a
-# project with a plain `flow debug exit 1` (seen 2026-09-03 on every
-# multi-debug task of the batch-A rerun, both arms).
+# Since UiPath/cli#3951 the CLI reports the refusal as
+# Context: {"HttpStatus": 400, "Stage": "overwrite-solution", "ErrorCode": "1001"}
+# instead of echoing the raw body; both envelopes must rotate.
 _OVERWRITE_STUCK_STAGE = "overwrite-solution"
 _OVERWRITE_STUCK_ATTEMPTS = 2  # the failed overwrite + one import-as-new retry
 _SOLUTION_ID_RE = re.compile(r'("SolutionId"\s*:\s*")([0-9a-fA-F-]{36})(")')
+# Rotated-away ids, one per line, beside the `.uipx`; `cleanup_solutions.py`
+# deletes them alongside the current id so the rotation leaks nothing.
+ROTATED_SOLUTION_IDS_SIDECAR = ".rotated-solution-ids"
 
 
 def _is_overwrite_stuck(result: subprocess.CompletedProcess) -> bool:
@@ -221,7 +211,9 @@ def _rotate_solution_id(project_dir: str) -> tuple[str, str] | None:
     Walks up from ``project_dir`` to the nearest ancestor holding exactly one
     ``*.uipx`` (a JSON text file; ``uip solution init`` writes it beside the
     project directory). Returns ``(old, new)``, or ``None`` when no unambiguous
-    ``.uipx`` is found — the caller then fails the plain way."""
+    ``.uipx`` is found — the caller then fails the plain way. The previous id is
+    appended to :data:`ROTATED_SOLUTION_IDS_SIDECAR` next to the ``.uipx`` so
+    ``cleanup_solutions.py`` can delete the solution it still names on the tenant."""
     import uuid
 
     here = os.path.abspath(project_dir)
@@ -239,6 +231,9 @@ def _rotate_solution_id(project_dir: str) -> tuple[str, str] | None:
             new = str(uuid.uuid4())
             with open(uipx[0], "w", encoding="utf-8") as handle:
                 handle.write(text[: match.start(2)] + new + text[match.end(2):])
+            sidecar = os.path.join(here, ROTATED_SOLUTION_IDS_SIDECAR)
+            with open(sidecar, "a", encoding="utf-8") as handle:
+                handle.write(match.group(2) + "\n")
             return match.group(2), new
         parent = os.path.dirname(here)
         if parent == here:
@@ -483,7 +478,7 @@ def run_debug(
                 f"INTERIM ({_OVERWRITE_STUCK_ISSUE}: Studio Web Overwrite → 400/1001 for an "
                 f"existing solution since 2026-09-02): rotated the bundled SolutionId "
                 f"{rotated[0]} → {rotated[1]}; retrying as a new import. The solution "
-                f"{rotated[0]} stays on the tenant (cleanup reads only the current id).",
+                f"{rotated[0]} is recorded in {ROTATED_SOLUTION_IDS_SIDECAR} for cleanup.",
                 file=sys.stderr,
                 flush=True,
             )
@@ -1745,7 +1740,7 @@ def find_flow_files(
     Debug callers intentionally do not use this helper: ``uip maestro flow
     debug`` is project-scoped and must continue through :func:`find_project_dir`.
     """
-    project_candidates = sorted(glob.glob(project_pattern, recursive=True))
+    project_candidates = _rglob_pruned(project_pattern)
     flow_projects = [path for path in project_candidates if _is_flow_project(path)]
     root_matches = _dedupe_flow_candidates(
         sorted(glob.glob(os.path.basename(flow_glob)))
@@ -1821,7 +1816,7 @@ def assert_no_flow_files() -> None:
     tasks. It deliberately scans every location because any emitted Flow is a
     failure; there is no preferred artifact to select in the absence case.
     """
-    matches = sorted(glob.glob("**/*.flow", recursive=True))
+    matches = _rglob_pruned("**/*.flow")
     if matches:
         joined = "\n  - ".join(matches)
         _fail(f"Unexpected .flow file(s) found:\n  - {joined}")
@@ -1955,7 +1950,7 @@ def _find_project(pattern: str) -> str:
     abandoned scaffold — see :func:`_dedupe_flow_projects` and
     :func:`_split_off_scaffold_husks`. Anything else stays a refusal.
     """
-    candidates = sorted(glob.glob(pattern, recursive=True))
+    candidates = _rglob_pruned(pattern)
     if not candidates:
         _fail(f"No project.uiproj found matching {pattern}")
     flow_projects = [p for p in candidates if _is_flow_project(p)]

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -596,6 +596,27 @@ def test_find_project_fails_when_multiple_flows(tmp_path, monkeypatch):
         _find_project("**/project.uiproj")
 
 
+def test_find_project_ignores_the_staged_node_modules_symlink(tmp_path, monkeypatch):
+    """stage-preview-sdk-workspace.sh symlinks the baked SDK tree to
+    ./node_modules; `glob('**')` follows it, so a fixture .flow/.uiproj inside
+    the SDK must never become a candidate (or a false `assert_no_flow_files`)."""
+    monkeypatch.chdir(tmp_path)
+    solution = tmp_path / "Real"
+    solution.mkdir()
+    _make_proj(solution, "Real", "Flow")
+    sdk = tmp_path.parent / f"{tmp_path.name}-sdk" / "node_modules" / "@uipath" / "flow-sdk" / "fixtures"
+    sdk.mkdir(parents=True)
+    (sdk / "project.uiproj").write_text('{"ProjectType": "Flow"}')
+    (sdk / "Fixture.flow").write_text("{}")
+    os.symlink(sdk.parent.parent.parent, tmp_path / "node_modules")
+    assert _find_project("**/project.uiproj") == os.path.join("Real", "Real")
+    assert flow_check._rglob_pruned("**/*.flow") == []
+    flow_check.assert_no_flow_files()  # does not raise
+    (solution / "Real" / "Real.flow").write_text("{}")
+    with pytest.raises(SystemExit, match="Real.flow"):
+        flow_check.assert_no_flow_files()
+
+
 def test_find_project_fails_when_no_candidates(tmp_path, monkeypatch):
     """No project.uiproj at all — original failure message preserved."""
     monkeypatch.chdir(tmp_path)
@@ -1094,8 +1115,42 @@ def test_run_debug_rotates_the_solution_id_on_overwrite_1001_then_imports(monkey
     err = capsys.readouterr().err
     assert "INTERIM (UiPath/cli#3938" in err
     assert "rotated the bundled SolutionId 79cda3cb-5a10-4f37-e091-08df08c2afbe" in err
-    # The orphaned server id is named, because cleanup reads only the current one.
     assert "previous: 79cda3cb-5a10-4f37-e091-08df08c2afbe" in err
+    # The rotated-away id is recorded beside the .uipx so cleanup_solutions.py
+    # deletes the tenant solution it still names (nothing leaks).
+    sidecar = sol / flow_check.ROTATED_SOLUTION_IDS_SIDECAR
+    assert sidecar.read_text().splitlines() == ["79cda3cb-5a10-4f37-e091-08df08c2afbe"]
+
+
+def test_cleanup_solutions_deletes_rotated_ids_from_the_sidecar(monkeypatch, tmp_path):
+    """The sidecar written by the rotation is a cleanup input, not a log line."""
+    import importlib.util
+
+    sol, _ = _uipx_project(tmp_path, solution_id="11111111-1111-4111-8111-111111111111")
+    (sol / flow_check.ROTATED_SOLUTION_IDS_SIDECAR).write_text(
+        "22222222-2222-4222-8222-222222222222\n\n11111111-1111-4111-8111-111111111111\n"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "cleanup_solutions", os.path.join(os.path.dirname(flow_check.__file__), "cleanup_solutions.py")
+    )
+    cleanup = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cleanup)
+    deleted: list[str] = []
+
+    def fake_run(cmd, **kwargs):
+        deleted.append(cmd[3])
+        return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(cleanup.subprocess, "run", fake_run)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("FLOW_E2E_CLEANUP", raising=False)
+    assert cleanup.main() == 0
+    # current id + rotated id, each exactly once (the sidecar's duplicate of the
+    # current id and its blank line are ignored)
+    assert sorted(deleted) == [
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+    ]
 
 
 def test_run_debug_rotates_the_solution_id_on_the_staged_overwrite_envelope(monkeypatch, tmp_path, capsys):

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
@@ -226,19 +226,30 @@ def test_multiselect_prompt_names_slack_as_the_required_connector() -> None:
 
 def test_paginated_lookup_accepts_both_supported_resolution_routes() -> None:
     text = _task_text("connector_features/paginated_reference_lookup.yaml")
+    blocks = [block for kind, block in _criterion_blocks(text) if kind == "command_executed"]
+    manual_block, paged_block = blocks[:2]
     patterns = re.findall(r"(?m)^\s+command_pattern:\s*'([^']+)'", text)
-    resolve_pattern, pagination_pattern = map(re.compile, patterns[:2])
+    manual_pattern, paged_pattern = map(re.compile, patterns[:2])
 
-    manual_commands = (
-        "uip is resources run list uipath-salesforce-slack conversations "
-        "--connection-id id --query nextPage=token"
-    )
+    page_one = 'bash -lc "uip is resources run list \\"uipath-salesforce-slack\\" \\"conversations\\" --connection-id id"'
+    page_two = page_one[:-1] + ' --query nextPage=token"'
     sdk_command = (
-        "uip maestro flow registry prepare uipath-salesforce-slack "
+        "npx flow-sdk registry prepare uipath-salesforce-slack "
         "send-message-to-channel --resolve channel:name=simple"
     )
 
-    assert resolve_pattern.search(manual_commands)
-    assert pagination_pattern.search(manual_commands)
-    assert resolve_pattern.search(sdk_command)
-    assert pagination_pattern.search(sdk_command)
+    # The v1 route is telemetry the SDK arm never produces: advisory, but it
+    # still asks for the loop (page 1 alone is not pagination).
+    assert "min_count: 2" in manual_block and "pass_threshold: 0.0" in manual_block
+    assert manual_pattern.search(page_one) and manual_pattern.search(page_two)
+    assert not manual_pattern.search(sdk_command)
+
+    # The gating criterion needs "went past page 1" on a SUCCESSFUL command:
+    # a page-1 call, or `--resolve channel:` typed on something other than
+    # `registry prepare`, earns nothing.
+    assert "require_success: true" in paged_block and "pass_threshold: 1.0" in paged_block
+    assert paged_pattern.search(page_two)
+    assert paged_pattern.search(sdk_command)
+    assert not paged_pattern.search(page_one)
+    assert not paged_pattern.search("uip maestro flow validate --resolve channel:name=simple")
+    assert not paged_pattern.search("echo nextPage=token")

--- a/tests/tasks/uipath-maestro-flow/_shared/test_validate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_validate_flow.py
@@ -164,10 +164,17 @@ def test_budget_exhaustion_reports_instead_of_running(monkeypatch, capsys):
     assert "-0s left" not in err  # negative remainder is clamped for display
 
 
-def test_no_flow_file_fails(monkeypatch, capsys):
+def test_no_flow_file_fails(monkeypatch):
+    """`find_flow_files()` exits with its own message when nothing is found;
+    `main` has no empty-list branch of its own."""
     _stub(monkeypatch, [], flows=())
-    assert validate_flow.main() == 1
-    assert "No .flow file found" in capsys.readouterr().err
+
+    def no_flows():
+        raise SystemExit("FAIL: No Flow project found matching '**/project.uiproj'")
+
+    monkeypatch.setattr(validate_flow, "find_flow_files", no_flows)
+    with pytest.raises(SystemExit, match="No Flow project found"):
+        validate_flow.main()
 
 
 @pytest.mark.parametrize(

--- a/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
@@ -164,10 +164,7 @@ def _validate(flow: str, deadline: float, budget: int) -> int:
 
 
 def main() -> int:
-    flows = find_flow_files()
-    if not flows:
-        print("FAIL: No .flow file found", file=sys.stderr)
-        return 1
+    flows = find_flow_files()  # exits with its own message when nothing is found
 
     budget = _budget_seconds()
     deadline = time.monotonic() + max(

--- a/tests/tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-bindings-idempotent-reconfigure
 description: >
   Step 1 of the DAPField-mirrored upsert in `upsertConnectionResourceBinding`

--- a/tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-bindings-multi-connector-independence
 description: >
   Two distinct connector nodes (different connector keys) in the same flow,

--- a/tests/tasks/uipath-maestro-flow/bindings/no_duplicate_connection_bindings.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/no_duplicate_connection_bindings.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-bindings-no-duplicates
 description: >
   Regression - `uip maestro flow node configure` previously appended

--- a/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-bindings-reconfigure-different-connection
 description: >
   When the same connector node is reconfigured against a different connection,

--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-ceql-where
 description: >
   Tests the CEQL where query IS feature — agent plans a structured filter
@@ -32,7 +31,7 @@ initial_prompt: |
 
   Branch on the result: if the call fails, stop the flow immediately;
   if it succeeds, log "CeqlWhere test passed".
-  Compile the final flow file. Do not fabricate a tenant connection merely to
+  Produce the final flow file. Do not fabricate a tenant connection merely to
   make product validation pass; the generated structure and the separately
   reviewable filter are the deliverables in this offline task.
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-complex-array
 description: >
   Tests the complex array IS feature — configures the Slack

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-dtl-load-by-default-false
 description: >
   Tests the DTL loadByDefault=false IS feature — configures a connector node

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-dtl-load-by-default-true
 description: >
   Tests the DTL loadByDefault=true IS feature — configures a Jira Get Issue

--- a/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-enhanced-enum
 description: >
   Tests the enhanced enum IS feature — configures a connector node with an
@@ -19,7 +18,7 @@ initial_prompt: |
   Build a flow that retrieves WooCommerce product reviews and lets the caller 
   choose whether they come back oldest-first or newest-first, picking from friendly 
   labels rather than raw codes. Discover the get-product-reviews operation and set 
-  its sort-order field. Compile the final flow file.
+  its sort-order field. Produce the final flow file.
   If the WooCommerce operation exists in the registry but the tenant has no
   live connection, keep the real WooCommerce operation node with its inputs left unset
   and stop there. Do not fabricate a tenant connection merely to make product

--- a/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-enum
 description: >
   Tests the enum IS feature — configures a connector node with an enum

--- a/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-generic-dynamic-node
 description: >
   Connector feature: validate a generic (dynamic) connector node end-to-end. A

--- a/tests/tasks/uipath-maestro-flow/connector_features/jdbc_databricks_query/jdbc_databricks_query.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/jdbc_databricks_query/jdbc_databricks_query.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # Tenant-gated. Requires the Databricks-backed Database Hub (JDBC)
 # connection in the runner tenant, reaching the sandbox.globalmart schema whose
 # `employees` table is seeded with the fixture rows this task asserts on (Alice

--- a/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-multiselect
 description: >
   Tests the multiselect IS feature — configures a Slack group direct message

--- a/tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/non_catalog_http_fallback.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/non_catalog_http_fallback.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-non-catalog-http-fallback
 description: >
   Integration test: a NON-catalog service (Spotify) has no IS connector of its

--- a/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
@@ -38,22 +38,28 @@ initial_prompt: |
   planning and implementation. Build the complete flow end-to-end in a single pass.
 
 success_criteria:
-# TWO ROUTES ARE CORRECT, and these criteria accept either. Manual discovery
-# may expose the channel collection as `conversations` or `curated_channels`;
-# the final artifact criterion below is the authority on the resolved id.
+# TWO ROUTES ARE CORRECT: the live-v1 loop pages `uip is resources run list`
+# by hand (the collection may be exposed as `conversations` or
+# `curated_channels`); the SDK route resolves the name inside
+# `npx flow-sdk registry prepare … --resolve channel:`. The first criterion is
+# v1-route telemetry and is advisory (the SDK arm never runs it); the second
+# gates on "went past page 1" for either route and only counts a command that
+# succeeded — typing the flag on a failing command does not page. The final
+# artifact criterion (resolved id C083AN4E61E) stays the authority.
   - type: command_executed
-    description: "Agent resolved the channel through the library — either a paged Slack channel-resource loop or `registry prepare --resolve`"
+    description: "Advisory (live-v1 route): paged Slack channel-resource loop ran more than once"
     tool_name: "Bash"
-    command_pattern: '(uip\s+is\s+resources\s+run\s+list\s+\\?"?uipath-salesforce-slack\\?"?\s+\\?"?(curated_channels|conversations)|registry\s+prepare\s+\\?"?uipath-salesforce-slack)'
-    min_count: 1
+    command_pattern: 'uip\s+is\s+resources\s+run\s+list\s+\\?"?uipath-salesforce-slack\\?"?\s+\\?"?(curated_channels|conversations)'
+    min_count: 2
     weight: 3.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Agent went past page 1 — `nextPage=<token>` by hand, or `--resolve channel:` which pages inside `prepare`"
+    description: "Agent went past page 1 — a channel-resource list call carrying `nextPage=<token>`, or `registry prepare … --resolve channel:` which pages inside `prepare`"
     tool_name: "Bash"
-    command_pattern: '(nextPage=|--resolve\s+\\?"?channel:)'
+    command_pattern: '(uip\s+is\s+resources\s+run\s+list\s+\\?"?uipath-salesforce-slack\\?"?\s+\\?"?(curated_channels|conversations)[^\n]*nextPage=|registry\s+prepare\s+\\?"?uipath-salesforce-slack\\?"?[^\n]*--resolve\s+\\?"?channel:)'
     min_count: 1
+    require_success: true
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-path-params
 description: >
   Tests the path parameters IS feature — configures a connector node with a

--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-query-params
 description: >
   Tests the query parameters IS feature — configures a connector node with a

--- a/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-searchable-joins
 description: >
   Tests the searchable joins IS feature — configures a connector node with

--- a/tests/tasks/uipath-maestro-flow/connector_features/slack-http-fallback/slack_http_fallback.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/slack-http-fallback/slack_http_fallback.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-slack-http-fallback
 description: >
   E2E test: a catalog connector (Slack, uipath-salesforce-slack) has no native

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_attachments/testmanager_attachments.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_attachments/testmanager_attachments.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # skip:true, tenant-gated. CONFIRMED available in Maestro Flow (2026-06-16):
 # `uip maestro flow registry pull` then search returns the
 # uipath.connector.uipath-uipath-testmanager.<op> nodes for this object group. A stale manifest

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_crud_grounded/testmanager_crud_grounded.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_crud_grounded/testmanager_crud_grounded.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # PROTOTYPE — data-grounded on the Maestro Flow surface. skip:true.
 # Agent builds a flow (create-test-case node -> get-test-case node -> output the
 # retrieved name) and EXECUTES it (`uip maestro flow debug`) to produce the

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_execution_results/testmanager_execution_results.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_execution_results/testmanager_execution_results.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # skip:true, tenant-gated. CONFIRMED available in Maestro Flow (2026-06-16):
 # `uip maestro flow registry pull` then search returns the
 # uipath.connector.uipath-uipath-testmanager.<op> nodes for this object group. A stale manifest

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_generic_records/testmanager_generic_records.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_generic_records/testmanager_generic_records.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # skip:true, tenant-gated. CONFIRMED available in Maestro Flow (2026-06-16):
 # `uip maestro flow registry pull` then search returns the
 # uipath.connector.uipath-uipath-testmanager.<op> nodes for this object group. A stale manifest

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_requirement_lifecycle/testmanager_requirement_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_requirement_lifecycle/testmanager_requirement_lifecycle.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # skip:true, tenant-gated. CONFIRMED available in Maestro Flow (2026-06-16):
 # `uip maestro flow registry pull` then search returns the
 # uipath.connector.uipath-uipath-testmanager.<op> nodes for this object group. A stale manifest

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_testcase_lifecycle/testmanager_testcase_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_testcase_lifecycle/testmanager_testcase_lifecycle.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # skip:true, tenant-gated. CONFIRMED available in Maestro Flow (2026-06-16):
 # `uip maestro flow registry pull` then search returns the
 # uipath.connector.uipath-uipath-testmanager.<op> nodes for this object group. A stale manifest

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_testset_lifecycle/testmanager_testset_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_testset_lifecycle/testmanager_testset_lifecycle.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # skip:true, tenant-gated. CONFIRMED available in Maestro Flow (2026-06-16):
 # `uip maestro flow registry pull` then search returns the
 # uipath.connector.uipath-uipath-testmanager.<op> nodes for this object group. A stale manifest

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/trigger_with_filter.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/trigger_with_filter.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-trigger-with-filter
 description: >
   Verifies that the uipath-maestro-flow skill teaches agents to emit a structured `filter` tree.

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/webhook_waitfor_parallel.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/webhook_waitfor_parallel.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-webhook-waitfor-parallel
 description: >
   E2E self-testing flow: a manual start trigger fans out into two parallel

--- a/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/batch_transform.yaml
+++ b/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/batch_transform.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-batch-transform
 description: >
   Create a UiPath Flow that runs a Batch Transform pattern node over a CSV

--- a/tests/tasks/uipath-maestro-flow/context-grounding/summarize/summarize.yaml
+++ b/tests/tasks/uipath-maestro-flow/context-grounding/summarize/summarize.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-summarize
 description: >
   Create a UiPath Flow that runs a Summarize pattern node (`uipath.pattern.deep-rag`)

--- a/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-e2e-devcon-expense-approval
 description: >
   DevCon end-to-end scenario: developer gives a vague expense approval requirement.

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/jira_create_issue.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/jira_create_issue.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-jira-create-issue
 description: >
   E2E live Jira coverage — builds a Flow with a manual trigger and an

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_get_issue/jira_get_issue.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_get_issue/jira_get_issue.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-jira-get-issue
 description: >
   E2E live Jira coverage — builds a Flow with a manual trigger and an Atlassian

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_lifecycle/jira_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_lifecycle/jira_lifecycle.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-jira-lifecycle
 description: >
   E2E live Jira coverage of a composite loop-and-switch flow. The agent builds

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_search_triage/jira_search_triage.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_search_triage/jira_search_triage.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-jira-search-triage
 description: >
   E2E live Jira coverage of a JQL-search-driven triage flow: a manual-trigger

--- a/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-add-node
 description: >
   Add a script node to an existing BellevueWeather flow that converts the

--- a/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-add-output
 description: >
   Add a "location" field to the end node outputs in the BellevueWeather flow.

--- a/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-group-to-subflow
 description: >
   Extract the getWeather HTTP node and formatSummary Script node into a subflow

--- a/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-move-node
 description: >
   Move the decision node before formatSummary so both branches merge back into

--- a/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-remove-node
 description: >
   Remove the formatSummary script node from the BellevueWeather flow and rewire

--- a/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-update-node
 description: >
   Edit an existing Bellevue-weather flow: rewrite the decision-branch script

--- a/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-eval-evaluator-type-choice
 description: >
   Smoke test: agent is given three evaluation goals and must pick the correct

--- a/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/inline_agent_eval.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/inline_agent_eval.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-eval-inline-agent
 description: >
   Skill-guided evaluation: agent uses the uipath-maestro-flow skill to build a

--- a/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-eval-local-crud
 description: >
   Skill-guided evaluation: agent uses the uipath-maestro-flow skill's evaluate

--- a/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-eval-no-auto-upload
 description: >
   Smoke test (anti-pattern guard): agent is asked to "make the eval run work"

--- a/tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-eval-simulation-crud
 description: >
   Skill-guided simulation CRUD: agent uses the uipath-maestro-flow skill's

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-quality-schema-design
 description: >
   Quality test: agent correctly maps a business description to a quickform

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-quality-result-downstream
 description: >
   Quality test: agent correctly references the HITL node's output via

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-quality-boolean-decision
 description: >
   Quality test: agent correctly wires a boolean HITL output field into a

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-quality-brownfield-insert
 description: >
   Quality test: agent inserts a HITL node into an existing flow without

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-smoke-node-placed
 description: >
   Smoke test: agent builds a simple invoice approval flow containing an inline

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-smoke-completed-port
 description: >
   Smoke test: agent wires the HITL node's `outcome-completed` output port

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-smoke-multi-outcome-routing
 description: >
   Smoke test: agent builds a flow where a Decision node reads the HITL

--- a/tests/tasks/uipath-maestro-flow/interactive/bellevue_weather_simulated/bellevue_weather_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/bellevue_weather_simulated/bellevue_weather_simulated.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-bellevue-weather-simulated
 description: >
   Bellevue weather flow (HTTP → script → decision), but driven by a simulated

--- a/tests/tasks/uipath-maestro-flow/interactive/cli_dice_roller_simulated/cli_dice_roller_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/cli_dice_roller_simulated/cli_dice_roller_simulated.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-cli-dice-roller-simulated
 description: >
   Dice-roller flow in interactive mode, driven by a simulated non-technical user

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_simulated/customer_escalation_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_simulated/customer_escalation_simulated.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-customer-escalation-simulated
 description: >
   Multi-branch Outlook→classify→decision escalation flow, but driven by a

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-interactive-customer-escalation-triage
 description: >
   Interactive end-to-end Flow evaluation. A simulated support-operations

--- a/tests/tasks/uipath-maestro-flow/interactive/expense_approval_simulated/expense_approval_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/expense_approval_simulated/expense_approval_simulated.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-expense-approval-simulated
 description: >
   Expense-approval flow with an inline HITL review step (trigger → script →

--- a/tests/tasks/uipath-maestro-flow/interactive/hitl_schema_design_simulated/hitl_schema_design_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/hitl_schema_design_simulated/hitl_schema_design_simulated.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-schema-design-simulated
 description: >
   Purchase-order review flow with an inline HITL quickform (trigger → script →

--- a/tests/tasks/uipath-maestro-flow/interactive/ixp_invoice_extraction_simulated/ixp_invoice_extraction_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/ixp_invoice_extraction_simulated/ixp_invoice_extraction_simulated.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-invoice-extraction-simulated
 description: >
   Invoice-processing flow (SharePoint trigger → IxP extraction → HTTP POST to

--- a/tests/tasks/uipath-maestro-flow/interactive/slack_channel_description_simulated/slack_channel_description_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/slack_channel_description_simulated/slack_channel_description_simulated.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-slack-channel-description-simulated
 description: >
   Single-connector Slack flow (read a channel's description and output it),

--- a/tests/tasks/uipath-maestro-flow/interactive/solution_select.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/solution_select.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-solution-select-ask
 description: >
   Interactive-mode variant of init-validate. The working directory already

--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-e2e-project-selection
 description: >
   E2E (project selection): on a tenant where the demo IxP project set is

--- a/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-integration-handle-routing
 description: >
   Integration: IxP extraction wired into a Decision node that routes on a

--- a/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-routing
 description: >
   IxP routing (positive) — document-extraction build prompts fanned out via

--- a/tests/tasks/uipath-maestro-flow/ixp/routing_listing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing_listing.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-routing-listing
 description: >
   IxP listing routing — user asks what IxP models / runtime projects are

--- a/tests/tasks/uipath-maestro-flow/ixp/routing_negative.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing_negative.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-routing-negative
 description: >
   Negative IxP routing — verifies the agent does NOT add a uipath.ixp.*

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-scaffold-minimal
 description: >
   Integration: minimal scaffold — manual trigger → IxP extract → script (logs "ok")

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-scaffold-multinode
 description: >
   Integration: multi-script fan-out from an IxP extraction — manual trigger →

--- a/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/bellevue_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/bellevue_weather.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-bellevue-weather
 description: >
   Create a UiPath Flow that fetches today's weather in Bellevue from open-meteo,

--- a/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-calculator
 description: >
   Create a UiPath Flow that takes two number inputs and calculates their product

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-customer-escalation
 description: >
   Complex multi-branch escalation flow: Outlook email-received trigger →

--- a/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/dice_roller.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/dice_roller.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-dice-roller
 description: >
   Create a UiPath Flow from scratch that simulates rolling a fair six-sided die.

--- a/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/feet_inches.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/feet_inches.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-feet-inches
 description: >
   Create a UiPath Flow that converts a value between feet and inches based on

--- a/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/loop_multiply.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/loop_multiply.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-loop-multiply
 description: >
   Create a UiPath Flow that uses a Loop node to multiply the numbers

--- a/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-multi-city-weather
 description: >
   Loop over 3 cities, fetch weather from open-meteo for each, classify warm/cold

--- a/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-reading-list
 description: >
   Create a UiPath Flow that curates a reading list from a catalog of math/ML/stats

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-slack-channel-description
 description: >
   Create a UiPath Flow that uses the Slack IS connector to retrieve the

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-slack-weather-pipeline
 description: >
   Multi-step pipeline: read Slack channel description, extract city with a script,

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-wiki-pageviews
 description: >
   Create a UiPath Flow that fetches a range of Wikipedia pageviews, keeps

--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-api-workflow
 description: >
   Create a UiPath Flow that invokes the name-to-age API workflow with the

--- a/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-decision
 description: >
   Create a UiPath Flow that takes a temperature in Fahrenheit and uses a Decision

--- a/tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-delay
 description: >
   Create a UiPath Flow with a single OOTB Delay node (`core.logic.delay`)

--- a/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-file-attachment-debug
 description: >
   Build a Flow whose trigger exposes a file-typed input variable, read the

--- a/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-lowcode-agent
 description: >
   Create a UiPath Flow that wires in the existing CountLetters low-code agent

--- a/tests/tasks/uipath-maestro-flow/single_node/openmeteo_weather/openmeteo_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/openmeteo_weather/openmeteo_weather.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-openmeteo-weather
 description: >
   End-to-end: build a Flow whose process fetches the CURRENT weather in Bellevue

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-outlook-trigger-inbox
 description: >
   Regression test for PR #348: verifies the agent freshly resolves the

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/outlook_waitfor_email.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/outlook_waitfor_email.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-outlook-waitfor-email
 description: >
   Build-and-validate: a Flow with a manual start trigger, a mid-flow

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-rpa
 description: >
   Create a UiPath Flow that uses the HelpDeskLookup RPA workflow to retrieve

--- a/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-subflow
 description: >
   Create a UiPath Flow that uses a Subflow node to encapsulate string-reversal

--- a/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-switch
 description: >
   Create a UiPath Flow that takes a quarter number (1-4) and uses a Switch node

--- a/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-terminate
 description: >
   Create a UiPath Flow with two parallel branches from the trigger. One branch

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-transform-filter
 description: >
   Create a UiPath Flow that uses a dedicated `core.action.transform.filter`

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-transform-group-by
 description: >
   Create a UiPath Flow with a single Group By transform node

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-transform-map
 description: >
   Smoke test: agent builds a pure-OOTB UiPath Flow with a single

--- a/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-init-validate
 description: >
   Skill-guided evaluation: agent creates a new UiPath Flow project and

--- a/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-inline-agent-robust
 description: >
   Skill-guided evaluation: agent uses the uipath-maestro-flow skill to build a

--- a/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-merge-parallel-sync
 description: >
   Build a UiPath Flow with two parallel branches that fork from the trigger and

--- a/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-registry-discovery
 description: >
   Skill-guided evaluation: agent uses the uipath-maestro-flow skill to explore

--- a/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
@@ -1,7 +1,6 @@
 # Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
 # v1-base prompt, outcome-graded criteria at preserved weights, and
 # arm-agnostic artifact discovery.
-# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-scheduled-trigger
 description: >
   Scaffold a UiPath Flow whose start node is a Scheduled Trigger


### PR DESCRIPTION
## Why

rockymadden's review on #2756 (changes requested) raised four majors, five minors and five nits. This PR lands the code side on the campaign branch; the #2756 body rewrite and the per-item response follow once this merges.

## What changed

- **MAJOR 1** `paginated_reference_lookup.yaml`: the v1 paged-loop telemetry is advisory again at `min_count: 2`; the gating criterion requires "went past page 1" on a **successful** command for either route (`… list … nextPage=` or `registry prepare … --resolve channel:`). The corpus test uses the real `npx flow-sdk registry prepare` form (the `uip maestro flow registry prepare` sample was a phantom verb) and adds negative cases: page-1-only, `--resolve channel:` on another command, bare `nextPage=`.
- **MAJOR 3** Overwrite rotation: `_rotate_solution_id` appends the rotated-away id to `.rotated-solution-ids` beside the `.uipx`; `cleanup_solutions.py` deletes those ids alongside the current one. Unit tests cover the write and the read.
- **MAJOR 2** SKILL.md prose casing `bpmn:ServiceTask` matches the template. The template itself is unchanged (it is byte-equal to the CLI's own `packages/maestro-sdk/src/manifest/bpmn-spec.json`; see the #2756 response).
- **MINOR 5** `ceql_where` / `enhanced_enum` prompts say "Produce the final flow file" — neither `validate` nor `compile` is graded there.
- **MINOR 7** the 99 campaign headers drop the workspaces-only plan path; the three decisions stay inline.
- **MINOR 8** `wiki_pageviews` anchors `operate.json` to the discovered `.bpmn`'s parent.
- **MINOR 9** the three cwd-rooted `**` scans in `flow_check.py` go through `_rglob_pruned`, which never descends into `node_modules`; test with a symlinked fixture tree holding a `.flow` and a `project.uiproj`.
- **Nits**: `stage_shared.sh` compares realpaths; `validate_flow.py` dead `if not flows` removed (its test now asserts the real exit path); `case_check.py:66` wrapped; Dockerfile drops `FLOW_SDK_CONNECTORS_DIR` and the empty-dir fallback (nothing reads it: not the SDK, not the stage script, not the workflows); CODEOWNERS `a7868335f` reverted here so it can land as its own one-line PR.
- `run-coder-eval.yml` passes `--build-arg FLOW_SDK_VERSION="${{ vars.FLOW_SDK_VERSION || 'latest' }}"`, mirroring `CLI_VERSION`.
- Comment blocks over `_OVERWRITE_STUCK` / `_VARIABLES_UNREADABLE` trimmed to what a maintainer needs; the evidence tables live in UiPath/cli#3938 and UiPath/cli#3929.

## Verification

- `tests/tasks/uipath-maestro-flow`: 1147 passed (was 1145; two new tests, one rewritten)
- `tests/tasks/uipath-maestro-bpmn`: 10 passed; `tests/tasks/uipath-maestro-case`: 167 passed, 14 skipped; `tests/scripts`: 79 passed, 26 skipped
- `coder-eval plan` on the pagination task: valid; `check-cli-verbs.py`: clean (pattern skipped as dynamic, as before)
- `STAGE_SHARED_ROOT=tests/tasks/../../etc` is now refused by the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UauCCMBpJ7ws1meQwBfYSS