### PR TITLE
chore(codeowners): preview uipath-maestro-case owned by @UiPath/maestro-cli-team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,7 +19,7 @@
 
 # preview skills
 /preview/uipath-maestro-flow/ @UiPath/maestro-cli-team
-/preview/uipath-maestro-case/ @dmetzgar @tmatup
+/preview/uipath-maestro-case/ @UiPath/maestro-cli-team
 /preview/uipath-maestro-bpmn/ @UiPath/maestro-cli-team
 
 # Activity references (bundled inside uipath-rpa skill)


### PR DESCRIPTION
Moves `/preview/uipath-maestro-case/` from `@dmetzgar @tmatup` to `@UiPath/maestro-cli-team`, matching the other two preview skills. Split out of #2756 on review request so the owner change carries its own sign-off (@dmetzgar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UauCCMBpJ7ws1meQwBfYSS
