### PR TITLE
feat(cve-findings): add skill for querying MER CVE findings

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -189,6 +189,8 @@
 /tests/tasks/uipath-mcp-servers/ @cristipufu @UiPath/team-coded-agents
 
 # Insights skill (job monitoring and analytics)
+/skills/uipath-cve-findings/ @rahul-sharma-uipath
+/tests/tasks/uipath-cve-findings/ @rahul-sharma-uipath
 /skills/uipath-insights/ @UiPath/insights
 /tests/tasks/uipath-insights/ @UiPath/insights
 /tests/tasks/activation/uipath-insights.jsonl @UiPath/insights

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -190,6 +190,8 @@
 /tests/tasks/uipath-mcp-servers/ @cristipufu @UiPath/team-coded-agents
 
 # Insights skill (job monitoring and analytics)
+/skills/uipath-cve-findings/ @rahul-sharma-uipath
+/tests/tasks/uipath-cve-findings/ @rahul-sharma-uipath
 /skills/uipath-insights/ @UiPath/insights
 /tests/tasks/uipath-insights/ @UiPath/insights
 /tests/tasks/activation/uipath-insights.jsonl @UiPath/insights

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | `uipath-automationhub` | In-development |
 | `uipath-coded-apps` | Preview |
 | `uipath-connector-builder` | In-development |
+| `uipath-cve-findings` | In-development |
 | `uipath-feedback` | Stable |
 | `uipath-functions` | Preview |
 | `uipath-governance` | In-development |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | `uipath-automationhub` | In-development |
 | `uipath-coded-apps` | Preview |
 | `uipath-connector-builder` | In-development |
+| `uipath-cve-findings` | Preview |
 | `uipath-feedback` | Stable |
 | `uipath-functions` | Preview |
 | `uipath-governance` | In-development |

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -81,6 +81,14 @@
       },
       "last_synced": null
     },
+    "uipath-cve-findings": {
+      "status": "in-development",
+      "confluence": {
+        "page_id": null,
+        "url": null
+      },
+      "last_synced": null
+    },
     "uipath-feedback": {
       "status": "stable",
       "confluence": {

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -81,6 +81,14 @@
       },
       "last_synced": null
     },
+    "uipath-cve-findings": {
+      "status": "preview",
+      "confluence": {
+        "page_id": null,
+        "url": null
+      },
+      "last_synced": null
+    },
     "uipath-feedback": {
       "status": "stable",
       "confluence": {

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -33,22 +33,26 @@
       "title": "Platform & Operations",
       "description": "Operate the platform via the uip CLI: Orchestrator, Integration Service, Data Fabric, Admin, source control and CI/CD pipelines, governance, testing, tasks, analytics, and MCP servers.",
       "skills": [
-        "uipath-platform",
         "uipath-admin",
         "uipath-aops",
-        "uipath-test",
+        "uipath-automationhub",
+        "uipath-cve-findings",
         "uipath-governance",
         "uipath-insights",
+        "uipath-mcp-servers",
+        "uipath-platform",
         "uipath-process-mining",
         "uipath-tasks",
-        "uipath-mcp-servers",
-        "uipath-automationhub"
+        "uipath-test"
       ]
     },
     {
       "title": "Diagnostics & Feedback",
       "description": "Investigate failures across any UiPath product and send bug reports or improvement suggestions to the team.",
-      "skills": ["uipath-troubleshoot", "uipath-feedback"]
+      "skills": [
+        "uipath-feedback",
+        "uipath-troubleshoot"
+      ]
     }
   ]
 }

