### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@4aa3d67

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 9856764. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 4aa3d67. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-bpmn/references/api.md
+++ b/preview/uipath-maestro-bpmn/references/api.md
@@ -116,6 +116,11 @@ export declare class BpmnBuilder extends ScopeBuilder {
     name(n: string): this;
     /** Process-level metadata — see `ProcessMetadata`. */
     metadata(meta: ProcessMetadata): this;
+    /**
+     * Declare the Canvas SCHEMA generation this document targets
+     * (`uipath:migrationVersion`).
+     */
+    schemaVersion(version: string): this;
     /** Name a JSON Schema once so several variables can share it. */
     schema(id: string, schema: unknown): this;
     /**

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 9856764. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 4aa3d67. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-case/references/api.md
+++ b/preview/uipath-maestro-case/references/api.md
@@ -129,6 +129,12 @@ declare class CaseBuilder {
     name(n: string): this;
     /** Set the case plan's schema version during the compatibility window. */
     version(v: string): this;
+    /**
+     * Declare the Case JSON SCHEMA version this plan targets.
+     *
+     * @defaultValue `'30.0.0'` — `CASE_FORMAT_PROFILE.writeVersion`.
+     */
+    schemaVersion(version: string): this;
     /** Describe the case plan. */
     description(text: string): this;
     /** Set the runtime case identifier (constant prefix, or an `=`-expression when type is `external`). */

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 9856764. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 4aa3d67. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -174,7 +174,7 @@ under `examples/` resolve inside this skill folder.
 | Filter | `core.action.transform.filter` | `transform({ variant: 'filter', ... })` | [Transform](#transform) | [transform.md](references/transform.md) | `examples/TrailLogSummary.flow.ts` |
 | Map | `core.action.transform.map` | `transform({ variant: 'map', ... })` | [Transform](#transform) | [transform.md](references/transform.md) | `examples/TrailLogSummary.flow.ts` |
 | Group by | `core.action.transform.group-by` | `transform({ variant: 'group-by', ... })` | [Transform](#transform) | [transform.md](references/transform.md) | `examples/TrailLogSummary.flow.ts` |
-| Integration Service action | `uipath.connector.<key>.<action>` (Data Service: `uipath.connector.uipath-uipath-dataservice.*`) | `connector(...)` | [Integration Service connectors](#integration-service-connectors) | [connector-params.md](references/connector-params.md) | `examples/ClubDirectory.flow.ts` |
+| Integration Service action | `uipath.connector.<key>.<action>` (Data Fabric / Data Service entity ops — create, delete, get-by-id, query-many: `uipath.connector.uipath-uipath-dataservice.*`) | `connector(...)` | [Integration Service connectors](#integration-service-connectors) | [connector-params.md](references/connector-params.md) | `examples/ClubDirectory.flow.ts` |
 | Data Fabric read | `core.datafabric.read` | `dataFabricRead(...)` | [Data Fabric](#data-fabric) | [data-fabric.md](references/data-fabric.md) | `examples/BeeHiveLedger.flow.ts` |
 | Data Fabric update | `core.datafabric.update` | `dataFabricUpdate(...)` | [Data Fabric](#data-fabric) | [data-fabric.md](references/data-fabric.md) | `examples/BeeHiveLedger.flow.ts` |
 | Subflow | `core.subflow` | `subflow(...)` | [Subflow](#subflow) | [subflow.md](references/subflow.md) | `examples/RecipeScaler.flow.ts` |
@@ -550,11 +550,14 @@ Check tenant uniqueness/schema settings; wait only when a consumer exists and it
 
 ## Data Fabric
 
-Use native Data Fabric nodes only when the scenario names Data Fabric
-(`core.datafabric.read` / `.update`). “Data Service” instead names the
-`uipath-uipath-dataservice` connector; route it to `connector(...)`.
-Signatures: `dataFabricRead({ entity, filters? })` and
-`dataFabricUpdate({ entity, record, set })` — `record` is exactly one of `{ byId }` or `{ fromRead: '<read step name>' }`.
+**Route on the VERB, not the name in the prompt.** "Data Fabric" and "Data
+Service" are one product (key `uipath-uipath-dataservice` shows as *UiPath Data Fabric*).
+`core.datafabric.*` has two verbs and no output schema: `dataFabricRead({ entity, filters? })`
+and `dataFabricUpdate({ entity, record, set })` (`record` is one of `{ byId }` /
+`{ fromRead: '<read step>' }`). **Create, delete, get-by-id, query-many with a row
+limit, file fields, declared outputs and events are
+`connector('uipath-uipath-dataservice', …)`** even when the scenario says "Data
+Fabric" — `registry prepare … -f entityName=<Entity>` first.
 
 ```ts
 .step('lookup', dataFabricRead({ entity: 'Invoices',
@@ -563,10 +566,7 @@ Signatures: `dataFabricRead({ entity, filters? })` and
   record: { fromRead: 'lookup' }, set: { Status: 'Paid' } }))
 ```
 
-Filters default to `operator: '='`; `or: true` joins a row with OR. No local
-rung reads a real entity — offline validate is the acceptance bar.
-
-**Reference: [`references/data-fabric.md`](references/data-fabric.md)**
+Filters default to `=`; `or: true` joins with OR. **Reference: [`references/data-fabric.md`](references/data-fabric.md)**
 
 ## Error handling
 
@@ -802,8 +802,8 @@ Signatures: `connector(descriptor, inputs, opts?)`;
   { connection: 'jira', folder: 'shared' }))
 ```
 
-Data Service uses connector key `uipath-uipath-dataservice`; never substitute
-`dataFabricRead`. Discover tenant-specific fields and ids; preserve every scenario-named input.
+Data Fabric is key `uipath-uipath-dataservice`: every entity operation but
+read-one/update-one lives here ([Data Fabric](#data-fabric)). Discover tenant-specific fields and ids; preserve every scenario-named input.
 
 **Reference: [`references/connector-params.md`](references/connector-params.md)**
 

--- a/preview/uipath-maestro-flow/references/api.md
+++ b/preview/uipath-maestro-flow/references/api.md
@@ -450,6 +450,11 @@ Behavior and worked examples: [document-pipeline.md](document-pipeline.md).
 ## dataFabricRead (function)
 
 ````ts
+/**
+ * Read ONE entity record from Data Fabric (`core.datafabric.read`). The record
+ * publishes to the step's `output`; downstream references re-fetch fresh data
+ * at activation time (the engine re-runs the query rather than caching).
+ */
 export declare function dataFabricRead(inputs: DataFabricReadInputs): ActionSpec;
 ````
 
@@ -471,6 +476,7 @@ Behavior and worked examples: [data-fabric.md](data-fabric.md).
 ## queueItem (function)
 
 ````ts
+/** Declare an Orchestrator QUEUE ITEM step. */
 export declare function queueItem(inputs: QueueItemInputs): ActionSpec;
 ````
 
@@ -926,6 +932,12 @@ declare class FlowBuilder extends StepList {
     triggerId(id: string): this;
     /** Set the flow's version. */
     version(vsn: string): this;
+    /**
+     * Declare the `.flow` FILE-FORMAT (schema) version this flow targets.
+     *
+     * @defaultValue `'1.9'` — `FLOW_FORMAT_PROFILE.version`, the fleet write floor.
+     */
+    schemaVersion(version: string): this;
     /** Declare the flow's inputs. Read them with `input('<name>')`. */
     input(shape: Record<string, TypeDesc | VarSpec>): this;
     /** Declare the flow's outputs — what `.return(...)` binds values to. */
@@ -2283,6 +2295,10 @@ export declare abstract class FlowResource extends FlowNode<never> {
 ## rawNode (function)
 
 ````ts
+/**
+ * Place a node this SDK has no factory for, carrying its definition verbatim
+ * (`uipath.exotic.thing@2.1` and the manifest the platform served for it).
+ */
 export declare function rawNode(spec: {
     /** The definition's `nodeType`, verbatim. */
     nodeType: string;
@@ -2551,6 +2567,7 @@ export interface BuiltFlow {
     name: string;
     description?: string;
     version: string;
+    schemaVersion?: string;
     inputs: VarDecl[];
     outputs: VarDecl[];
     vars: VarDecl[];

--- a/preview/uipath-maestro-flow/references/brownfield.md
+++ b/preview/uipath-maestro-flow/references/brownfield.md
@@ -90,8 +90,20 @@ whose definition is MISSING from the file — nothing can carry it, so it lowers
 to `mock() /* TODO: unsupported node type … */`; leave that node untouched and
 merge restores the original.
 
-Two findings the source cannot carry are printed on stderr as
-`flow-decompile: warning: …` (and `--strict` turns the first into an error):
+## The file's schema version comes back out
+
+`decompile` emits `.schemaVersion("<the file's version>")` as the first line of
+the chain, so the recompile declares the version the file had — not the SDK's
+own floor. Most deployed flows are `1.8`; the writable band is `1.6`–`1.10`.
+Leave that call alone unless you mean to retarget the document, and note that
+`check` warns either way off the `1.9` floor (`SCHEMA_VERSION_ABOVE_FLOOR`: a
+reader pinned lower refuses the file; `SCHEMA_VERSION_BELOW_FLOOR`: every reader
+migrates it forward on open). Changing versions is `uip maestro flow migrate`'s
+job, not an edit to this call.
+
+Three findings the source cannot carry are printed on stderr as
+`flow-decompile: warning: …` (and `--strict` turns the first and third into an
+error):
 
 - A node **no trigger reaches** — no edge leads to it, as when a designer or
   `node add` left it unconnected. The builder has no detached-node construct,
@@ -102,6 +114,10 @@ Two findings the source cannot carry are printed on stderr as
   serves `core.trigger.manual@1.0`, the SDK ships `1.0.0`, and versions resolve
   exactly. The source keeps the file's pair, so `compile` refuses it until you
   drop that `{ version }`; the node then takes the SDK's pinned version.
+- A **file-format version outside the writable band** (below `1.6`) — the source
+  omits the `.schemaVersion()` call, marks the spot with a `// TODO:` line, and
+  recompiling writes `1.9`. Migrate the file first, or keep the original and
+  merge into it: `merge` preserves the original's declared version.
 
 Validate `Deployed.merged.flow`, not the intermediate edited compile. Before
 placing it in a solution, copy it over the canonical artifact rather than next

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -4,10 +4,14 @@
 
 Call a curated or generic Integration Service operation.
 
-**Data Service is an Integration Service connector, not Data Fabric.** For a
-task that names a Data Service entity, use connector key
-`uipath-uipath-dataservice` (for example, action `query-entity-records`) and
-never replace it with `dataFabricRead()` / `core.datafabric.read`.
+**Data Fabric entity operations are Integration Service connector actions.**
+"Data Fabric" and "Data Service" name one product — the tenant displays connector
+key `uipath-uipath-dataservice` as *UiPath Data Fabric* — so a task naming either
+one routes here for every entity operation EXCEPT read-one
+(`dataFabricRead()`) and update-one (`dataFabricUpdate()`), the only two verbs
+`core.datafabric.*` has. Create, delete, get-by-id, query-many with a row limit
+and the file record fields are connector actions; see
+[`data-fabric.md`](data-fabric.md) for the routing table.
 
 Signatures:
 

--- a/preview/uipath-maestro-flow/references/data-fabric.md
+++ b/preview/uipath-maestro-flow/references/data-fabric.md
@@ -1,16 +1,74 @@
 # Data Fabric
 
-*Exact signatures, fields, and defaults: [`dataFabricRead()`](api.md#datafabricread-function) and [`dataFabricUpdate()`](api.md#datafabricupdate-function).*
+*Exact signatures, fields, and defaults: [`dataFabricRead()`](api.md#datafabricread-function), [`dataFabricUpdate()`](api.md#datafabricupdate-function), and — for every other entity operation — [`connector()`](api.md#connector-function).*
 
-Data Fabric and Data Service are different authoring surfaces. Use this native
-node family only when the scenario says **Data Fabric**. A **Data Service**
-entity is reached through the Integration Service connector key
-`uipath-uipath-dataservice`; follow
-[`connector-params.md`](connector-params.md) and do not substitute
-`dataFabricRead()` for that request.
+## Two surfaces, one product — choose by the verb
 
-Read entity records with filters (`core.datafabric.read`) and write fields back
-to one record (`core.datafabric.update`).
+"Data Fabric" and "Data Service" are **the same product under two names**: the
+tenant lists connector key `uipath-uipath-dataservice` with the display name
+**UiPath Data Fabric**, and `uip df entities` manages the entities that
+connector reads. What differs is the authoring surface, and the surfaces are not
+interchangeable, because the native one has exactly two verbs:
+
+| Operation | Surface |
+| --- | --- |
+| Read ONE record (optionally filtered) | `dataFabricRead()` → `core.datafabric.read` |
+| Update ONE record | `dataFabricUpdate()` → `core.datafabric.update` |
+| Create a record | `connector('uipath-uipath-dataservice', 'create-entity-record', …)` |
+| Get a record by id | `connector(…, 'get-entity-record-by-id', …)` |
+| Query MANY records / a row limit | `connector(…, 'query-entity-records', …)` |
+| Delete a record | `connector(…, 'delete-entity-record', …)` |
+| Upload / download / delete a file record field | `connector(…, '…-file-…-record-field', …)` |
+| Record Created / Record Updated events | `onEvent(…)` on the same connector |
+
+**So a task can say "Data Fabric" and still be a connector task.** Route on the
+operation you need, never on which of the two names the scenario used. Reaching
+for a `dataFabricCreate()` is the predictable dead end — there is no such node in
+`core.datafabric.*` and none is coming; the create verb has always lived on the
+connector.
+
+`core.datafabric.*` also declares **no output schema**, so a step that must map
+declared outputs downstream is a connector step for that reason alone.
+
+### The connector path, end to end
+
+An entity operation's body fields come from the entity, so the static library
+cannot carry them — `compile` refuses them as unknown inputs until you resolve
+the schema once:
+
+```bash
+npx flow-sdk registry prepare uipath-uipath-dataservice create-entity-record \
+  -f entityName=ContractRegistry
+# → connectors-local/ + bindings.json, with the entity's own fields as inputs
+```
+
+```ts
+.step('create', connector('uipath-uipath-dataservice', 'create-entity-record',
+  { entityName: 'ContractRegistry', contractTitle: 'Q3 renewal', status: 'Draft' },
+  { connection: 'dataservice', folder: 'shared' }))
+```
+
+Full rules, including the parent-field (`GenerateSchema` over `entityName`)
+shape these operations use: [`connector-params.md`](connector-params.md).
+
+**Read the operation's own doc before guessing anything.** The connector library
+ships a Markdown page per operation, and an environment that stages a library
+points `$FLOW_SDK_LIBRARY_MD` at it (`uip maestro registry path --library-md`
+otherwise):
+
+```bash
+sed -n '1,60p' "$FLOW_SDK_LIBRARY_MD/uipath-uipath-dataservice/create-entity-record@1.0.0.md"
+```
+
+That page names the connector *UiPath Data Fabric*, gives the HTTP route
+(`POST /v2/{entityName}/CreateEntityRecord`), and prints the exact
+`prepare-connector … -f entityName=<value>` line to run — before any of it has to
+be inferred.
+
+## The native two-verb family
+
+Read one entity record with filters (`core.datafabric.read`) and write fields
+back to one record (`core.datafabric.update`).
 
 Data Fabric **events** (Record Created / Record Updated on an entity) are
 Integration Service connector events on `uipath-uipath-dataservice`, not this


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `9856764` to current `UiPath/flow-builder-sdk@main` (`4aa3d67`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)