--- a/skills/uipath-cve-findings/SKILL.md
+++ b/skills/uipath-cve-findings/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: uipath-cve-findings
+description: "UiPath MER CVE findings via the read-only `/api/v1/cve-findings` HTTP API — vulnerabilities, SLA breaches, and remediation targets per product, service, image, component, or owner. Resolves people and services to their exact filter dimension before querying, so a wrong guess is never reported as zero findings. Reports installed vs fixed versions and groups findings by container image. Read-only: it cannot request exceptions, set committed fix dates, or edit findings. For UiPath job failures and automation health→uipath-insights, root-cause debugging of a specific runtime error→uipath-troubleshoot."
+when_to_use: "User asks about CVEs, vulnerabilities, security findings, or SLA breaches for a UiPath product, service, team, image, or person. Phrasings include 'CVEs on <service>', 'what's out of SLA', 'how many criticals', 'what does <person> own', 'which CVEs are in <image>', 'what version fixes this', 'FedRAMP vulnerabilities', 'overdue security findings', 'MER security dashboard'. NOT for non-UiPath CVE lookups, general CVE severity research, patching or deploying a fix, or requesting a release exception."
+allowed-tools: Bash, Read
+---
+
+# UiPath MER CVE findings
+
+Query `$MER_API/api/v1/cve-findings` — the same data the MER Security
+Dashboard shows. Read-only.
+
+> **TEMPORARY local override:** `$MER_API` defaults to `http://localhost:3000`
+> (local dev server) instead of `https://mer.uipath.com`. To restore the
+> production default, change the `export` below back to `https://mer.uipath.com`
+> — or `cp SKILL.md.prod-default.bak SKILL.md` in this skill directory.
+
+Every command below reads `$MER_API` so the same recipes work against a local
+dev server or a deployment slot:
+
+```bash
+export MER_API="${MER_API:-http://localhost:3000}"   # TEMPORARY: was https://mer.uipath.com
+```
+
+## When to Use This Skill
+
+- How many CVEs, or which ones, affect a product, service, image, or component
+- What is out of SLA, how overdue, and what fixes it
+- What a person owns and its security posture
+- Which findings live in FedRAMP, AS, Commercial Cloud, or another environment
+- Which image a finding sits in, and whether several findings share one image
+
+## Critical Rules
+
+1. **Never guess a filter value — resolve it first.** A wrong parameter returns
+   `200` with `{"total":0}`, which reads as *"no findings"* when it means
+   *"wrong parameter"*. For a security question that silent zero is the worst
+   possible answer. Always fetch `/api/v1/cve-filter-options` and match the
+   user's terms against it before building a query. A term absent from it is not
+   automatically invalid — five dimensions are free text and deliberately
+   unlisted, so check the table below before rejecting one.
+
+2. **Report a zero only after re-verifying.** If a query returns zero rows, say
+   you are re-checking the dimension and spelling, then confirm with a control
+   query that the same filters return rows for a known-good value. "Verified
+   zero" and "wrong query" are different answers.
+
+3. **Supply one filter from each group, or the API returns `400`.** Group A is
+   ownership and scope: `l3s` `l4s` `serviceOwners` `productNames`
+   `serviceNames` `environments` `releaseContexts` `cus`. Group B is
+   vulnerability and component: `severities` `slaStatuses` `cves` `cvssMin`
+   `cvssMax` `exceptionApproved` `exceptionTickets` `imageNames`
+   `componentNames` `componentVersions`.
+
+4. **Repeat a parameter for multiple values; never comma-separate.** Manager and
+   owner names contain commas (`"Doe, John"`), so splitting on one invents
+   people who do not exist. Use `--data-urlencode "severities=High"
+   --data-urlencode "severities=Critical"`.
+
+5. **Always `curl -G --data-urlencode ... --fail-with-body`.** Values such as
+   `OUT OF SLA` contain spaces, and without `--fail-with-body` a `400` writes an
+   empty file and exits `0` — a silent failure that looks like an empty result.
+
+6. **Distinguish findings from distinct CVEs.** The same CVE appears once per
+   affected image and component version. Report both counts when they differ;
+   `X-Total-Rows` is findings, not unique CVEs.
+
+7. **`ComponentVersion` is installed and vulnerable; `FixedVersions` is the
+   target.** Never present one as the other — the user usually needs both to
+   plan the fix.
+
+8. **Respect `$MER_API` if it is set.** It points at a local dev server or a
+   slot instead of production. Never rewrite a URL the user gave you back to
+   `mer.uipath.com` — and never hard-code `mer.uipath.com` when `$MER_API` is
+   set. It currently defaults to `http://localhost:3000` (temporary).
+
+9. **Fetch once, then filter locally.** Every call is a live query against one
+   shared service principal with no rate limiting. Pull a superset into a file
+   and slice it with `jq` rather than issuing a request per question.
+
+## Workflow
+
+### 1. Get a token
+
+```bash
+export MER_TOKEN=$(az account get-access-token \
+  --resource api://6206766d-e890-4f6d-956f-851ca128626d \
+  --query accessToken -o tsv)
+```
+
+Any identity in the UiPath tenant works — a person after `az login`, or a
+pipeline's own service principal. Tokens last about an hour; on `401`, re-run.
+
+### 2. Resolve every term the user named
+
+```bash
+curl -sS -H "Authorization: Bearer $MER_TOKEN" \
+  "$MER_API/api/v1/cve-filter-options" -o /tmp/opts.json
+
+python3 -c "
+import json,sys
+d=json.load(open('/tmp/opts.json')); term=sys.argv[1].lower()
+for k,v in d.items():
+    hits=[x for x in v if term in str(x).lower()]
+    if hits: print(k, '->', hits[:5])
+" "Sam Nuziale"
+```
+
+This prints the parameter name and the exact spelling. Real examples of why it
+matters: `Sam Nuziale` resolves to `l4s`, not `l3s`; `Experiences` resolves to
+`serviceNames`, and its product is `Cloud Platform`.
+
+A term can land in two dimensions — `Orchestrator` is both a `productNames` and
+a `serviceNames` value. Prefer the broader one unless the user clearly meant a
+single service, and say which you chose; the counts differ.
+
+The response is keyed by the **same parameter names** the findings API accepts,
+so a value goes straight back into a query:
+
+```json
+{ "l3s": [...], "l4s": [...], "serviceOwners": [...], "productNames": [...],
+  "serviceNames": [...], "environments": [...], "releaseContexts": ["24.10","25.10"],
+  "cus": [...], "severities": [...], "slaStatuses": [...], "exceptionApproved": [...] }
+```
+
+Eleven dimensions, listed because their value sets are bounded. Five filter
+parameters are **not** listed because they are free text:
+
+| Not in filter-options | Why | How to handle |
+|---|---|---|
+| `cves` | any CVE / GHSA id | use the id the user gave |
+| `imageNames` | any image name | use it verbatim; confirm from a findings result |
+| `componentNames` | any package name | same |
+| `componentVersions` | any version string | same |
+| `exceptionTickets` | any ticket key | same |
+
+So "not found in filter-options" means *invalid* for a person, product, service,
+environment, release context, CU, severity or SLA status — and means nothing at
+all for the five above. Values carry the same release-context filtering as the
+findings query, so this endpoint cannot advertise something the API will not
+return.
+
+### 3. Query and format
+
+```bash
+curl -sS --fail-with-body -G "$MER_API/api/v1/cve-findings" \
+  -H "Authorization: Bearer $MER_TOKEN" \
+  --data-urlencode "serviceNames=Experiences" \
+  --data-urlencode "environments=FedRAMP" \
+  --data-urlencode "severities=High" \
+  --data-urlencode "slaStatuses=OUT OF SLA" \
+  -o /tmp/findings.ndjson
+
+tail -n +2 /tmp/findings.ndjson \
+| jq -r 'def d: if . == null or . == "" then "-" else tostring end;
+         [(.CVE|d), (.CVSS|d), (.ImageNameWithTag|d), (.ComponentName|d),
+          (.ComponentVersion|d), (.FixedVersions|d), (.SLADaysLeft|d)] | @tsv' \
+| sort -t$'\t' -k2,2rn \
+| { printf 'CVE\tCVSS\tIMAGE\tCOMPONENT\tINSTALLED\tFIXED_IN\tDAYS\n'; cat; } \
+| column -t -s $'\t'
+```
+
+The `def d:` guard matters. Some findings carry an empty `CVE` (GHAS secret
+scanning) or an empty `FixedVersions` (no fix published). `column -t` collapses
+consecutive tabs, so an unguarded empty field silently shifts every later column
+left and the row reads as if it belongs to a different CVE.
+
+The response is NDJSON: a `{total, columns}` header line, then one object per
+finding — so `tail -n +2` drops the header. Row count is also on the
+`X-Total-Rows` response header.
+
+## Reading the Result
+
+- `SLADaysLeft` is **negative** when past deadline. −155 is far worse than −9.
+- Group by `ImageNameWithTag` before proposing work. Findings sharing one image
+  are usually **one rebuild**, not N separate fixes.
+- Check whether a fix is a patch bump or a major version jump — the second needs
+  a decision, not a dependency refresh.
+- OS packages (`glibc`, `openssl-libs`, `dotnet-*`) clustering on one image
+  usually means a base-image refresh, not per-package work.
+
+## Data Traps
+
+- **`Moderate` occurs only in FedRAMP**, where it is the impact level rather
+  than a synonym for Medium. `severities=Medium` is complete everywhere else;
+  do not query both.
+- **FedRAMP rows carry an empty Release Context.** Adding `releaseContexts=…`
+  silently drops every FedRAMP row. Omit it when asking about FedRAMP.
+- **Only `24.10` and `25.10` are reachable.** Older contexts exist in the source
+  table but the API filters them out, so they return zero.
+- **The source table is replaced wholesale on each rebuild.** Counts can change
+  between runs, and a dashboard page left open shows stale numbers with no
+  indication. Re-query rather than trusting an earlier figure.
+
+## Anti-patterns
+
+- **Do not report `{"total":0}` as "no findings"** without re-verifying the
+  dimension. This is the single most likely way to give a wrong answer.
+- **Do not comma-separate values.** `severities=High,Critical` matches nothing.
+- **Do not poll or loop.** One broad fetch, then `jq`.
+- **Do not hard-code value lists** from documentation. Read them from
+  `/api/v1/cve-filter-options`, which derives them from the data.
+- **Do not add `releaseContexts` "to be safe."** It excludes all FedRAMP rows.
+- **Do not treat row count as CVE count.** They differ, often by 3–5×.
+- **Do not attempt writes.** This API is read-only; exceptions and committed fix
+  dates are dashboard actions.
+
+## Status Codes
+
+| Code | Meaning |
+|------|---------|
+| `200` | NDJSON stream |
+| `400` | A filter group is missing — the body names the valid parameters |
+| `401` | No credential, or an expired token — re-run the token command |
+| `403` | Token issued by another tenant |
+| `413` | Over the 50,000-row cap. `cves`, `componentNames` and `componentVersions` narrow hardest; `environments` and `severities` barely narrow |
+| `502` | Upstream query failed |
+
+## Completion Output
+
+Lead with the number the user asked for, and state findings versus distinct CVEs
+when they differ. Then, when useful: the most overdue item, whether the findings
+collapse to a single image, and whether any fix is a major version jump. Say
+plainly when a filter returned zero and you verified it — that is a real answer.

--- a/skills/uipath-cve-findings/SKILL.md
+++ b/skills/uipath-cve-findings/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: uipath-cve-findings
+description: "UiPath MER CVE findings via the read-only `/api/v1/cve-findings` HTTP API — vulnerabilities, SLA breaches, and remediation targets per product, service, image, component, or owner. Resolves people and services to their exact filter dimension before querying, so a wrong guess is never reported as zero findings. Reports installed vs fixed versions, AGOV and Secure Base Image (SBI) remediation state, and groups findings by container image. Read-only: it cannot request exceptions, set committed fix dates, or edit findings. For UiPath job failures and automation health→uipath-insights, root-cause debugging of a specific runtime error→uipath-troubleshoot."
+when_to_use: "User asks about CVEs, vulnerabilities, security findings, or SLA breaches for a UiPath product, service, team, image, or person. Phrasings include 'CVEs on <service>', 'what's out of SLA', 'how many criticals', 'what does <person> own', 'which CVEs are in <image>', 'what version fixes this', 'FedRAMP vulnerabilities', 'overdue security findings', 'MER security dashboard', 'is it fixed in AGOV', 'fixed in SBI', 'which gov cluster'. NOT for non-UiPath CVE lookups, general CVE severity research, patching or deploying a fix, or requesting a release exception."
+allowed-tools: Bash, Read
+---
+
+# UiPath MER CVE findings
+
+Query `https://mer.uipath.com/api/v1/cve-findings` — the same data the MER
+Security Dashboard shows. Read-only.
+
+Every command below reads `$MER_API` so the same recipes work against a local
+dev server or a deployment slot:
+
+```bash
+export MER_API="${MER_API:-https://mer.uipath.com}"
+```
+
+## When to Use This Skill
+
+- How many CVEs, or which ones, affect a product, service, image, or component
+- What is out of SLA, how overdue, and what fixes it
+- What a person owns and its security posture
+- Which findings live in FedRAMP, AS, Commercial Cloud, or another environment
+- Which image a finding sits in, and whether several findings share one image
+
+## Critical Rules
+
+1. **Never guess a filter value — resolve it first.** A wrong parameter returns
+   `200` with `{"total":0}`, which reads as *"no findings"* when it means
+   *"wrong parameter"*. For a security question that silent zero is the worst
+   possible answer. Always fetch `/api/v1/cve-filter-options` and match the
+   user's terms against it before building a query. A term absent from it is not
+   automatically invalid — five dimensions are free text and deliberately
+   unlisted, so check the table below before rejecting one.
+
+2. **Report a zero only after re-verifying.** If a query returns zero rows, say
+   you are re-checking the dimension and spelling, then confirm with a control
+   query that the same filters return rows for a known-good value. "Verified
+   zero" and "wrong query" are different answers.
+
+3. **Supply one filter from each group, or the API returns `400`.** Group A is
+   ownership and scope: `l3s` `l4s` `serviceOwners` `productNames`
+   `serviceNames` `environments` `releaseContexts` `cus`. Group B is
+   vulnerability and component: `severities` `slaStatuses` `cves` `cvssMin`
+   `cvssMax` `exceptionApproved` `exceptionTickets` `imageNames`
+   `componentNames` `componentVersions`.
+
+4. **Repeat a parameter for multiple values; never comma-separate.** Manager and
+   owner names contain commas (`"Doe, John"`), so splitting on one invents
+   people who do not exist. Use `--data-urlencode "severities=High"
+   --data-urlencode "severities=Critical"`.
+
+5. **Always `curl -G --data-urlencode ... --fail-with-body`.** Values such as
+   `OUT OF SLA` contain spaces, and without `--fail-with-body` a `400` writes an
+   empty file and exits `0` — a silent failure that looks like an empty result.
+
+6. **Distinguish findings from distinct CVEs.** The same CVE appears once per
+   affected image and component version. Report both counts when they differ;
+   `X-Total-Rows` is findings, not unique CVEs.
+
+7. **`ComponentVersion` is installed and vulnerable; `FixedVersions` is the
+   target.** Never present one as the other — the user usually needs both to
+   plan the fix.
+
+8. **Respect `$MER_API` if it is set.** It points at a local dev server or a
+   slot instead of production. Never rewrite a URL the user gave you back to
+   `mer.uipath.com`.
+
+9. **Fetch once, then filter locally.** Every call is a live query against one
+   shared service principal with no rate limiting. Pull a superset into a file
+   and slice it with `jq` rather than issuing a request per question.
+
+10. **A concept missing from the filters may still be a column.**
+    `/api/v1/cve-filter-options` covers only what you can *filter on*; the
+    response carries many more columns, and most are output-only. AGOV is the
+    standing example — `agov` matches no filter dimension, yet every row has
+    `FixedinAGOV` and `AGOVLatest`. Grep the `columns` array before telling a
+    user MER does not track something, and grep the column *names*, not just
+    values.
+
+11. **Never hard-code a count, percentage or ratio** — into an answer or into
+    this file. The source table is rebuilt wholesale, so a baked-in number goes
+    stale silently while still reading as authoritative. State the shape of the
+    finding and give the command that derives the current figure.
+
+## Workflow
+
+### 1. Get a token
+
+```bash
+export MER_TOKEN=$(az account get-access-token \
+  --resource api://6206766d-e890-4f6d-956f-851ca128626d \
+  --query accessToken -o tsv)
+```
+
+Any identity in the UiPath tenant works — a person after `az login`, or a
+pipeline's own service principal. Tokens last about an hour; on `401`, re-run.
+
+**Each Bash call is a fresh shell** — an `export` in one call is gone in the
+next. Re-read the token inside every command: `MER_TOKEN=$(cat <path>/token.txt)`.
+
+**If the harness denies the `az` call**, do not retry or work around it. Ask the
+user to run it and redirect to a file — **the file, not an export**, since a
+variable exported in their shell never reaches your tool calls:
+
+```bash
+az account get-access-token --resource api://6206766d-e890-4f6d-956f-851ca128626d \
+  --query accessToken -o tsv > <scratchpad>/mer_token.txt
+```
+
+### 2. Resolve every term the user named
+
+```bash
+curl -sS -H "Authorization: Bearer $MER_TOKEN" \
+  "$MER_API/api/v1/cve-filter-options" -o /tmp/opts.json
+
+python3 -c "
+import json,sys
+d=json.load(open('/tmp/opts.json')); term=sys.argv[1].lower()
+for k,v in d.items():
+    hits=[x for x in v if term in str(x).lower()]
+    if hits: print(k, '->', hits[:5])
+" "Sam Nuziale"
+```
+
+This prints the parameter name and the exact spelling. Real examples of why it
+matters: `Sam Nuziale` resolves to `l4s`, not `l3s`; `Experiences` resolves to
+`serviceNames`, and its product is `Cloud Platform`.
+
+A term can land in two dimensions — `Orchestrator` is both a `productNames` and
+a `serviceNames` value. Prefer the broader one unless the user clearly meant a
+single service, and say which you chose; the counts differ.
+
+The response is keyed by the **same parameter names** the findings API accepts,
+so a value goes straight back into a query:
+
+```json
+{ "l3s": [...], "l4s": [...], "serviceOwners": [...], "productNames": [...],
+  "serviceNames": [...], "environments": [...], "releaseContexts": ["24.10","25.10"],
+  "cus": [...], "severities": [...], "slaStatuses": [...], "exceptionApproved": [...] }
+```
+
+Eleven dimensions, listed because their value sets are bounded. Five filter
+parameters are **not** listed because they are free text:
+
+| Not in filter-options | Why | How to handle |
+|---|---|---|
+| `cves` | any CVE / GHSA id | use the id the user gave |
+| `imageNames` | any image name | use it verbatim; confirm from a findings result |
+| `componentNames` | any package name | same |
+| `componentVersions` | any version string | same |
+| `exceptionTickets` | any ticket key | same |
+
+So "not found in filter-options" means *invalid* for a person, product, service,
+environment, release context, CU, severity or SLA status — and means nothing at
+all for the five above. Values carry the same release-context filtering as the
+findings query, so this endpoint cannot advertise something the API will not
+return.
+
+**Resolving a term is two lookups, not one.** A miss in filter-options is not a
+verdict until you have also checked the column names:
+
+```bash
+head -n 1 /tmp/findings.ndjson | jq -r '.columns[]' | grep -i agov
+# FixedinAGOV
+# AGOVLatest
+```
+
+`agov` is invisible to filter-options and answerable from the columns. Same for
+`sbi`. Only after both lookups miss is "MER does not track that" a real answer.
+
+### 3. Query and format
+
+To satisfy a filter group without actually narrowing, repeat every value of a
+cheap dimension. Listing all severities from filter-options makes `severities` a
+no-op that still fills Group B — useful when the real filter is in Group A:
+
+```bash
+args=()
+while IFS= read -r v; do args+=(--data-urlencode "severities=$v"); done \
+  < <(jq -r '.severities[]' /tmp/opts.json)
+
+curl -sS --fail-with-body -G "$MER_API/api/v1/cve-findings" \
+  -H "Authorization: Bearer $MER_TOKEN" \
+  --data-urlencode "environments=FedRAMP" "${args[@]}" -o /tmp/findings.ndjson
+```
+
+The `while read` loop rather than `for s in $(...)`: `slaStatuses` values contain
+spaces (`OUT OF SLA`), which word-splitting would shatter into three parameters.
+Avoid `xargs -d` — it is GNU-only and absent on macOS.
+
+Do the same with `slaStatuses` when severity is the real filter.
+
+
+```bash
+curl -sS --fail-with-body -G "$MER_API/api/v1/cve-findings" \
+  -H "Authorization: Bearer $MER_TOKEN" \
+  --data-urlencode "serviceNames=Experiences" \
+  --data-urlencode "environments=FedRAMP" \
+  --data-urlencode "severities=High" \
+  --data-urlencode "slaStatuses=OUT OF SLA" \
+  -o /tmp/findings.ndjson
+
+tail -n +2 /tmp/findings.ndjson \
+| jq -r 'def d: if . == null or . == "" then "-" else tostring end;
+         [(.CVE|d), (.CVSS|d), (.ImageNameWithTag|d), (.ComponentName|d),
+          (.ComponentVersion|d), (.FixedVersions|d), (.SLADaysLeft|d)] | @tsv' \
+| sort -t$'\t' -k2,2rn \
+| { printf 'CVE\tCVSS\tIMAGE\tCOMPONENT\tINSTALLED\tFIXED_IN\tDAYS\n'; cat; } \
+| column -t -s $'\t'
+```
+
+The `def d:` guard matters. Some findings carry an empty `CVE` (GHAS secret
+scanning) or an empty `FixedVersions` (no fix published). `column -t` collapses
+consecutive tabs, so an unguarded empty field silently shifts every later column
+left and the row reads as if it belongs to a different CVE.
+
+The response is NDJSON: a `{total, columns}` header line, then one object per
+finding — so `tail -n +2` drops the header. Row count is also on the
+`X-Total-Rows` response header.
+
+## Columns Beyond the Filters
+
+Only the filter parameters are queryable; every other column is read-only per
+row. Dump the list before assuming something is untracked — never work from a
+remembered set, it grows:
+
+```bash
+head -n 1 /tmp/findings.ndjson | jq -r '.columns[]' | nl
+```
+
+### Remediation state — what users actually ask about
+
+| Column | Values | Meaning |
+|---|---|---|
+| `FixedinAGOV` | `True` / `False` | Does the AGOV build already carry the fix |
+| `AGOVLatest` | version string | Latest AGOV build for that image |
+| `FixedinSBI` | `Fixed in latest SBI`, `Unfixed in latest SBI`, `SBI rescan pending`, `Not reported on SBI` | Secure Base Image state |
+| `Cluster` | e.g. `kf-pgov-plt-vir-01-g-aks` | Gov cluster the row was scanned on |
+
+**All four are populated on FedRAMP rows only** — empty on AS, Commercial Cloud
+and everywhere else. A question about AGOV or SBI is implicitly a FedRAMP
+question. Never read their emptiness on a non-FedRAMP row as "not fixed"; it
+means "not applicable".
+
+`FixedinAGOV=False` alongside an `AGOVLatest` newer than the scanned `ImageTag`
+means **rolling forward will not clear the finding** — the fix is absent from
+that build too. That is usually the whole point of the question, so say it.
+
+`Not reported on SBI` is by far the most common `FixedinSBI` value; it means the
+image is outside SBI coverage, not that it is unfixed.
+
+### Columns you cannot trust at face value
+
+`ENGStatus`, `VULNStatus`, `ETA_MER`, `ETA_MER_Notes`, `Justification`, `Reason`,
+`Submitter`, `AlertUrl` and `TicketURL` came back empty on every row of a broad
+sample; `CommittedFixDate` on a small minority. Unpopulated is **not** a
+negative — never report them as "nothing is in progress".
+
+`ENGJiraTicket` is not uniform: a bare key (`MST-11432`) on some rows, a full
+`https://uipath.atlassian.net/browse/...` URL on others. Normalise before
+grouping, or one ticket counts twice.
+
+Check population against the row total before reporting any column — far below
+means sparse, absent means empty throughout:
+
+```bash
+tail -n +2 /tmp/findings.ndjson \
+| jq -r '[to_entries[]|select(.value!=null and .value!="")|.key]|.[]' \
+| sort | uniq -c | sort -rn
+```
+
+## Reading the Result
+
+- `SLADaysLeft` is **negative** when past deadline. −155 is far worse than −9.
+- Group by `ImageNameWithTag` before proposing work. Findings sharing one image
+  are usually **one rebuild**, not N separate fixes.
+- Check whether a fix is a patch bump or a major version jump — the second needs
+  a decision, not a dependency refresh.
+- OS packages (`glibc`, `openssl-libs`, `dotnet-*`) clustering on one image
+  usually means a base-image refresh, not per-package work.
+
+## Data Traps
+
+- **`Moderate` occurs only in FedRAMP**, where it is the impact level rather
+  than a synonym for Medium. `severities=Medium` is complete everywhere else;
+  do not query both.
+- **FedRAMP rows carry an empty Release Context.** Adding `releaseContexts=…`
+  silently drops every FedRAMP row. Omit it when asking about FedRAMP.
+- **Only the release contexts that filter-options lists are reachable.** Older
+  ones exist in the source table but the API filters them out, so they return
+  zero. Read the list rather than assuming a pair.
+- **`SLAStatus` is not a live overdue flag.** Most `OUT OF SLA` rows have a
+  *non-negative* `SLADaysLeft` — the majority, not a fringe. The status appears
+  sticky once breached; `SLADaysLeft` is the live countdown. Always split the
+  two and count both from the response in hand:
+
+  ```bash
+  tail -n +2 /tmp/findings.ndjson \
+  | jq -r 'if .SLADaysLeft < 0 then "past deadline" else "within deadline" end' \
+  | sort | uniq -c
+  ```
+
+  Report the `slaStatuses=OUT OF SLA` total as the dashboard-consistent figure,
+  then the past-deadline subset. The first alone overstates the fire; the second
+  alone contradicts the dashboard the user is looking at.
+- **`SLAColorFlag` nearly tracks the sign of `SLADaysLeft`, but not exactly** — a
+  handful of rows disagree. Derive "overdue" from `SLADaysLeft` itself.
+- **The source table is replaced wholesale on each rebuild.** Counts can change
+  between runs, and a dashboard page left open shows stale numbers with no
+  indication. Re-query rather than trusting an earlier figure.
+
+## Anti-patterns
+
+A scan list; each one is argued above.
+
+- `{"total":0}` reported as "no findings" without re-verifying the dimension —
+  the single most likely way to give a wrong answer.
+- Comma-separated values; `severities=High,Critical` matches nothing.
+- Polling or looping instead of one broad fetch, then `jq`.
+- Value lists hard-coded from documentation rather than read from filter-options.
+- `releaseContexts` added "to be safe" — it excludes every FedRAMP row.
+- Row count reported as CVE count.
+- "MER does not track that", said without grepping the `columns` header.
+- An empty column read as a negative finding.
+- `OUT OF SLA` equated with "past deadline today".
+- **Any write.** This API is read-only; exceptions and committed fix dates are
+  dashboard actions.
+
+## Status Codes
+
+| Code | Meaning |
+|------|---------|
+| `200` | NDJSON stream |
+| `400` | A filter group is missing — the body names the valid parameters |
+| `401` | No credential, or an expired token — re-run the token command |
+| `403` | Token issued by another tenant |
+| `413` | Over the row cap — the body names the limit; read it rather than assuming. `cves`, `componentNames` and `componentVersions` narrow hardest; `environments` and `severities` barely narrow |
+| `502` | Upstream query failed |
+
+## Completion Output
+
+Lead with the number the user asked for, and state findings versus distinct CVEs
+when they differ. When the answer came from `slaStatuses=OUT OF SLA`, give the
+genuinely-past-deadline subset alongside it. Then, when useful: the most overdue
+item, whether the findings collapse to a single image, whether any fix is a
+major version jump, and for FedRAMP, what `FixedinAGOV` / `FixedinSBI` say about
+whether a rebuild would even help. Say plainly when a filter returned zero and
+you verified it — that is a real answer.

--- a/skills/uipath-cve-findings/SKILL.md.prod-default.bak
+++ b/skills/uipath-cve-findings/SKILL.md.prod-default.bak
@@ -1,0 +1,218 @@
+---
+name: uipath-cve-findings
+description: "UiPath MER CVE findings via the read-only `/api/v1/cve-findings` HTTP API — vulnerabilities, SLA breaches, and remediation targets per product, service, image, component, or owner. Resolves people and services to their exact filter dimension before querying, so a wrong guess is never reported as zero findings. Reports installed vs fixed versions and groups findings by container image. Read-only: it cannot request exceptions, set committed fix dates, or edit findings. For UiPath job failures and automation health→uipath-insights, root-cause debugging of a specific runtime error→uipath-troubleshoot."
+when_to_use: "User asks about CVEs, vulnerabilities, security findings, or SLA breaches for a UiPath product, service, team, image, or person. Phrasings include 'CVEs on <service>', 'what's out of SLA', 'how many criticals', 'what does <person> own', 'which CVEs are in <image>', 'what version fixes this', 'FedRAMP vulnerabilities', 'overdue security findings', 'MER security dashboard'. NOT for non-UiPath CVE lookups, general CVE severity research, patching or deploying a fix, or requesting a release exception."
+allowed-tools: Bash, Read
+---
+
+# UiPath MER CVE findings
+
+Query `https://mer.uipath.com/api/v1/cve-findings` — the same data the MER
+Security Dashboard shows. Read-only.
+
+Every command below reads `$MER_API` so the same recipes work against a local
+dev server or a deployment slot:
+
+```bash
+export MER_API="${MER_API:-https://mer.uipath.com}"
+```
+
+## When to Use This Skill
+
+- How many CVEs, or which ones, affect a product, service, image, or component
+- What is out of SLA, how overdue, and what fixes it
+- What a person owns and its security posture
+- Which findings live in FedRAMP, AS, Commercial Cloud, or another environment
+- Which image a finding sits in, and whether several findings share one image
+
+## Critical Rules
+
+1. **Never guess a filter value — resolve it first.** A wrong parameter returns
+   `200` with `{"total":0}`, which reads as *"no findings"* when it means
+   *"wrong parameter"*. For a security question that silent zero is the worst
+   possible answer. Always fetch `/api/v1/cve-filter-options` and match the
+   user's terms against it before building a query. A term absent from it is not
+   automatically invalid — five dimensions are free text and deliberately
+   unlisted, so check the table below before rejecting one.
+
+2. **Report a zero only after re-verifying.** If a query returns zero rows, say
+   you are re-checking the dimension and spelling, then confirm with a control
+   query that the same filters return rows for a known-good value. "Verified
+   zero" and "wrong query" are different answers.
+
+3. **Supply one filter from each group, or the API returns `400`.** Group A is
+   ownership and scope: `l3s` `l4s` `serviceOwners` `productNames`
+   `serviceNames` `environments` `releaseContexts` `cus`. Group B is
+   vulnerability and component: `severities` `slaStatuses` `cves` `cvssMin`
+   `cvssMax` `exceptionApproved` `exceptionTickets` `imageNames`
+   `componentNames` `componentVersions`.
+
+4. **Repeat a parameter for multiple values; never comma-separate.** Manager and
+   owner names contain commas (`"Doe, John"`), so splitting on one invents
+   people who do not exist. Use `--data-urlencode "severities=High"
+   --data-urlencode "severities=Critical"`.
+
+5. **Always `curl -G --data-urlencode ... --fail-with-body`.** Values such as
+   `OUT OF SLA` contain spaces, and without `--fail-with-body` a `400` writes an
+   empty file and exits `0` — a silent failure that looks like an empty result.
+
+6. **Distinguish findings from distinct CVEs.** The same CVE appears once per
+   affected image and component version. Report both counts when they differ;
+   `X-Total-Rows` is findings, not unique CVEs.
+
+7. **`ComponentVersion` is installed and vulnerable; `FixedVersions` is the
+   target.** Never present one as the other — the user usually needs both to
+   plan the fix.
+
+8. **Respect `$MER_API` if it is set.** It points at a local dev server or a
+   slot instead of production. Never rewrite a URL the user gave you back to
+   `mer.uipath.com`.
+
+9. **Fetch once, then filter locally.** Every call is a live query against one
+   shared service principal with no rate limiting. Pull a superset into a file
+   and slice it with `jq` rather than issuing a request per question.
+
+## Workflow
+
+### 1. Get a token
+
+```bash
+export MER_TOKEN=$(az account get-access-token \
+  --resource api://6206766d-e890-4f6d-956f-851ca128626d \
+  --query accessToken -o tsv)
+```
+
+Any identity in the UiPath tenant works — a person after `az login`, or a
+pipeline's own service principal. Tokens last about an hour; on `401`, re-run.
+
+### 2. Resolve every term the user named
+
+```bash
+curl -sS -H "Authorization: Bearer $MER_TOKEN" \
+  "$MER_API/api/v1/cve-filter-options" -o /tmp/opts.json
+
+python3 -c "
+import json,sys
+d=json.load(open('/tmp/opts.json')); term=sys.argv[1].lower()
+for k,v in d.items():
+    hits=[x for x in v if term in str(x).lower()]
+    if hits: print(k, '->', hits[:5])
+" "Sam Nuziale"
+```
+
+This prints the parameter name and the exact spelling. Real examples of why it
+matters: `Sam Nuziale` resolves to `l4s`, not `l3s`; `Experiences` resolves to
+`serviceNames`, and its product is `Cloud Platform`.
+
+A term can land in two dimensions — `Orchestrator` is both a `productNames` and
+a `serviceNames` value. Prefer the broader one unless the user clearly meant a
+single service, and say which you chose; the counts differ.
+
+The response is keyed by the **same parameter names** the findings API accepts,
+so a value goes straight back into a query:
+
+```json
+{ "l3s": [...], "l4s": [...], "serviceOwners": [...], "productNames": [...],
+  "serviceNames": [...], "environments": [...], "releaseContexts": ["24.10","25.10"],
+  "cus": [...], "severities": [...], "slaStatuses": [...], "exceptionApproved": [...] }
+```
+
+Eleven dimensions, listed because their value sets are bounded. Five filter
+parameters are **not** listed because they are free text:
+
+| Not in filter-options | Why | How to handle |
+|---|---|---|
+| `cves` | any CVE / GHSA id | use the id the user gave |
+| `imageNames` | any image name | use it verbatim; confirm from a findings result |
+| `componentNames` | any package name | same |
+| `componentVersions` | any version string | same |
+| `exceptionTickets` | any ticket key | same |
+
+So "not found in filter-options" means *invalid* for a person, product, service,
+environment, release context, CU, severity or SLA status — and means nothing at
+all for the five above. Values carry the same release-context filtering as the
+findings query, so this endpoint cannot advertise something the API will not
+return.
+
+### 3. Query and format
+
+```bash
+curl -sS --fail-with-body -G "$MER_API/api/v1/cve-findings" \
+  -H "Authorization: Bearer $MER_TOKEN" \
+  --data-urlencode "serviceNames=Experiences" \
+  --data-urlencode "environments=FedRAMP" \
+  --data-urlencode "severities=High" \
+  --data-urlencode "slaStatuses=OUT OF SLA" \
+  -o /tmp/findings.ndjson
+
+tail -n +2 /tmp/findings.ndjson \
+| jq -r 'def d: if . == null or . == "" then "-" else tostring end;
+         [(.CVE|d), (.CVSS|d), (.ImageNameWithTag|d), (.ComponentName|d),
+          (.ComponentVersion|d), (.FixedVersions|d), (.SLADaysLeft|d)] | @tsv' \
+| sort -t$'\t' -k2,2rn \
+| { printf 'CVE\tCVSS\tIMAGE\tCOMPONENT\tINSTALLED\tFIXED_IN\tDAYS\n'; cat; } \
+| column -t -s $'\t'
+```
+
+The `def d:` guard matters. Some findings carry an empty `CVE` (GHAS secret
+scanning) or an empty `FixedVersions` (no fix published). `column -t` collapses
+consecutive tabs, so an unguarded empty field silently shifts every later column
+left and the row reads as if it belongs to a different CVE.
+
+The response is NDJSON: a `{total, columns}` header line, then one object per
+finding — so `tail -n +2` drops the header. Row count is also on the
+`X-Total-Rows` response header.
+
+## Reading the Result
+
+- `SLADaysLeft` is **negative** when past deadline. −155 is far worse than −9.
+- Group by `ImageNameWithTag` before proposing work. Findings sharing one image
+  are usually **one rebuild**, not N separate fixes.
+- Check whether a fix is a patch bump or a major version jump — the second needs
+  a decision, not a dependency refresh.
+- OS packages (`glibc`, `openssl-libs`, `dotnet-*`) clustering on one image
+  usually means a base-image refresh, not per-package work.
+
+## Data Traps
+
+- **`Moderate` occurs only in FedRAMP**, where it is the impact level rather
+  than a synonym for Medium. `severities=Medium` is complete everywhere else;
+  do not query both.
+- **FedRAMP rows carry an empty Release Context.** Adding `releaseContexts=…`
+  silently drops every FedRAMP row. Omit it when asking about FedRAMP.
+- **Only `24.10` and `25.10` are reachable.** Older contexts exist in the source
+  table but the API filters them out, so they return zero.
+- **The source table is replaced wholesale on each rebuild.** Counts can change
+  between runs, and a dashboard page left open shows stale numbers with no
+  indication. Re-query rather than trusting an earlier figure.
+
+## Anti-patterns
+
+- **Do not report `{"total":0}` as "no findings"** without re-verifying the
+  dimension. This is the single most likely way to give a wrong answer.
+- **Do not comma-separate values.** `severities=High,Critical` matches nothing.
+- **Do not poll or loop.** One broad fetch, then `jq`.
+- **Do not hard-code value lists** from documentation. Read them from
+  `/api/v1/cve-filter-options`, which derives them from the data.
+- **Do not add `releaseContexts` "to be safe."** It excludes all FedRAMP rows.
+- **Do not treat row count as CVE count.** They differ, often by 3–5×.
+- **Do not attempt writes.** This API is read-only; exceptions and committed fix
+  dates are dashboard actions.
+
+## Status Codes
+
+| Code | Meaning |
+|------|---------|
+| `200` | NDJSON stream |
+| `400` | A filter group is missing — the body names the valid parameters |
+| `401` | No credential, or an expired token — re-run the token command |
+| `403` | Token issued by another tenant |
+| `413` | Over the 50,000-row cap. `cves`, `componentNames` and `componentVersions` narrow hardest; `environments` and `severities` barely narrow |
+| `502` | Upstream query failed |
+
+## Completion Output
+
+Lead with the number the user asked for, and state findings versus distinct CVEs
+when they differ. Then, when useful: the most overdue item, whether the findings
+collapse to a single image, and whether any fix is a major version jump. Say
+plainly when a filter returned zero and you verified it — that is a real answer.

--- a/tests/tasks/activation/README.md
+++ b/tests/tasks/activation/README.md
@@ -10,7 +10,7 @@ plus a confusion matrix.
 |------|---------|
 | `<skill>.jsonl` | Positives for that skill — every prompt should fire that skill. `expected_skill` is injected per file by `activation.yaml`. |
 | `negative.jsonl` | Shared negatives — prompts that should fire **no** skill (small talk, unrelated dev tasks, adjacent UiPath products, other workflow tools). |
-| `activation.yaml` | coder-eval task config. Uses `dataset.paths` to merge all skill jsonls + `negative.jsonl`, and stacks 24 `skill_triggered` criteria — one per skill — each computing its own confusion matrix from the same agent traces. |
+| `activation.yaml` | coder-eval task config. Uses `dataset.paths` to merge all skill jsonls + `negative.jsonl`, and stacks one `skill_triggered` criterion per skill, each computing its own confusion matrix from the same agent traces. |
 
 The `expected_skill` field on each row is the row's true label (the skill it should fire, or `""` for negatives). Each criterion compares its own `skill_name` to `expected_skill`: `expected="yes"` iff they match. So for skill X:
 - `<X>.jsonl` rows are positives.

--- a/tests/tasks/activation/activation.yaml
+++ b/tests/tasks/activation/activation.yaml
@@ -14,6 +14,7 @@ dataset:
     - uipath-api-workflow.jsonl
     - uipath-automation-discovery.jsonl
     - uipath-coded-apps.jsonl
+    - uipath-cve-findings.jsonl
     - uipath-functions.jsonl
     - uipath-troubleshoot.jsonl
     - uipath-feedback.jsonl
@@ -108,6 +109,13 @@ success_criteria:
   - type: skill_triggered
     description: "uipath-human-in-the-loop activation"
     skill_name: uipath-human-in-the-loop
+    expected_skill: "${row.expected_skill}"
+    suite_thresholds: {recall.yes: 0.70}
+    stop_early:
+      on_pass: stop
+  - type: skill_triggered
+    description: "uipath-cve-findings activation"
+    skill_name: uipath-cve-findings
     expected_skill: "${row.expected_skill}"
     suite_thresholds: {recall.yes: 0.70}
     stop_early:

--- a/tests/tasks/activation/uipath-cve-findings.jsonl
+++ b/tests/tasks/activation/uipath-cve-findings.jsonl
@@ -1,0 +1,12 @@
+{"id": "uipath-cve-findings-001", "prompt": "How many CVEs are out of SLA under Sam Nuziale?", "expected_skill": "uipath-cve-findings"}
+{"id": "uipath-cve-findings-002", "prompt": "What vulnerabilities are on the Experiences service?", "expected_skill": "uipath-cve-findings"}
+{"id": "uipath-cve-findings-003", "prompt": "How many criticals does Orchestrator have?", "expected_skill": "uipath-cve-findings"}
+{"id": "uipath-cve-findings-004", "prompt": "Show me the FedRAMP security findings that are overdue", "expected_skill": "uipath-cve-findings"}
+{"id": "uipath-cve-findings-005", "prompt": "Which image is CVE-2025-55315 in?", "expected_skill": "uipath-cve-findings"}
+{"id": "uipath-cve-findings-006", "prompt": "What version fixes the glibc vulnerability in our portal image?", "expected_skill": "uipath-cve-findings"}
+{"id": "uipath-cve-findings-007", "prompt": "Are those FedRAMP findings fixed in AGOV yet?", "expected_skill": "uipath-cve-findings"}
+{"id": "uipath-cve-findings-008", "prompt": "Is that CVE fixed in the latest SBI?", "expected_skill": "uipath-cve-findings"}
+{"id": "uipath-cve-findings-009", "prompt": "What does Dragos Bobolea own and how bad is its security posture?", "expected_skill": "uipath-cve-findings"}
+{"id": "uipath-cve-findings-010", "prompt": "Which gov cluster are these vulnerabilities scanned on?", "expected_skill": "uipath-cve-findings"}
+{"id": "uipath-cve-findings-011", "prompt": "Give me the MER security dashboard numbers for Automation Hub", "expected_skill": "uipath-cve-findings"}
+{"id": "uipath-cve-findings-012", "prompt": "How many out of SLA findings does Cloud Platform have right now?", "expected_skill": "uipath-cve-findings"}

--- a/tests/tasks/uipath-cve-findings/e2e_remediation_columns.yaml
+++ b/tests/tasks/uipath-cve-findings/e2e_remediation_columns.yaml
@@ -1,0 +1,68 @@
+task_id: skill-cve-findings-e2e-remediation-columns
+description: >
+  E2E test: the agent answers an AGOV/SBI remediation question from the response
+  columns, not the filter dimensions. "agov" matches no value in
+  /api/v1/cve-filter-options, but every row carries FixedinAGOV, AGOVLatest and
+  FixedinSBI. An agent that resolves terms only against filter-options concludes
+  MER does not track AGOV — the failure this test exists to catch. Requires a
+  reachable MER API and an az session in the UiPath tenant.
+tags: [uipath-cve-findings, e2e, mode:diagnose, lifecycle:operate]
+
+run_limits:
+  expected_turns: 12
+  max_turns: 40
+  turn_timeout: 900
+
+initial_prompt: |
+  For the FedRAMP High findings that are out of SLA on the Experiences service —
+  are they fixed in AGOV yet?
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-cve-findings skill"
+    skill_name: "uipath-cve-findings"
+    expected_skill: "uipath-cve-findings"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent inspected the response columns rather than only the filter dimensions"
+    tool_name: "Bash"
+    command_pattern: 'columns|FixedinAGOV'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent answers from FixedinAGOV instead of declaring AGOV untracked"
+    include_agent_output: true
+    prompt: |
+      The user asked whether some FedRAMP findings are fixed in AGOV. AGOV is not
+      a filterable dimension — it appears in no value list returned by
+      /api/v1/cve-filter-options — but every findings row carries a FixedinAGOV
+      column (True/False) alongside AGOVLatest and FixedinSBI.
+
+      PASS if the response answers the question using the FixedinAGOV column (or
+      explicitly reports what that column says for the rows in question). Also
+      PASS if it reports the API was unreachable or auth failed.
+
+      FAIL if the response claims AGOV is not a valid filter, not tracked by MER,
+      or unknown, on the grounds that it was absent from the filter options —
+      without ever checking the response columns.
+    weight: 3.0
+    pass_threshold: 0.7
+
+  - type: llm_judge
+    description: "Agent does not read an empty non-FedRAMP value as 'not fixed'"
+    include_agent_output: true
+    prompt: |
+      FixedinAGOV, AGOVLatest, FixedinSBI and Cluster are populated on FedRAMP
+      rows only; they are empty on AS, Commercial Cloud and every other
+      environment, where they mean "not applicable" rather than "not fixed".
+
+      PASS if the response either confines its AGOV claim to FedRAMP rows, or
+      says nothing about non-FedRAMP rows. Also PASS if the API was unreachable.
+      FAIL if it reports non-FedRAMP findings as "not fixed in AGOV" on the basis
+      of an empty column.
+    weight: 1.5
+    pass_threshold: 0.7

--- a/tests/tasks/uipath-cve-findings/e2e_service_posture.yaml
+++ b/tests/tasks/uipath-cve-findings/e2e_service_posture.yaml
@@ -1,0 +1,52 @@
+task_id: skill-cve-findings-e2e-service-posture
+description: >
+  E2E test: full investigation of one service against a live tenant — resolve the
+  term to its dimension, fetch findings, and report findings vs distinct CVEs,
+  the SLA breakdown, and which container images the findings sit in. Requires a
+  reachable MER API and an az session in the UiPath tenant.
+tags: [uipath-cve-findings, e2e, mode:diagnose, lifecycle:operate]
+skip: true
+# Blocked: needs a live MER deployment plus an az-authenticated session in the
+# UiPath tenant. Unblock once /api/v1/cve-findings is deployed to production and
+# CI has a tenant identity that can mint a token for its audience.
+
+run_limits:
+  expected_turns: 15
+  max_turns: 40
+  turn_timeout: 900
+
+initial_prompt: |
+  Give me a full picture of the CVEs on the Experiences service: how many
+  findings and how many distinct CVEs, the breakdown by severity and SLA status,
+  which images they live in, and what I should fix first.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-cve-findings skill"
+    skill_name: "uipath-cve-findings"
+    expected_skill: "uipath-cve-findings"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent resolved the term via filter-options before querying"
+    tool_name: "Bash"
+    command_pattern: 'cve-filter-options'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent distinguishes finding count from distinct CVE count, and names the images"
+    include_agent_output: true
+    prompt: |
+      The user asked for a full picture of the CVEs on the Experiences service.
+      The same CVE appears once per affected image and component version, so the
+      row count and the distinct-CVE count differ, often by 3-5x.
+
+      PASS if the response reports BOTH a finding count and a distinct-CVE count
+      (or explicitly says they are the same, having checked), AND names the
+      container image(s) the findings sit in. FAIL if it reports a single
+      ambiguous number as "the number of CVEs", or omits the images.
+    weight: 2.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-cve-findings/e2e_service_posture.yaml
+++ b/tests/tasks/uipath-cve-findings/e2e_service_posture.yaml
@@ -1,0 +1,51 @@
+task_id: skill-cve-findings-e2e-service-posture
+description: >
+  E2E test: full investigation of one service against a live tenant — resolve the
+  term to its dimension, fetch findings, and report findings vs distinct CVEs,
+  the SLA breakdown, and which container images the findings sit in. Requires a
+  reachable MER API and an az session in the UiPath tenant.
+tags: [uipath-cve-findings, e2e, mode:diagnose, lifecycle:operate]
+# Requires a reachable https://mer.uipath.com and an az session in the UiPath
+# tenant that can mint a token for the API's audience. The API shipped in
+# UiPath/MER#584; auth is tenant membership, so any tenant identity works.
+
+run_limits:
+  expected_turns: 15
+  max_turns: 40
+  turn_timeout: 900
+
+initial_prompt: |
+  Give me a full picture of the CVEs on the Experiences service: how many
+  findings and how many distinct CVEs, the breakdown by severity and SLA status,
+  which images they live in, and what I should fix first.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-cve-findings skill"
+    skill_name: "uipath-cve-findings"
+    expected_skill: "uipath-cve-findings"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent resolved the term via filter-options before querying"
+    tool_name: "Bash"
+    command_pattern: 'cve-filter-options'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent distinguishes finding count from distinct CVE count, and names the images"
+    include_agent_output: true
+    prompt: |
+      The user asked for a full picture of the CVEs on the Experiences service.
+      The same CVE appears once per affected image and component version, so the
+      row count and the distinct-CVE count generally differ.
+
+      PASS if the response reports BOTH a finding count and a distinct-CVE count
+      (or explicitly says they are the same, having checked), AND names the
+      container image(s) the findings sit in. FAIL if it reports a single
+      ambiguous number as "the number of CVEs", or omits the images.
+    weight: 2.5
+    pass_threshold: 0.7

--- a/tests/tasks/uipath-cve-findings/smoke_free_text_dimension.yaml
+++ b/tests/tasks/uipath-cve-findings/smoke_free_text_dimension.yaml
@@ -1,0 +1,49 @@
+task_id: skill-cve-findings-smoke-free-text-dimension
+description: >
+  Smoke test: the agent does not reject a component name just because it is
+  absent from filter-options. Five dimensions (cves, imageNames, componentNames,
+  componentVersions, exceptionTickets) are free text and deliberately unlisted,
+  so "not in filter-options" means nothing for them. The agent should still
+  build a componentNames query rather than refusing. Auth errors are expected.
+tags: [uipath-cve-findings, smoke, mode:diagnose, negative]
+
+run_limits:
+  expected_turns: 8
+
+initial_prompt: |
+  Which services are affected by the openssl-libs component?
+
+  The API is not reachable from this environment, so requests will fail — that
+  is expected. Run each command once and move on. Do NOT retry or log in.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-cve-findings skill"
+    skill_name: "uipath-cve-findings"
+    expected_skill: "uipath-cve-findings"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent queried componentNames rather than refusing the unlisted term"
+    tool_name: "Bash"
+    command_pattern: 'componentNames'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent does not reject openssl-libs as invalid just because filter-options omits it"
+    include_agent_output: true
+    prompt: |
+      The user asked which services are affected by the openssl-libs component.
+      componentNames is a free-text filter dimension, so it is deliberately NOT
+      listed by /api/v1/cve-filter-options. Absence from that endpoint says
+      nothing about whether the component is valid.
+
+      PASS if the response proceeds with a componentNames query (or reports the
+      request failed for environment/auth reasons). FAIL if it claims
+      openssl-libs is invalid, unknown, or does not exist because it was not
+      found in the filter options.
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-cve-findings/smoke_free_text_dimension.yaml
+++ b/tests/tasks/uipath-cve-findings/smoke_free_text_dimension.yaml
@@ -1,0 +1,55 @@
+task_id: skill-cve-findings-smoke-free-text-dimension
+description: >
+  Smoke test: the agent does not reject a component name just because it is
+  absent from filter-options. Five dimensions (cves, imageNames, componentNames,
+  componentVersions, exceptionTickets) are free text and deliberately unlisted,
+  so "not in filter-options" means nothing for them. The agent should still
+  build a componentNames query rather than refusing. Auth errors are expected.
+tags: [uipath-cve-findings, smoke, mode:diagnose, negative]
+# The prompt insists the agent still issues the findings query. Without that, a
+# correct agent stops once filter-options errors on the unreachable API, and the
+# componentNames assertion below fails for the wrong reason.
+
+run_limits:
+  expected_turns: 8
+
+initial_prompt: |
+  Which services are affected by the openssl-libs component?
+
+  The API is not reachable from this environment, so every request will fail with
+  a network or auth error. That is expected and is not something to fix or work
+  around. Even so, still construct and run the findings query you would use, so
+  the approach is visible — do not stop just because an earlier request failed.
+  Run each command once and move on. Do NOT retry or log in.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-cve-findings skill"
+    skill_name: "uipath-cve-findings"
+    expected_skill: "uipath-cve-findings"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent queried componentNames rather than refusing the unlisted term"
+    tool_name: "Bash"
+    command_pattern: 'componentNames'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent does not reject openssl-libs as invalid just because filter-options omits it"
+    include_agent_output: true
+    prompt: |
+      The user asked which services are affected by the openssl-libs component.
+      componentNames is a free-text filter dimension, so it is deliberately NOT
+      listed by /api/v1/cve-filter-options. Absence from that endpoint says
+      nothing about whether the component is valid.
+
+      PASS if the response proceeds with a componentNames query (or reports the
+      request failed for environment/auth reasons). FAIL if it claims
+      openssl-libs is invalid, unknown, or does not exist because it was not
+      found in the filter options.
+    weight: 2.0
+    pass_threshold: 0.7

--- a/tests/tasks/uipath-cve-findings/smoke_resolve_before_query.yaml
+++ b/tests/tasks/uipath-cve-findings/smoke_resolve_before_query.yaml
@@ -1,0 +1,45 @@
+task_id: skill-cve-findings-smoke-resolve-before-query
+description: >
+  Smoke test: the agent resolves a person's name to the correct filter dimension
+  before querying, rather than guessing. "Sam Nuziale" is an L4 manager, so a
+  query using l3s returns zero rows and reads as "no findings" — the failure this
+  skill exists to prevent. The agent should fetch /api/v1/cve-filter-options
+  first. Auth errors are expected (no live tenant).
+tags: [uipath-cve-findings, smoke, mode:diagnose, lifecycle:discover]
+# Deliberately does NOT assert --data-urlencode. The API is unreachable here, so
+# a correct agent stops after filter-options fails rather than issuing a findings
+# query — asserting query construction needs a reachable API, and is covered by
+# smoke_free_text_dimension where the agent does issue one.
+
+run_limits:
+  expected_turns: 8
+
+initial_prompt: |
+  How many out-of-SLA High CVEs are there for Sam Nuziale?
+
+  The API is not reachable from this environment, so requests will fail — that
+  is expected. Run each command once and move on. Do NOT retry or attempt to
+  log in.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-cve-findings skill"
+    skill_name: "uipath-cve-findings"
+    expected_skill: "uipath-cve-findings"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched filter-options to resolve the name before querying"
+    tool_name: "Bash"
+    command_pattern: 'cve-filter-options'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent never comma-separates filter values (names contain commas)"
+    tool_name: "Bash"
+    command_pattern: 'severities=[^&"\n]*,|l3s=[^&"\n]*,|l4s=[^&"\n]*,'
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-cve-findings/smoke_scope_boundaries.yaml
+++ b/tests/tasks/uipath-cve-findings/smoke_scope_boundaries.yaml
@@ -1,0 +1,53 @@
+task_id: skill-cve-findings-smoke-scope-boundaries
+description: >
+  Smoke test: the agent handles an in-scope request and declines three
+  out-of-scope ones — requesting a release exception (a dashboard write), a
+  non-UiPath CVE lookup, and root-causing a runtime job error. The API is
+  read-only, so no write should be attempted.
+tags: [uipath-cve-findings, smoke, mode:diagnose, negative]
+
+run_limits:
+  expected_turns: 8
+
+initial_prompt: |
+  Handle each of these four requests using the appropriate approach. The API is
+  not reachable here, so requests will fail — that is expected. Run each command
+  once and move on. Do NOT retry.
+
+  1. How many out-of-SLA CVEs are on the Experiences service?
+  2. Request a release exception for CVE-2026-14257.
+  3. What is the CVSS score of CVE-2021-44228 in general?
+  4. Why did job abc-123 fail with a FileNotFoundException? Debug it.
+
+  For requests this skill cannot handle, explain what should be used instead.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-cve-findings skill"
+    skill_name: "uipath-cve-findings"
+    expected_skill: "uipath-cve-findings"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent queried the findings API for the in-scope request"
+    tool_name: "Bash"
+    command_pattern: 'cve-findings'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent declines the release-exception request as out of scope for a read-only API"
+    include_agent_output: true
+    prompt: |
+      The user asked four things, one of which was "Request a release exception
+      for CVE-2026-14257". This API is read-only — exceptions are a dashboard
+      action, not something the API can perform.
+
+      PASS if the response declines that request and says it cannot be done
+      through this API (naming the dashboard, or "read-only", or directing the
+      user elsewhere). FAIL if the response claims to have submitted an
+      exception, or gives an API call that would create one.
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-cve-findings/smoke_scope_boundaries.yaml
+++ b/tests/tasks/uipath-cve-findings/smoke_scope_boundaries.yaml
@@ -1,0 +1,53 @@
+task_id: skill-cve-findings-smoke-scope-boundaries
+description: >
+  Smoke test: the agent handles an in-scope request and declines three
+  out-of-scope ones — requesting a release exception (a dashboard write), a
+  non-UiPath CVE lookup, and root-causing a runtime job error. The API is
+  read-only, so no write should be attempted.
+tags: [uipath-cve-findings, smoke, mode:diagnose, negative]
+
+run_limits:
+  expected_turns: 8
+
+initial_prompt: |
+  Handle each of these four requests using the appropriate approach. The API is
+  not reachable here, so requests will fail — that is expected. Run each command
+  once and move on. Do NOT retry.
+
+  1. How many out-of-SLA CVEs are on the Experiences service?
+  2. Request a release exception for CVE-2026-14257.
+  3. What is the CVSS score of CVE-2021-44228 in general?
+  4. Why did job abc-123 fail with a FileNotFoundException? Debug it.
+
+  For requests this skill cannot handle, explain what should be used instead.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-cve-findings skill"
+    skill_name: "uipath-cve-findings"
+    expected_skill: "uipath-cve-findings"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent queried the findings API for the in-scope request"
+    tool_name: "Bash"
+    command_pattern: 'cve-findings'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent declines the release-exception request as out of scope for a read-only API"
+    include_agent_output: true
+    prompt: |
+      The user asked four things, one of which was "Request a release exception
+      for CVE-2026-14257". This API is read-only — exceptions are a dashboard
+      action, not something the API can perform.
+
+      PASS if the response declines that request and says it cannot be done
+      through this API (naming the dashboard, or "read-only", or directing the
+      user elsewhere). FAIL if the response claims to have submitted an
+      exception, or gives an API call that would create one.
+    weight: 2.0
+    pass_threshold: 0.7


### PR DESCRIPTION
Adds a skill over the read-only `/api/v1/cve-findings` API, which serves the same data as the MER Security Dashboard.

## Why

The API returns `200` with `{"total":0}` when a filter names the wrong dimension — `l3s=Sam Nuziale` when Sam is an L4, or `productNames=Experiences` when Experiences is a service under the Cloud Platform product. Both read as *"no findings"* rather than *"wrong parameter"*, and for a security question that silent zero is the worst possible answer.

So the workflow resolves every term against `/api/v1/cve-filter-options` before querying, and reports a zero only after re-verifying the dimension against a control query.

## Resolving against filter-options is necessary but not sufficient

The second half is easy to miss, and this PR now covers it. `filter-options` describes only what is **filterable**; the response carries many more columns that are output-only.

AGOV is the case that motivated the rule. `agov` matches no value in any filter dimension, so an agent that stops at `filter-options` concludes MER does not track it — while every row in fact carries `FixedinAGOV`, `AGOVLatest` and `FixedinSBI`. The skill now requires grepping the `columns` header, **by name and not only by value**, before telling a user something is untracked.

## Traps encoded

Found while exercising the API against live data:

| Trap | Consequence if missed |
|---|---|
| `Moderate` occurs only in FedRAMP (impact level, not a synonym for Medium) | Querying both double-counts |
| FedRAMP rows carry an empty Release Context | `releaseContexts=…` silently drops every FedRAMP row |
| One CVE appears once per affected image and component version | Row count reported as CVE count |
| `SLAStatus` is not a live overdue flag — most `OUT OF SLA` rows have a non-negative `SLADaysLeft`, and the status appears sticky once breached | Status alone overstates the fire; countdown alone contradicts the dashboard. The skill reports both |
| `FixedinAGOV` / `AGOVLatest` / `FixedinSBI` / `Cluster` are populated on FedRAMP rows only | An empty value elsewhere read as "not fixed" rather than "not applicable" |
| `ENGStatus`, `VULNStatus`, `ETA_MER` and friends are empty on every row seen | Reported as "nothing in progress" when they are simply unpopulated |
| `ENGJiraTicket` holds a bare key on some rows, a full browse URL on others | One ticket counts twice when grouping |
| `ComponentVersion` is installed-and-vulnerable; `FixedVersions` is the target | Presenting one as the other misdirects the fix |
| Findings sharing a container image are usually one rebuild | N tickets filed for one base-image refresh |
| The source table is replaced wholesale on each rebuild | Stale numbers presented as current |

## No hard-coded numbers

That last trap generalises into a rule the file applies to itself: **never hard-code a count, percentage or ratio.** Every such figure is stated as a shape plus the command that derives the current number, so the skill cannot go stale while still reading as authoritative. Two pre-existing hard-coded figures were removed as part of this (a distinct-CVE ratio in the e2e judge prompt, and a stale criteria count in the activation README).

## Tests

- Four task evals — one e2e, three smoke — covering resolve-before-query, free-text dimensions, and scope boundaries.
- **New:** `e2e_remediation_columns` pins the AGOV behaviour directly. It fails an agent that declares AGOV untracked on the strength of `filter-options` alone, and separately fails one that reads an empty non-FedRAMP column as "not fixed".
- **New:** activation coverage. The skill had no `activation.jsonl`, so it was absent from the activation confusion matrix entirely. It now has positives spanning owner, service, image, SLA, AGOV and SBI phrasings, registered in `activation.yaml`.

## Status

Preview. The API shipped in UiPath/MER#584 and is live on mer.uipath.com. Verified end to end against production — resolve, query and format all work, **every shell snippet in the skill was executed against live data**, and a credential-less call returns `401` JSON rather than a redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
