### PR TITLE
fix(uipath-agents): repair failing coder-eval tasks from the 2026-09-03/04 nightlies

### DIFF
--- a/skills/uipath-agents/references/coded/capabilities/datafabric.md
+++ b/skills/uipath-agents/references/coded/capabilities/datafabric.md
@@ -51,6 +51,8 @@ Both paths can coexist in a single agent — use SDK for known operations and `c
 
 Use the Python SDK's `EntitiesService` for deterministic CRUD operations. No LLM intermediary — the agent code specifies exactly what to fetch or write.
 
+**Fixed-shape does not mean inline.** Even when the query is always the same, expose each SDK call as a `@tool`-decorated function and hand it to the agent (see § Wiring into a LangGraph Agent). Do NOT call `sdk.entities.*` directly inside a plain graph node — a tool keeps the SDK call bindable, testable, and invocable by the agent.
+
 ### Setup
 
 ```python
@@ -195,7 +197,7 @@ content: bytes = await sdk.entities.download_attachment_async(
 
 ### Wiring into a LangGraph Agent
 
-Wrap SDK calls as LangChain tools so the agent can invoke them:
+Wrap every SDK call as a LangChain `@tool` so the agent can invoke it. This applies to fixed-shape queries too — the deterministic query lives inside the tool body; the agent decides when to call it. Never place `sdk.entities.*` calls in a plain graph node.
 
 ```python
 from langchain_core.tools import tool
@@ -434,13 +436,15 @@ graph = create_agent(llm, tools=[query_tool, close_order], messages=[SystemMessa
 
 2. **For freeform queries, use `create_datafabric_tool` — not a custom solution.** Import it from `uipath_langchain.agent.tools`. Do NOT use `create_datafabric_query_tool` or any other internal function — those are implementation details and may change without notice.
 
-3. **Single vs. batch trigger behavior** — `insert_record` / `update_record` / `delete_record` fire entity triggers. Batch variants (`insert_records`, `update_records`, `delete_records`) do **not**.
+3. **SDK-direct calls are always `@tool`-wrapped — even fixed-shape ones.** "Same query every time" describes the tool's body, not a reason to skip the tool. An `sdk.entities.*` call inline in a graph node is not invocable by the agent and is the most common shape mistake on this path.
 
-4. **SQL query constraints** — `query_entity_records` only accepts SELECT statements. Queries without WHERE must include LIMIT. Subqueries, UNION, WITH, and DML/DDL are forbidden.
+4. **Single vs. batch trigger behavior** — `insert_record` / `update_record` / `delete_record` fire entity triggers. Batch variants (`insert_records`, `update_records`, `delete_records`) do **not**.
 
-5. **Entity schemas resolve lazily** in `create_datafabric_tool` — the first invocation fetches schemas from Data Fabric and caches them. Subsequent calls reuse the cache.
+5. **SQL query constraints** — `query_entity_records` only accepts SELECT statements. Queries without WHERE must include LIMIT. Subqueries, UNION, WITH, and DML/DDL are forbidden.
 
-6. **Reserved field names** — `Id`, `CreatedBy`, `CreateTime`, `UpdatedBy`, `UpdateTime` are system fields and cannot be used as user field names.
+6. **Entity schemas resolve lazily** in `create_datafabric_tool` — the first invocation fetches schemas from Data Fabric and caches them. Subsequent calls reuse the cache.
+
+7. **Reserved field names** — `Id`, `CreatedBy`, `CreateTime`, `UpdatedBy`, `UpdateTime` are system fields and cannot be used as user field names.
 
 ## Comparison with Low-Code DataFabric Context
 

--- a/skills/uipath-agents/references/coded/capabilities/datafabric.md
+++ b/skills/uipath-agents/references/coded/capabilities/datafabric.md
@@ -63,13 +63,13 @@ sdk = UiPath()
 
 ### Reading Records
 
+`list_records` supports pagination only — it has NO `filter`/`select`/`orderby` parameters. To filter, sort, or project, use `retrieve_records` (see Structured Query with Filters below).
+
 ```python
-# List with OData-style filter and pagination
+# List with pagination
 records = await sdk.entities.list_records_async(
     entity_key="Orders",
-    filter="Status eq 'Open'",
-    select=["OrderId", "CustomerName", "Total"],
-    orderby="CreatedTime desc",
+    start=0,
     limit=50,
 )
 
@@ -200,6 +200,12 @@ Wrap SDK calls as LangChain tools so the agent can invoke them:
 ```python
 from langchain_core.tools import tool
 from uipath.platform import UiPath
+from uipath.platform.entities import (
+    EntityQueryFilter,
+    EntityQueryFilterGroup,
+    LogicalOperator,
+    QueryFilterOperator,
+)
 
 
 @tool
@@ -210,17 +216,29 @@ async def get_open_orders(customer_name: str) -> str:
         customer_name: The customer name to look up.
     """
     sdk = UiPath()
-    # Escape single quotes for OData string literals (e.g. O'Brien → O''Brien)
-    safe_name = customer_name.replace("'", "''")
-    records = await sdk.entities.list_records_async(
+    result = await sdk.entities.retrieve_records_async(
         entity_key="Orders",
-        filter=f"CustomerName eq '{safe_name}' and Status eq 'Open'",
-        select=["OrderId", "Total", "CreatedTime"],
+        filter_group=EntityQueryFilterGroup(
+            logical_operator=LogicalOperator.And,
+            query_filters=[
+                EntityQueryFilter(
+                    field_name="CustomerName",
+                    operator=QueryFilterOperator.Equals,
+                    value=customer_name,
+                ),
+                EntityQueryFilter(
+                    field_name="Status",
+                    operator=QueryFilterOperator.Equals,
+                    value="Open",
+                ),
+            ],
+        ),
+        selected_fields=["OrderId", "Total", "CreatedTime"],
         limit=50,
     )
-    if not records:
+    if not result.items:
         return f"No open orders found for {customer_name}."
-    lines = [f"- {r.model_extra['OrderId']}: ${r.model_extra['Total']}" for r in records]
+    lines = [f"- {r.model_extra['OrderId']}: ${r.model_extra['Total']}" for r in result.items]
     return f"Open orders for {customer_name}:\n" + "\n".join(lines)
 
 
@@ -243,14 +261,15 @@ async def close_order(order_id: str) -> str:
 Then add to your agent graph:
 
 ```python
-from uipath_langchain.agent import create_agent
+from langchain_core.messages import SystemMessage
+from uipath_langchain.agent.react.agent import create_agent
 from uipath_langchain.chat import UiPathChat
 
 def _make_llm():
     """Lazy LLM factory — never call at module level."""
     return UiPathChat(model="gpt-4.1-mini-2025-04-14")
 
-graph = create_agent(_make_llm(), tools=[get_open_orders, close_order], system_prompt="...")
+graph = create_agent(_make_llm(), tools=[get_open_orders, close_order], messages=[SystemMessage("...")])
 ```
 
 ---
@@ -274,6 +293,7 @@ Use the entity ID, name, and folder key from Step 1 discovery.
 ### Usage
 
 ```python
+from langchain_core.messages import SystemMessage
 from uipath.platform.entities import DataFabricEntityItem
 from uipath_langchain.agent.react.agent import create_agent
 from uipath_langchain.agent.tools import create_datafabric_tool
@@ -307,12 +327,12 @@ datafabric_tool = create_datafabric_tool(
     ],
 )
 
-graph = create_agent(llm, tools=[datafabric_tool], system_prompt=system_prompt)
+graph = create_agent(llm, tools=[datafabric_tool], messages=[SystemMessage(system_prompt)])
 ```
 
 ### Key Design Constraint
 
-**The same `system_prompt` must be passed to both `create_agent` and `create_datafabric_tool`.** The tool forwards it to the inner SQL-generation sub-graph so the agent's instructions apply consistently at both levels.
+**The same instruction string must reach both levels: pass it as `messages=[SystemMessage(...)]` to `create_agent` and as `base_system_prompt` to `create_datafabric_tool`.** The tool forwards it to the inner SQL-generation sub-graph so the agent's instructions apply consistently at both levels.
 
 ### How It Works Internally
 
@@ -342,7 +362,7 @@ def create_datafabric_tool(
 |-------|------|----------|--------|
 | `id` | `str` (UUID) | Yes | `uip df entities list` |
 | `name` | `str` | Yes | Entity display name |
-| `folder_key` | `str` (UUID) | Yes | `uip df entities list` or Orchestrator folder ID |
+| `folder_key` | `str` (UUID) | Yes | `uip df entities list` or Orchestrator folder ID. Tenant-level entities: pass the discovered all-zeros `FolderId` (`00000000-0000-0000-0000-000000000000`) as-is |
 | `entity_key` | `str` | No | Technical entity identifier |
 | `description` | `str` | No | Helps the LLM understand the entity's purpose |
 
@@ -353,10 +373,11 @@ def create_datafabric_tool(
 A single agent can use both paths. Use SDK tools for known operations and the DataFabric tool for open-ended exploration:
 
 ```python
+from langchain_core.messages import SystemMessage
 from langchain_core.tools import tool
 from uipath.platform import UiPath
 from uipath.platform.entities import DataFabricEntityItem
-from uipath_langchain.agent import create_agent
+from uipath_langchain.agent.react.agent import create_agent
 from uipath_langchain.agent.tools import create_datafabric_tool
 from uipath_langchain.chat import UiPathChat
 
@@ -402,7 +423,7 @@ query_tool = create_datafabric_tool(
     ],
 )
 
-graph = create_agent(llm, tools=[query_tool, close_order], system_prompt=system_prompt)
+graph = create_agent(llm, tools=[query_tool, close_order], messages=[SystemMessage(system_prompt)])
 ```
 
 ---

--- a/skills/uipath-agents/references/coded/capabilities/human-in-the-loop.md
+++ b/skills/uipath-agents/references/coded/capabilities/human-in-the-loop.md
@@ -13,11 +13,13 @@ If the user has not named one, your ENTIRE response must be a question that list
 | Pattern | When | LangGraph | LlamaIndex |
 |---|---|---|---|
 | API trigger | Resumed via an Orchestrator inbox URL; no Action Center involved | `interrupt({...})` | `InputRequiredEvent(...)` |
-| Action Center task | Structured form for a human reviewer | `interrupt(CreateTask(...))` | `CreateTaskEvent(...)` |
-| Escalation task | Task flagged as escalation | `interrupt(CreateEscalation(...))` | use `CreateTaskEvent` (no event-level distinction) |
+| Action Center task | Structured form for a human reviewer, described as a normal review / sign-off task. Resume delivers only the task `data` | `interrupt(CreateTask(...))` | `CreateTaskEvent(...)` |
+| Escalation task | The request calls the hand-off an escalation (`escalate`, `escalation`, "needs sign-off above a limit"), or the agent must branch on the reviewer's approve/reject outcome. Resume delivers the full `Task` (incl. `action`) | `interrupt(CreateEscalation(...))` | use `CreateTaskEvent` (no event-level distinction) |
 | Wait for existing task | A task was already created elsewhere; resume when it completes | `interrupt(WaitTask(...))` | `WaitTaskEvent(...)` |
 | Invoke a process | Trigger an RPA process; resume on completion | `interrupt(InvokeProcess(...))` | `InvokeProcessEvent(...)` |
 | Wait for existing job | A job is running elsewhere; resume on its completion | `interrupt(WaitJob(...))` | `WaitJobEvent(...)` |
+
+**CreateTask vs CreateEscalation is decided by the request's wording, not by preference.** "Escalate" / "escalation" → `CreateEscalation`. "Review task" / "sign-off" / "not an escalation" → `CreateTask`. Never substitute one for the other: they resume with different payloads (see § Escalation Variant).
 
 OpenAI Agents has no first-class HITL support. Coded Function (no framework) has no checkpoint/resume — call `sdk.tasks.create()` then `sdk.tasks.retrieve()` synchronously if a synchronous human step is needed.
 
@@ -56,7 +58,7 @@ class GraphState(MessagesState):
     request: str
     approval_status: str | None = None
 
-async def escalate_to_human(state: GraphState) -> Command:
+async def request_review(state: GraphState) -> Command:
     task_output = interrupt(CreateTask(
         app_name="RequestReview",
         app_folder_path="MyFolderPath",
@@ -86,7 +88,7 @@ async def escalate_to_human(state: GraphState) -> Command:
 
 ### Escalation Variant
 
-Swap `CreateTask` for `CreateEscalation` when the task is an escalation. It is the same task shape: `CreateEscalation` extends `CreateTask` with the same fields. Difference is the resume return value: escalation returns the full `Task`; normal task returns `task.data`.
+Use `CreateEscalation` whenever the request describes the hand-off as an escalation (a threshold breach routed to a manager / director, "escalate to a reviewer"), or when the agent must act on whether the reviewer approved or rejected. It is the same task shape: `CreateEscalation` extends `CreateTask` with the same fields. Difference is the resume return value: escalation returns the full `Task` (so `task_output.action` / `task_output.data` are both available); normal task returns only `task.data`. Do not use `CreateTask` for an escalation — its resume payload has no `action`, so approve/reject cannot be read back.
 
 ```python
 from uipath.platform.common import CreateEscalation
@@ -143,10 +145,12 @@ output = interrupt(WaitJob(job=background_job, process_folder_path="Workflows"))
 
 ### Conditional Interrupt
 
+Threshold breach routed to a director is an escalation → `CreateEscalation`.
+
 ```python
 async def conditional_workflow(state: GraphState) -> Command:
     if state["amount"] > 10000:
-        result = interrupt(CreateTask(
+        result = interrupt(CreateEscalation(
             assignee="finance-director@example.com",
             title="Approve Large Request",
             app_name="ApprovalProcess",

--- a/skills/uipath-agents/references/coded/capabilities/human-in-the-loop.md
+++ b/skills/uipath-agents/references/coded/capabilities/human-in-the-loop.md
@@ -15,11 +15,11 @@ If the user has not named one, your ENTIRE response must be a question that list
 | API trigger | Resumed via an Orchestrator inbox URL; no Action Center involved | `interrupt({...})` | `InputRequiredEvent(...)` |
 | Action Center task | Structured form for a human reviewer, described as a normal review / sign-off task. Resume delivers only the task `data` | `interrupt(CreateTask(...))` | `CreateTaskEvent(...)` |
 | Escalation task | The request calls the hand-off an escalation (`escalate`, `escalation`, "needs sign-off above a limit"), or the agent must branch on the reviewer's approve/reject outcome. Resume delivers the full `Task` (incl. `action`) | `interrupt(CreateEscalation(...))` | use `CreateTaskEvent` (no event-level distinction) |
-| Wait for existing task | A task was already created elsewhere; resume when it completes | `interrupt(WaitTask(...))` | `WaitTaskEvent(...)` |
+| Wait for existing task | A task was already created elsewhere; resume when it completes. Same split as above: `WaitTask` resumes with the task `data`; `WaitEscalation` resumes with the full `Task` (incl. `action`) | `interrupt(WaitTask(...))` / `interrupt(WaitEscalation(...))` | `WaitTaskEvent(...)` |
 | Invoke a process | Trigger an RPA process; resume on completion | `interrupt(InvokeProcess(...))` | `InvokeProcessEvent(...)` |
 | Wait for existing job | A job is running elsewhere; resume on its completion | `interrupt(WaitJob(...))` | `WaitJobEvent(...)` |
 
-**CreateTask vs CreateEscalation is decided by the request's wording, not by preference.** "Escalate" / "escalation" → `CreateEscalation`. "Review task" / "sign-off" / "not an escalation" → `CreateTask`. Never substitute one for the other: they resume with different payloads (see § Escalation Variant).
+**Task vs Escalation is decided by the request's wording, not by preference — for both the create pair and the wait pair.** "Escalate" / "escalation" / must act on the approve-reject decision → `CreateEscalation` / `WaitEscalation`. "Review task" / "sign-off" / "not an escalation" / only carry the reviewer's input forward → `CreateTask` / `WaitTask`. Never substitute one for the other: they resume with different payloads (see § Escalation Variant).
 
 OpenAI Agents has no first-class HITL support. Coded Function (no framework) has no checkpoint/resume — call `sdk.tasks.create()` then `sdk.tasks.retrieve()` synchronously if a synchronous human step is needed.
 
@@ -114,6 +114,8 @@ async def monitor_task(state: GraphState) -> Command:
     task_output = interrupt(WaitTask(action=state["existing_task"]))
     return Command(update={"task_result": task_output})
 ```
+
+`WaitTask` resumes with the task's `data` only. Swap in `WaitEscalation` (same fields, `from uipath.platform.common import WaitEscalation`) when the existing task is an escalation, or the agent must branch on the reviewer's approve/reject `action` — it resumes with the full `Task`. Same rule as `CreateTask` vs `CreateEscalation`.
 
 **LlamaIndex equivalent:** `ctx.write_event_to_stream(WaitTaskEvent(action=...))`
 

--- a/skills/uipath-agents/references/coded/flow-integration.md
+++ b/skills/uipath-agents/references/coded/flow-integration.md
@@ -36,7 +36,7 @@ Fallback discovery paths if the deploy output is unavailable or unparseable, **t
 
 If all paths return empty / 404, the deploy command's stdout JSON is authoritative — re-run the deploy and capture its output rather than chasing post-hoc discovery endpoints.
 
-For the flow node JSON shape, see the uipath-maestro-flow skill agent-plugin reference (Published variant). `model.section` is `"Published"`.
+For the flow node JSON shape, see the uipath-maestro-flow skill agent-plugin reference (Published variant). Registry output marks the published variant with `category: "agent.published"` and omits `model.section`.
 
 ---
 
@@ -75,7 +75,7 @@ Coded agents use `location: "external"`.
 | Node type | `uipath.core.agent.<resourceKey>` (local, from `project add`) | `uipath.core.agent.<resourceKey>` (Orchestrator-assigned) | `uipath.agent.resource.tool.agent` |
 | Lifecycle | `uip solution upload` (single pass) | `uip codedagent deploy` | `uip codedagent deploy` |
 | Runtime lookup | Studio Web projects API | Orchestrator Releases API | Orchestrator (via parent agent) |
-| `model.section` | `"In this solution"` | `"Published"` or absent | n/a |
+| `model.section` | `"In this solution"` | absent (`category: "agent.published"`) | n/a |
 | Cross-flow reuse | No | Yes | Yes |
 
 ---

--- a/skills/uipath-maestro-flow/references/author/plugins/agent/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/agent/impl.md
@@ -5,7 +5,7 @@ Agent nodes invoke UiPath AI agents through `uipath.core.agent.{key}`. Coded (Py
 Agents are either:
 
 - **In this solution**: a sibling project. `{key}` is the local `resource.key` minted by `uip solution projects add` and written to `resources/solution_folder/process/agent/<CodedAgentProject>.json`. Runtime resolution uses the Studio Web projects API after `uip solution upload`; `definitions[]` uses `model.section: "In this solution"`.
-- **Published**: an Orchestrator tenant resource. `{key}` is the Orchestrator-assigned resource key, discoverable with `uip maestro flow registry search`; `definitions[]` uses `model.section: "Published"`.
+- **Published**: an Orchestrator tenant resource. `{key}` is the Orchestrator-assigned resource key, discoverable with `uip maestro flow registry search`; `definitions[]` uses `category: "agent.published"` (registry output omits `model.section`).
 
 The `nodes[]` shape is the same; only the `definitions[]` manifest differs.
 

--- a/tests/tasks/uipath-agents/coded/coded_in_flow_published/check_coded_in_flow_published.py
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_published/check_coded_in_flow_published.py
@@ -8,8 +8,11 @@ Asserts:
      would indicate Pattern 1, not Pattern 2).
   2. The flow file contains at least one node of type
      `uipath.core.agent.<resourceKey>`.
-  3. That agent node's `model.section` is `"Published"` (the Pattern 2
-     marker per `flow-integration.md`'s Pattern Comparison table).
+  3. The agent node's `definitions[]` entry carries the Pattern 2 marker:
+     either `model.section == "Published"` (legacy registry output) or —
+     per current registry output, which omits `model.section` entirely —
+     `category == "agent.published"`. Matches `flow-integration.md`'s
+     Pattern Comparison table (`"Published"` or absent).
   4. The flow file does NOT contain `"In this solution"` for that node
      (would indicate Pattern 1).
 """
@@ -63,12 +66,37 @@ def assert_pattern_2_not_pattern_1(flow_path: Path) -> dict:
             "The agent must be referenced as a Published resource."
         )
 
-    if '"Published"' not in text:
+    agent_defs = [
+        dfn
+        for dfn in doc.get("definitions", [])
+        if isinstance(dfn, dict)
+        and str(dfn.get("nodeType", "")).startswith("uipath.core.agent.")
+    ]
+    if not agent_defs:
         fail(
-            f"{flow_path} does not contain `section: \"Published\"` for the agent node. "
-            "Pattern 2 requires the agent node's model.section to be 'Published'."
+            f"{flow_path} has no `definitions[]` entry for a "
+            "`uipath.core.agent.<resourceKey>` node — the definition must be "
+            "copied verbatim from `uip maestro flow registry get`"
         )
-    print("OK: agent node carries `section: \"Published\"` (Pattern 2)")
+    for dfn in agent_defs:
+        node_type = dfn.get("nodeType")
+        section = (dfn.get("model") or {}).get("section")
+        category = dfn.get("category")
+        # Pattern 2 marker: legacy registry output set model.section to
+        # "Published"; current registry output omits model.section and sets
+        # category to "agent.published" instead. Accept either.
+        if section == "Published" or (section is None and category == "agent.published"):
+            continue
+        fail(
+            f"{flow_path} definition for `{node_type}` is not Pattern 2 "
+            f"(Published): model.section={section!r}, category={category!r}. "
+            "Expected model.section == 'Published' or (model.section absent "
+            "and category == 'agent.published')."
+        )
+    print(
+        "OK: agent definition carries the Published marker "
+        "(`model.section: \"Published\"` or `category: \"agent.published\"`) (Pattern 2)"
+    )
 
     return doc
 

--- a/tests/tasks/uipath-agents/coded/datafabric_combined/check_datafabric_combined.py
+++ b/tests/tasks/uipath-agents/coded/datafabric_combined/check_datafabric_combined.py
@@ -90,10 +90,17 @@ def check_entity_config(text: str) -> None:
         sys.exit("FAIL: no id= parameter found in DataFabricEntityItem configuration")
     print(f"OK: entity ID configured ({uuids[0][:8]}...)")
 
-    # Verify folder_key= parameter exists (inline or constant)
-    if not re.search(r'\bfolder_key\s*=', text):
-        sys.exit("FAIL: no folder_key= parameter found in DataFabricEntityItem configuration")
-    print(f"OK: folder key configured")
+    # Verify the folder is configured (inline or constant). The SDK model's
+    # field is `folder_key`, but its constructor alias is `folderId` (the
+    # exact name `uip df entities list` prints), so both spellings are
+    # valid Python and both must pass.
+    m = re.search(r'\b(folder_key|folderId)\s*=', text)
+    if not m:
+        sys.exit(
+            "FAIL: no folder_key= / folderId= parameter found in "
+            "DataFabricEntityItem configuration"
+        )
+    print(f"OK: folder key configured ({m.group(1)}=)")
 
 
 def check_prompt_forwarding(text: str) -> None:

--- a/tests/tasks/uipath-agents/coded/datafabric_combined/check_datafabric_combined.py
+++ b/tests/tasks/uipath-agents/coded/datafabric_combined/check_datafabric_combined.py
@@ -55,7 +55,7 @@ def find_graph_module() -> Path:
 
 def check_nl_tool_factory(text: str) -> None:
     if not re.search(
-        r"from\s+uipath_langchain\.agent\.tools\s+import\s+[^\n]*\bcreate_datafabric_tool\b",
+        r"from\s+uipath_langchain\.agent\.tools\s+import\s+(?:[^\n]*\bcreate_datafabric_tool\b|\([^)]*\bcreate_datafabric_tool\b)",
         text,
     ):
         sys.exit(
@@ -67,7 +67,7 @@ def check_nl_tool_factory(text: str) -> None:
 
 def check_entity_item_import(text: str) -> None:
     if not re.search(
-        r"from\s+uipath\.platform\.entities\s+import\s+[^\n]*\bDataFabricEntityItem\b",
+        r"from\s+uipath\.platform\.entities\s+import\s+(?:[^\n]*\bDataFabricEntityItem\b|\([^)]*\bDataFabricEntityItem\b)",
         text,
     ):
         sys.exit(
@@ -110,7 +110,7 @@ def check_prompt_forwarding(text: str) -> None:
 
 def check_sdk_import(text: str) -> None:
     if not re.search(
-        r"from\s+uipath\.platform\s+import\s+[^\n]*\bUiPath\b", text
+        r"from\s+uipath\.platform\s+import\s+(?:[^\n]*\bUiPath\b|\([^)]*\bUiPath\b)", text
     ):
         sys.exit("FAIL: must import UiPath from `uipath.platform`")
     print("OK: imports UiPath from uipath.platform")

--- a/tests/tasks/uipath-agents/coded/datafabric_combined/datafabric_combined.yaml
+++ b/tests/tasks/uipath-agents/coded/datafabric_combined/datafabric_combined.yaml
@@ -12,12 +12,12 @@ run_limits:
 
 initial_prompt: |
   Build me a coded agent called `order-manager` that works with our
-  order data in Data Fabric — find the right entity by listing what's
-  available. It needs to handle two things:
+  order data in Data Fabric — the entity is named exactly `Order`;
+  find it by listing what's available. It needs to handle two things:
   1. Users asking freeform questions about orders — anything from
      totals to customer lookups. I can't predict these ahead of time.
-  2. Closing a specific order by setting its Status to "Closed" —
-     this is always the same operation.
+  2. Marking a specific order as delivered by setting its Status to
+     "Delivered" — this is always the same operation.
 
   The agent's instructions should apply consistently everywhere.
   Scaffold and init only — don't run or deploy.

--- a/tests/tasks/uipath-agents/coded/datafabric_nl_tool/check_datafabric_nl_tool.py
+++ b/tests/tasks/uipath-agents/coded/datafabric_nl_tool/check_datafabric_nl_tool.py
@@ -51,7 +51,7 @@ def find_graph_module() -> Path:
 
 def check_tool_factory_import(text: str) -> None:
     if not re.search(
-        r"from\s+uipath_langchain\.agent\.tools\s+import\s+[^\n]*\bcreate_datafabric_tool\b",
+        r"from\s+uipath_langchain\.agent\.tools\s+import\s+(?:[^\n]*\bcreate_datafabric_tool\b|\([^)]*\bcreate_datafabric_tool\b)",
         text,
     ):
         sys.exit(
@@ -63,7 +63,7 @@ def check_tool_factory_import(text: str) -> None:
 
 def check_entity_item_import(text: str) -> None:
     if not re.search(
-        r"from\s+uipath\.platform\.entities\s+import\s+[^\n]*\bDataFabricEntityItem\b",
+        r"from\s+uipath\.platform\.entities\s+import\s+(?:[^\n]*\bDataFabricEntityItem\b|\([^)]*\bDataFabricEntityItem\b)",
         text,
     ):
         sys.exit(

--- a/tests/tasks/uipath-agents/coded/datafabric_sdk_tool/check_datafabric_sdk_tool.py
+++ b/tests/tasks/uipath-agents/coded/datafabric_sdk_tool/check_datafabric_sdk_tool.py
@@ -5,7 +5,7 @@ Asserts:
   1. `main.py` (or `graph.py`) imports `UiPath` from `uipath.platform`.
   2. The graph module calls a specific sdk.entities retrieval method
      (list_records, retrieve_records, query_entity_records, or get_record).
-  3. A `filter=` parameter is present in the retrieval call.
+  3. A `filter=` or `filter_group=` parameter is present in the retrieval call.
   4. An `entity_key=` parameter references a discovered entity.
   5. A `@tool`-decorated function wraps the SDK call.
   6. No module-level `UiPath()` or LLM client construction.
@@ -46,7 +46,7 @@ def find_graph_module() -> Path:
 
 def check_sdk_import(text: str) -> None:
     if not re.search(
-        r"from\s+uipath\.platform\s+import\s+[^\n]*\bUiPath\b", text
+        r"from\s+uipath\.platform\s+import\s+(?:[^\n]*\bUiPath\b|\([^)]*\bUiPath\b)", text
     ):
         sys.exit(
             "FAIL: must import UiPath from `uipath.platform` "
@@ -69,7 +69,7 @@ def check_entities_usage(text: str) -> None:
 
 
 def check_filter_usage(text: str) -> None:
-    if not re.search(r'\bfilter\s*=', text):
+    if not re.search(r'\bfilter(?:_group)?\s*=', text):
         sys.exit(
             "FAIL: no filter= parameter found — "
             "expected the tool to filter records by customer name"
@@ -80,8 +80,13 @@ def check_filter_usage(text: str) -> None:
 def check_entity_key(text: str) -> None:
     # The agent should have discovered an entity and passed its name
     # as entity_key= to the SDK call. We don't check for a specific
-    # entity name — just that entity_key is present with a non-empty string.
-    if not re.search(r'entity_key\s*=\s*["\'][^"\']+["\']', text):
+    # entity name — just that entity_key is present, either as an inline
+    # string or as a module-level constant (entity_key=ORDER_ENTITY where
+    # ORDER_ENTITY = "..."), matching the combined-task checker's tolerance.
+    if not (
+        re.search(r'entity_key\s*=\s*["\'][^"\']+["\']', text)
+        or re.search(r'entity_key\s*=\s*[A-Za-z_][A-Za-z0-9_]*', text)
+    ):
         sys.exit(
             "FAIL: no entity_key= with a string value found — "
             "expected the agent to reference a discovered Data Fabric entity"

--- a/tests/tasks/uipath-agents/coded/datafabric_sdk_tool/datafabric_sdk_tool.yaml
+++ b/tests/tasks/uipath-agents/coded/datafabric_sdk_tool/datafabric_sdk_tool.yaml
@@ -12,9 +12,11 @@ run_limits:
 initial_prompt: |
   Build me a coded agent called `order-lookup` that can look up
   customer orders. The data lives in Data Fabric — find the right
-  entity by listing what's available. The agent should take a
-  customer name and return their open orders — the query is always
-  the same shape.
+  entity by listing what's available. Users ask in plain language
+  ("what's still open for Acme?", "any outstanding orders from the
+  O'Brien account?") — the agent should work out which customer they
+  mean, fetch that customer's open orders (that query is always the
+  same shape), and summarize the results conversationally.
 
   Scaffold and init only — don't run or deploy.
 

--- a/tests/tasks/uipath-agents/coded/eval_exact_match/check_eval_exact_match.py
+++ b/tests/tasks/uipath-agents/coded/eval_exact_match/check_eval_exact_match.py
@@ -2,27 +2,41 @@
 """Eval-lifecycle check for the ExactMatch path.
 
 Validates that the agent authored both halves of the evaluation
-harness — the evaluator config under `evaluations/evaluators/` AND
-the evaluation set under `evaluations/eval-sets/` whose `evaluatorRefs`
-match the evaluator `id` — and that `uip codedagent eval --no-report`
-produced an output file in which every test case has
-`status == "PASSED"` (an enum-constrained tag on deliberately
-unambiguous cases + a deterministic evaluator means anything else is
-a bug).
+harness — an exact-match evaluator config under `evaluations/evaluators/`
+AND an evaluation set under `evaluations/eval-sets/` whose `evaluatorRefs`
+reference that evaluator — and that `uip codedagent eval --no-report`
+actually ran that evaluator over every case of the set and wrote the
+results out.
+
+This grades the evaluation HARNESS, not the authored agent: whether the
+language tagger gets every case right is the agent's quality, which
+depends on the LLM and is not what this task exercises. Scores are
+reported as INFO and never fail the check.
+
+Everything is located by CONTENT, never by file count or dictated
+filename:
+
+  * The skill's quickstart mandates a `smoke-test.json` eval set for every
+    agent, and the prompt asks for a language-tagging eval set — so two
+    eval-set files is the *expected* shape, not an error. Any number of
+    evaluators / eval sets may exist; the check grades the exact-match
+    ones.
+  * Results files are matched to eval sets by `evaluationSetName` ==
+    the set's `name`, wherever the agent chose to write them.
 
 Checks:
-  1. `lingo-tagger/evaluations/evaluators/<file>.json` has
-     `evaluatorTypeId` == "uipath-exact-match" and a non-empty `id`.
-  2. `lingo-tagger/evaluations/eval-sets/<file>.json` has version "1.0",
-     `evaluatorRefs` referencing the evaluator id, at least 2 test
-     cases, and each test case's `evaluationCriterias` keys the
-     evaluator id.
-  3. `eval-results.json` exists with the documented top-level shape
-     (`evaluationSetName`, `evaluationSetResults: [...]`), every
-     test case in `evaluationSetResults` has at least one matching
-     `evaluationRunResults[]` entry for the configured evaluator,
-     and every such entry scored exactly 1.0 (unambiguous cases +
-     deterministic evaluator: anything below 1.0 is a bug).
+  1. >= 1 evaluator under `evaluations/evaluators/` has
+     `evaluatorTypeId == "uipath-exact-match"` and a non-empty `id`.
+  2. >= 1 eval set under `evaluations/eval-sets/` has version "1.0",
+     `evaluatorRefs` naming an exact-match evaluator, >= 2 test cases,
+     and every case's `evaluationCriterias` keyed on that evaluator.
+  3. >= 1 qualifying eval set has a results file (top-level
+     `evaluationSetResults` list, `evaluationSetName` == set name) with
+     one entry per test case, each carrying an `evaluationRunResults`
+     entry for the evaluator with a numeric `result.score` — i.e. the
+     exact-match evaluator ran on every case. The score VALUE is not
+     graded. A qualifying set that was never run is reported but not
+     fatal (the graded set is the one the agent ran).
 """
 
 from __future__ import annotations
@@ -30,12 +44,15 @@ from __future__ import annotations
 import json
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("lingo-tagger")
+EXACT_MATCH_TYPE = "uipath-exact-match"
+SKIP_DIRS = {".venv", "node_modules", "__pycache__", ".git"}
 
 
 def _load_json(path: Path) -> dict:
@@ -47,141 +64,215 @@ def _load_json(path: Path) -> dict:
         sys.exit(f"FAIL: {path} is not valid JSON: {e}")
 
 
-def find_single_json(directory: Path) -> Path:
+def _json_files(directory: Path) -> list[Path]:
     if not directory.is_dir():
         sys.exit(f"FAIL: {directory} does not exist")
     files = sorted(p for p in directory.glob("*.json") if p.is_file())
     if not files:
         sys.exit(f"FAIL: {directory} contains no .json files")
-    if len(files) > 1:
-        sys.exit(f"FAIL: {directory} should contain exactly one .json file, got {len(files)}")
-    return files[0]
+    return files
 
 
-def check_evaluator() -> str:
-    path = find_single_json(ROOT / "evaluations" / "evaluators")
-    doc = _load_json(path)
-    type_id = doc.get("evaluatorTypeId")
-    if type_id != "uipath-exact-match":
+def check_evaluators() -> set[str]:
+    """Return the ids of every exact-match evaluator config."""
+    ids: set[str] = set()
+    seen: list[str] = []
+    for path in _json_files(ROOT / "evaluations" / "evaluators"):
+        doc = _load_json(path)
+        type_id = doc.get("evaluatorTypeId")
+        seen.append(f"{path.name} ({type_id!r})")
+        if type_id != EXACT_MATCH_TYPE:
+            continue
+        eval_id = doc.get("id")
+        if not eval_id:
+            sys.exit(f"FAIL: {path.name} is an exact-match evaluator but is missing `id`")
+        ids.add(eval_id)
+        print(f'OK: evaluator config {path.name} has evaluatorTypeId={type_id!r} id={eval_id!r}')
+    if not ids:
         sys.exit(
-            f'FAIL: {path.name} evaluatorTypeId should be "uipath-exact-match", '
-            f'got {type_id!r}'
+            f'FAIL: no evaluator with evaluatorTypeId == "{EXACT_MATCH_TYPE}" under '
+            f"evaluations/evaluators/. Found: {', '.join(seen)}"
         )
-    eval_id = doc.get("id")
-    if not eval_id:
-        sys.exit(f"FAIL: {path.name} is missing required `id` field")
-    print(f'OK: evaluator config {path.name} has evaluatorTypeId={type_id!r} id={eval_id!r}')
-    return eval_id
+    return ids
 
 
-def check_eval_set(evaluator_id: str) -> int:
-    path = find_single_json(ROOT / "evaluations" / "eval-sets")
-    doc = _load_json(path)
-    if doc.get("version") != "1.0":
-        sys.exit(f'FAIL: eval set version should be "1.0", got {doc.get("version")!r}')
-    refs = doc.get("evaluatorRefs") or []
-    if evaluator_id not in refs:
-        sys.exit(
-            f'FAIL: eval set `evaluatorRefs` does not include the evaluator '
-            f'id {evaluator_id!r}. Got: {refs}'
-        )
-    cases = doc.get("evaluations") or []
-    if len(cases) < 2:
-        sys.exit(f"FAIL: eval set must have at least 2 test cases, got {len(cases)}")
-    for i, case in enumerate(cases):
-        crit = case.get("evaluationCriterias") or {}
-        if evaluator_id not in crit:
-            sys.exit(
-                f'FAIL: eval set test case {i} (`{case.get("id", "?")}`) does '
-                f'not key its evaluationCriterias on the evaluator id '
-                f'{evaluator_id!r}. Got keys: {list(crit.keys())}'
+@dataclass
+class EvalSet:
+    path: Path
+    name: str
+    evaluator_id: str
+    case_count: int
+
+
+def find_eval_sets(evaluator_ids: set[str]) -> list[EvalSet]:
+    """Return every eval set that is wired to an exact-match evaluator."""
+    qualifying: list[EvalSet] = []
+    rejected: list[str] = []
+    for path in _json_files(ROOT / "evaluations" / "eval-sets"):
+        doc = _load_json(path)
+        if doc.get("version") != "1.0":
+            rejected.append(f'{path.name}: version is {doc.get("version")!r}, expected "1.0"')
+            continue
+        refs = [r for r in (doc.get("evaluatorRefs") or []) if r in evaluator_ids]
+        if not refs:
+            rejected.append(
+                f"{path.name}: evaluatorRefs {doc.get('evaluatorRefs')!r} names no "
+                f"exact-match evaluator {sorted(evaluator_ids)}"
             )
-    print(f'OK: eval set {path.name} references {evaluator_id!r} across {len(cases)} test cases')
-    return len(cases)
+            continue
+        evaluator_id = refs[0]
+        cases = doc.get("evaluations") or []
+        if len(cases) < 2:
+            rejected.append(f"{path.name}: only {len(cases)} test case(s), need >= 2")
+            continue
+        unkeyed = [
+            case.get("id", f"#{i}")
+            for i, case in enumerate(cases)
+            if evaluator_id not in (case.get("evaluationCriterias") or {})
+        ]
+        if unkeyed:
+            rejected.append(
+                f"{path.name}: test case(s) {unkeyed} do not key evaluationCriterias "
+                f"on {evaluator_id!r}"
+            )
+            continue
+        name = doc.get("name") or path.stem
+        qualifying.append(EvalSet(path, name, evaluator_id, len(cases)))
+        print(
+            f'OK: eval set {path.name} ("{name}") references {evaluator_id!r} '
+            f"across {len(cases)} test cases"
+        )
+    if not qualifying:
+        sys.exit(
+            "FAIL: no eval set under evaluations/eval-sets/ is wired to an "
+            "exact-match evaluator. " + " | ".join(rejected)
+        )
+    return qualifying
 
 
-def _find_results_file() -> Path:
-    """Locate the eval-results JSON by content, not a dictated filename.
+def _find_results_files() -> dict[str, list[Path]]:
+    """Map `evaluationSetName` -> results files carrying that name.
 
     `uip codedagent eval --output-file <name>` lets the caller pick the
-    name (the skill's examples use `results.json`); accept any project
-    JSON carrying the documented `evaluationSetResults` shape so the
-    prompt doesn't have to dictate the filename.
+    filename and location, so results are found by the documented
+    top-level shape and matched to their eval set by name.
     """
-    skip = {".venv", "node_modules", "__pycache__", ".git"}
+    found: dict[str, list[Path]] = {}
     for p in sorted(ROOT.rglob("*.json")):
-        if any(part in skip for part in p.parts):
+        if any(part in SKIP_DIRS for part in p.parts):
             continue
         try:
             doc = json.loads(p.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             continue
         if isinstance(doc, dict) and isinstance(doc.get("evaluationSetResults"), list):
-            return p
-    sys.exit(
-        "FAIL: no eval-results JSON with a top-level `evaluationSetResults` "
-        "list found in the project — `uip codedagent eval --output-file` "
-        "likely never produced results"
-    )
+            found.setdefault(str(doc.get("evaluationSetName")), []).append(p)
+    return found
 
 
-def check_results(evaluator_id: str, expected_case_count: int) -> None:
-    path = _find_results_file()
+def _validate_results(path: Path, eval_set: EvalSet) -> list[str]:
+    """Return a list of problems with one results file for one eval set."""
     doc = _load_json(path)
-    if not isinstance(doc, dict):
-        sys.exit(f"FAIL: {path.name} top-level should be an object, got {type(doc).__name__}")
     cases = doc.get("evaluationSetResults")
     if not isinstance(cases, list) or not cases:
-        sys.exit(
-            f"FAIL: {path.name} is missing a non-empty `evaluationSetResults` "
-            f"list. Top-level keys: {list(doc.keys())}"
+        return [f"{path.name}: `evaluationSetResults` is missing or empty"]
+    problems: list[str] = []
+    if len(cases) != eval_set.case_count:
+        problems.append(
+            f"{path.name}: {len(cases)} entries in evaluationSetResults, but eval set "
+            f"{eval_set.path.name} has {eval_set.case_count} test cases"
         )
-    if len(cases) != expected_case_count:
-        sys.exit(
-            f"FAIL: expected {expected_case_count} entries in "
-            f"`evaluationSetResults` (one per eval-set test case), got {len(cases)}"
-        )
-    print(f'OK: eval-results.json carries {len(cases)} entries in evaluationSetResults')
-    bad_cases = []
-    matching_run_count = 0
     for case in cases:
         if not isinstance(case, dict):
             continue
         case_name = case.get("evaluationName") or "?"
-        runs = case.get("evaluationRunResults") or []
         matching = [
-            r for r in runs
-            if isinstance(r, dict) and r.get("evaluatorId") == evaluator_id
+            r for r in (case.get("evaluationRunResults") or [])
+            if isinstance(r, dict) and r.get("evaluatorId") == eval_set.evaluator_id
         ]
         if not matching:
-            bad_cases.append(
-                f'{case_name!r}: no evaluationRunResults entry references '
-                f'evaluatorId={evaluator_id!r}'
+            problems.append(
+                f"{path.name} {case_name!r}: no evaluationRunResults entry for "
+                f"evaluatorId={eval_set.evaluator_id!r}"
             )
             continue
         for r in matching:
             score = (r.get("result") or {}).get("score")
-            if score != 1.0:
-                bad_cases.append(
-                    f'{case_name!r}: evaluator {evaluator_id!r} scored '
-                    f'{score!r}, expected 1.0 (unambiguous cases + '
-                    f'deterministic evaluator)'
+            if not isinstance(score, (int, float)):
+                problems.append(
+                    f"{path.name} {case_name!r}: evaluator {eval_set.evaluator_id!r} "
+                    f"run has no numeric `result.score` (got {score!r}) — the "
+                    f"evaluator did not actually run"
                 )
-        matching_run_count += len(matching)
-    if bad_cases:
-        sys.exit("FAIL: " + " | ".join(bad_cases))
-    print(
-        f'OK: every test case has an ExactMatchEvaluator run scoring 1.0 '
-        f'({matching_run_count} run(s) across {len(cases)} case(s))'
-    )
+    return problems
+
+
+def _score_summary(path: Path, eval_set: EvalSet) -> str:
+    """Informational: how the authored agent fared. Not graded."""
+    doc = _load_json(path)
+    scores = [
+        (r.get("result") or {}).get("score")
+        for case in doc.get("evaluationSetResults") or []
+        if isinstance(case, dict)
+        for r in case.get("evaluationRunResults") or []
+        if isinstance(r, dict) and r.get("evaluatorId") == eval_set.evaluator_id
+    ]
+    nums = [s for s in scores if isinstance(s, (int, float))]
+    if not nums:
+        return "no scores"
+    perfect = sum(1 for s in nums if s == 1.0)
+    return f"{perfect}/{len(nums)} cases scored 1.0 (avg {sum(nums) / len(nums):.2f})"
+
+
+def check_results(eval_sets: list[EvalSet]) -> None:
+    by_name = _find_results_files()
+    if not by_name:
+        sys.exit(
+            "FAIL: no eval-results JSON with a top-level `evaluationSetResults` "
+            "list found in the project — `uip codedagent eval --output-file` "
+            "likely never produced results"
+        )
+    validated = 0
+    unrun: list[str] = []
+    problems: list[str] = []
+    for es in eval_sets:
+        paths = by_name.get(es.name)
+        if not paths and len(eval_sets) == 1 and len(by_name) == 1:
+            # Single set, single results file: pair them even if the name drifted.
+            paths = next(iter(by_name.values()))
+        if not paths:
+            unrun.append(f'{es.path.name} ("{es.name}")')
+            continue
+        for p in paths:
+            bad = _validate_results(p, es)
+            if bad:
+                problems.extend(bad)
+            else:
+                validated += 1
+                print(
+                    f"OK: {p.relative_to(ROOT)} covers eval set {es.path.name}: "
+                    f"{es.evaluator_id!r} ran on all {es.case_count} case(s)"
+                )
+                print(f"INFO: {p.relative_to(ROOT)}: {_score_summary(p, es)} (not graded)")
+    if problems:
+        sys.exit("FAIL: " + " | ".join(problems))
+    if validated == 0:
+        sys.exit(
+            "FAIL: results files exist "
+            f"({', '.join(str(p.relative_to(ROOT)) for ps in by_name.values() for p in ps)}) "
+            f"but none has evaluationSetName matching a qualifying eval set "
+            f"({', '.join(unrun)})"
+        )
+    if unrun:
+        print(f"NOTE: eval set(s) authored but not run: {', '.join(unrun)}")
 
 
 def main() -> None:
     if not ROOT.is_dir():
         sys.exit(f"FAIL: project directory {ROOT} does not exist")
-    evaluator_id = check_evaluator()
-    case_count = check_eval_set(evaluator_id)
-    check_results(evaluator_id, case_count)
+    evaluator_ids = check_evaluators()
+    eval_sets = find_eval_sets(evaluator_ids)
+    check_results(eval_sets)
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/coded/eval_exact_match/check_eval_exact_match.py
+++ b/tests/tasks/uipath-agents/coded/eval_exact_match/check_eval_exact_match.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
-"""Eval-lifecycle check for the deterministic ExactMatch path.
+"""Eval-lifecycle check for the ExactMatch path.
 
 Validates that the agent authored both halves of the evaluation
 harness — the evaluator config under `evaluations/evaluators/` AND
 the evaluation set under `evaluations/eval-sets/` whose `evaluatorRefs`
 match the evaluator `id` — and that `uip codedagent eval --no-report`
 produced an output file in which every test case has
-`status == "PASSED"` (deterministic agent + deterministic evaluator
-means anything else is a bug).
+`status == "PASSED"` (an enum-constrained tag on deliberately
+unambiguous cases + a deterministic evaluator means anything else is
+a bug).
 
 Checks:
-  1. `adder/evaluations/evaluators/<file>.json` has `evaluatorTypeId`
-     == "uipath-exact-match" and a non-empty `id`.
-  2. `adder/evaluations/eval-sets/<file>.json` has version "1.0",
+  1. `lingo-tagger/evaluations/evaluators/<file>.json` has
+     `evaluatorTypeId` == "uipath-exact-match" and a non-empty `id`.
+  2. `lingo-tagger/evaluations/eval-sets/<file>.json` has version "1.0",
      `evaluatorRefs` referencing the evaluator id, at least 2 test
      cases, and each test case's `evaluationCriterias` keys the
      evaluator id.
@@ -20,7 +21,7 @@ Checks:
      (`evaluationSetName`, `evaluationSetResults: [...]`), every
      test case in `evaluationSetResults` has at least one matching
      `evaluationRunResults[]` entry for the configured evaluator,
-     and every such entry scored exactly 1.0 (deterministic agent +
+     and every such entry scored exactly 1.0 (unambiguous cases +
      deterministic evaluator: anything below 1.0 is a bug).
 """
 
@@ -34,7 +35,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
-ROOT = find_project_root("adder")
+ROOT = find_project_root("lingo-tagger")
 
 
 def _load_json(path: Path) -> dict:
@@ -163,7 +164,7 @@ def check_results(evaluator_id: str, expected_case_count: int) -> None:
             if score != 1.0:
                 bad_cases.append(
                     f'{case_name!r}: evaluator {evaluator_id!r} scored '
-                    f'{score!r}, expected 1.0 (deterministic agent + '
+                    f'{score!r}, expected 1.0 (unambiguous cases + '
                     f'deterministic evaluator)'
                 )
         matching_run_count += len(matching)

--- a/tests/tasks/uipath-agents/coded/eval_exact_match/eval_exact_match.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_exact_match/eval_exact_match.yaml
@@ -1,30 +1,32 @@
 task_id: skill-agent-coded-eval-exact-match
 description: >
-  Coded-agent eval lifecycle, deterministic path. Verifies the skill
+  Coded-agent eval lifecycle, exact-match path. Verifies the skill
   guides the agent to author an evaluator config under
   `evaluations/evaluators/`, an evaluation set under
   `evaluations/eval-sets/` whose `evaluatorRefs` match the evaluator
-  `id`, and run `uip codedagent eval --no-report` against a
-  deterministic Simple Function agent. All test cases must score 1.0
-  and report PASSED in the output file.
-tags: [uipath-agents, e2e, coded, lifecycle:validate, feature:eval]
+  `id`, and run `uip codedagent eval --no-report` against a LangGraph
+  enum classifier (language tagging via the LLM gateway). Cases are
+  deliberately unambiguous, so every test case must score 1.0 and
+  report PASSED in the output file.
+tags: [uipath-agents, e2e, mode:build, coded, lifecycle:validate, feature:eval, feature:framework-langgraph]
 
 run_limits:
-  expected_turns: 23
+  expected_turns: 35
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a deterministic UiPath coded agent named `adder` that adds two
-  whole numbers and returns the sum — no LLM, just arithmetic.
+  Build a LangGraph UiPath coded agent named `lingo-tagger` that reads
+  a short customer message and tags its language — english, french,
+  german, or spanish. Use the platform LLM gateway and return just the
+  tag.
 
-  Then set up an evaluation for it: cover a handful of cases and check
-  that the agent's output matches the expected answer exactly. Since
-  both the agent and the check are deterministic, every case should
-  score a perfect pass. Run the evals locally — no cloud reporting — and
-  write the results out so I can look them over.
+  Then set up an evaluation for it: cover a handful of clearly
+  unambiguous messages and check the tag matches the expected one
+  exactly. The cases are blatant on purpose — every one should score a
+  perfect pass. Run the evals locally — no cloud reporting — and write
+  the results out so I can look them over.
 
-  It's all local — no sign-in, nothing to publish or deploy. Work
-  through it in a single pass.
+  Nothing to publish or deploy. Work through it in a single pass.
 
 success_criteria:
   - type: command_executed

--- a/tests/tasks/uipath-agents/coded/eval_exact_match/eval_exact_match.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_exact_match/eval_exact_match.yaml
@@ -5,9 +5,12 @@ description: >
   `evaluations/evaluators/`, an evaluation set under
   `evaluations/eval-sets/` whose `evaluatorRefs` match the evaluator
   `id`, and run `uip codedagent eval --no-report` against a LangGraph
-  enum classifier (language tagging via the LLM gateway). Cases are
-  deliberately unambiguous, so every test case must score 1.0 and
-  report PASSED in the output file.
+  enum classifier (language tagging via the LLM gateway). Grades the
+  evaluation harness only: the exact-match evaluator must have run on
+  every case of the set and written results. The scores themselves are
+  the authored agent's quality, reported as INFO and never graded. The
+  skill-mandated `smoke-test.json` may coexist with the task's own set;
+  the checker locates sets and results by content, not by file count.
 tags: [uipath-agents, e2e, mode:build, coded, lifecycle:validate, feature:eval, feature:framework-langgraph]
 
 run_limits:
@@ -46,7 +49,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Evaluator + eval-set + results shape, all test cases PASSED"
+    description: "Exact-match evaluator authored, eval set wired to it, evaluator ran on every case with results written (scores not graded)"
     command: "python3 $TASK_DIR/check_eval_exact_match.py"
     timeout: 30
     expected_exit_code: 0

--- a/tests/tasks/uipath-agents/coded/hitl_create_task/check_hitl_create_task.py
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task/check_hitl_create_task.py
@@ -106,10 +106,10 @@ def _find_create_escalation_call(tree: ast.Module) -> ast.Call | None:
 
 
 def check_imports_and_calls(text: str, tree: ast.Module) -> None:
-    if not re.search(r"from\s+langgraph\.types\s+import\s+[^\n]*\binterrupt\b", text):
+    if not re.search(r"from\s+langgraph\.types\s+import\s+(?:[^\n]*\binterrupt\b|\([^)]*\binterrupt\b)", text):
         sys.exit("FAIL: missing `from langgraph.types import interrupt`")
     print("OK: imports `interrupt` from langgraph.types")
-    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bCreateEscalation\b", text):
+    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+(?:[^\n]*\bCreateEscalation\b|\([^)]*\bCreateEscalation\b)", text):
         sys.exit(
             "FAIL: missing `from uipath.platform.common import CreateEscalation`. "
             "The prompt describes an explicit escalation — the skill prescribes "

--- a/tests/tasks/uipath-agents/coded/hitl_create_task/check_hitl_create_task.py
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task/check_hitl_create_task.py
@@ -11,9 +11,13 @@ Asserts the primitives that together make
      `CreateEscalation` for that path (`CreateTask` is the general
      form for non-escalation HITL).
   3. `bindings.json` declares the `app` resource for the Action
-     Center app the escalation targets — `app_name=ExpenseReview`,
-     `app_folder_path=Finance`. Without this binding,
-     `uipath push` would not create the virtual placeholder.
+     Center app the escalation targets — `app_name=ExpenseReviewApp`,
+     `app_folder_path=Shared/uipath-agents/ExpenseReviewSol`. Without
+     this binding, `uipath push` would not create the virtual
+     placeholder. The binding `key` is accepted in either form: the
+     `{kind}.{name}.{folder}` form that `uip codedagent init` (SDK
+     >= 2.14) generates and the runtime resolves, or the bare
+     `{name}.{folder}` form documented in bindings-reference.md.
 
 Also runs the lazy-LLM-init AST scan as a hygiene check.
 """
@@ -31,6 +35,12 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("expense-approver")
+
+APP_NAME = "ExpenseReviewApp"
+APP_FOLDER = "Shared/uipath-agents/ExpenseReviewSol"
+# SDK-generated (`uip codedagent init`, uipath >= 2.14) and hand-authored
+# (bindings-reference.md) key forms — both resolve at runtime.
+APP_KEYS = (f"app.{APP_NAME}.{APP_FOLDER}", f"{APP_NAME}.{APP_FOLDER}")
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.bindings_assertions import (  # noqa: E402
@@ -60,7 +70,7 @@ def _module_constants(tree: ast.Module) -> dict[str, object]:
     """Collect module-level `<Name> = <Constant>` assignments.
 
     Resolves the common pattern where the agent extracts string literals
-    into constants (e.g. ``ACTION_CENTER_APP = "ExpenseReview"``).
+    into constants (e.g. ``ACTION_CENTER_APP = "ExpenseReviewApp"``).
     """
     consts: dict[str, object] = {}
     for node in tree.body:
@@ -73,7 +83,7 @@ def _module_constants(tree: ast.Module) -> dict[str, object]:
             and isinstance(node.value, ast.Constant)
             and isinstance(node.target, ast.Name)
         ):
-            # Annotated constant, e.g. ``APP_NAME: str = "ExpenseReview"``.
+            # Annotated constant, e.g. ``APP_NAME: str = "ExpenseReviewApp"``.
             consts[node.target.id] = node.value.value
     return consts
 
@@ -122,7 +132,7 @@ def check_imports_and_calls(text: str, tree: ast.Module) -> None:
     print("OK: graph node calls interrupt(CreateEscalation(...))")
     consts = _module_constants(tree)
     kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
-    expected = {"app_name": "ExpenseReview", "app_folder_path": "Finance"}
+    expected = {"app_name": APP_NAME, "app_folder_path": APP_FOLDER}
     for kw, want in expected.items():
         if kw not in kwargs:
             sys.exit(f'FAIL: `CreateEscalation(...)` is missing `{kw}=`')
@@ -131,17 +141,23 @@ def check_imports_and_calls(text: str, tree: ast.Module) -> None:
             sys.exit(
                 f'FAIL: `CreateEscalation({kw}=...)` resolves to {got!r}, expected {want!r}.'
             )
-    print('OK: escalation targets app_name="ExpenseReview" / app_folder_path="Finance"')
+    print(f'OK: escalation targets app_name="{APP_NAME}" / app_folder_path="{APP_FOLDER}"')
 
 
 def check_app_binding() -> None:
     doc = load_bindings(ROOT / "bindings.json")
-    entry = find_resource(doc, resource="app", key="ExpenseReview.Finance")
-    assert_value_field(entry, field="name", expected="ExpenseReview")
-    assert_value_field(entry, field="folderPath", expected="Finance")
+    present = {
+        r.get("key")
+        for r in (doc.get("resources") or [])
+        if isinstance(r, dict) and r.get("resource") == "app"
+    }
+    key = next((k for k in APP_KEYS if k in present), APP_KEYS[0])
+    entry = find_resource(doc, resource="app", key=key)
+    assert_value_field(entry, field="name", expected=APP_NAME)
+    assert_value_field(entry, field="folderPath", expected=APP_FOLDER)
     assert_metadata_field(entry, field="ActivityName", expected="create_async")
-    assert_metadata_field(entry, field="DisplayLabel", expected="ExpenseReview")
-    print("OK: bindings.json declares the ExpenseReview/Finance `app` resource")
+    assert_metadata_field(entry, field="DisplayLabel", expected=APP_NAME)
+    print(f'OK: bindings.json declares the {APP_NAME} `app` resource (key="{key}")')
 
 
 def main() -> None:

--- a/tests/tasks/uipath-agents/coded/hitl_create_task/hitl_create_task.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task/hitl_create_task.yaml
@@ -8,7 +8,7 @@ description: >
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:hitl-coded]
 
 run_limits:
-  expected_turns: 29
+  expected_turns: 40
   turn_timeout: 1200
 
 initial_prompt: |
@@ -16,12 +16,13 @@ initial_prompt: |
   reimbursements? Call it expense-approver. Anything $1000 or under can
   just get auto-approved, but bigger than that needs a manager to sign off
   before it goes through. When something's over the limit, escalate it to
-  a reviewer through the ExpenseReview app (it's in the Finance folder) and
-  pass along the whole request - the agent should wait while that's pending,
-  then pick back up once the reviewer decides and report whether it got
-  approved and what they said.
+  a reviewer through the ExpenseReviewApp app (it's in the
+  Shared/uipath-agents/ExpenseReviewSol folder) and pass along the whole
+  request - the agent should wait while that's pending, then pick back up
+  once the reviewer decides and report whether it got approved and what
+  they said.
 
-  Just build it with the ExpenseReview app wired up so it can actually
+  Just build it with the ExpenseReviewApp app wired up so it can actually
   escalate - no need to run, sign in, or deploy. Take it all the way
   through and only stop if you hit something you genuinely can't get past.
 

--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/check_hitl_create_task_with_app.py
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/check_hitl_create_task_with_app.py
@@ -41,6 +41,9 @@ ROOT = find_project_root("refund-gate")
 
 APP_NAME = "RefundReviewApp"
 APP_FOLDER = "Shared/uipath-agents/RefundReviewSol"
+# SDK-generated (`uip codedagent init`, uipath >= 2.14) and hand-authored
+# (bindings-reference.md) key forms — both resolve at runtime.
+APP_KEYS = (f"app.{APP_NAME}.{APP_FOLDER}", f"{APP_NAME}.{APP_FOLDER}")
 
 
 def fail(msg: str) -> None:
@@ -152,12 +155,18 @@ def main() -> None:
     print("OK: no module-level UiPath* construction")
 
     doc = load_bindings(ROOT / "bindings.json")
-    entry = find_resource(doc, resource="app", key=f"{APP_NAME}.{APP_FOLDER}")
+    present = {
+        r.get("key")
+        for r in (doc.get("resources") or [])
+        if isinstance(r, dict) and r.get("resource") == "app"
+    }
+    key = next((k for k in APP_KEYS if k in present), APP_KEYS[0])
+    entry = find_resource(doc, resource="app", key=key)
     assert_value_field(entry, field="name", expected=APP_NAME)
     assert_value_field(entry, field="folderPath", expected=APP_FOLDER)
     assert_metadata_field(entry, field="ActivityName", expected="create_async")
     assert_metadata_field(entry, field="DisplayLabel", expected=APP_NAME)
-    print(f"OK: bindings.json declares the {APP_NAME}/{APP_FOLDER} `app` resource")
+    print(f'OK: bindings.json declares the {APP_NAME}/{APP_FOLDER} `app` resource (key="{key}")')
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/check_hitl_create_task_with_app.py
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/check_hitl_create_task_with_app.py
@@ -107,11 +107,11 @@ def main() -> None:
     except SyntaxError as exc:
         fail(f"{module} has a syntax error: {exc}")
 
-    if not re.search(r"from\s+langgraph\.types\s+import\s+[^\n]*\binterrupt\b", text):
+    if not re.search(r"from\s+langgraph\.types\s+import\s+(?:[^\n]*\binterrupt\b|\([^)]*\binterrupt\b)", text):
         fail("missing `from langgraph.types import interrupt`")
     print("OK: imports `interrupt` from langgraph.types")
 
-    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bCreateTask\b", text):
+    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+(?:[^\n]*\bCreateTask\b|\([^)]*\bCreateTask\b)", text):
         fail(
             "missing `from uipath.platform.common import CreateTask`. "
             "The scenario opens a new Action Center task — use `CreateTask`."

--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
@@ -70,5 +70,5 @@ success_criteria:
     pass_threshold: 1.0
 
 run_limits:
-  expected_turns: 36
+  expected_turns: 50
   turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/hitl_wait_task/check_hitl_wait_task.py
+++ b/tests/tasks/uipath-agents/coded/hitl_wait_task/check_hitl_wait_task.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
-"""HITL `interrupt(WaitTask)` shape check.
+"""HITL `interrupt(WaitTask)` / `interrupt(WaitEscalation)` shape check.
 
 This is the "wait on a task that already exists" pattern, distinct from
-`CreateTask` / `CreateEscalation` (which open a new task). Asserts:
+`CreateTask` / `CreateEscalation` (which open a new task). Both wait
+classes are accepted: `WaitEscalation` subclasses `WaitTask` in the SDK
+(same fields, same `action=` target); they differ only in the resume
+payload (`WaitTask` -> task `data`, `WaitEscalation` -> full `Task` incl.
+`action`). The prompt asks the agent to read the reviewer's decision,
+which either class can serve, so the choice is not graded. Asserts:
 
   1. `main.py` imports `interrupt` from `langgraph.types`.
-  2. `main.py` imports `WaitTask` from `uipath.platform.common`.
-  3. At least one `interrupt(WaitTask(...))` call exists.
+  2. `main.py` imports `WaitTask` or `WaitEscalation` from
+     `uipath.platform.common`.
+  3. At least one `interrupt(WaitTask(...))` or
+     `interrupt(WaitEscalation(...))` call exists.
   4. `main.py` does NOT use `CreateTask` / `CreateEscalation` — the
      scenario is monitoring an existing task, not creating one.
   5. A top-level `graph =` variable is exported (LangGraph entrypoint).
@@ -30,6 +37,10 @@ from _shared.langgraph_assertions import assert_langgraph_config  # noqa: E402
 
 ROOT = find_project_root("purchase-gate")
 
+# `WaitEscalation` is a subclass of `WaitTask` (uipath.platform.common);
+# either is a valid "wait on an existing task" interrupt.
+WAIT_CLASSES = ("WaitTask", "WaitEscalation")
+
 
 def fail(msg: str) -> None:
     sys.exit(f"FAIL: {msg}")
@@ -44,7 +55,8 @@ def find_graph_module() -> Path:
     raise SystemExit(1)  # unreachable, for type checkers
 
 
-def has_interrupt_wait_task(tree: ast.Module) -> bool:
+def find_interrupt_wait_class(tree: ast.Module) -> str | None:
+    """Return the wait class name used inside `interrupt(...)`, if any."""
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
@@ -54,9 +66,9 @@ def has_interrupt_wait_task(tree: ast.Module) -> bool:
         if not node.args:
             continue
         inner = node.args[0]
-        if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name) and inner.func.id == "WaitTask":
-            return True
-    return False
+        if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name) and inner.func.id in WAIT_CLASSES:
+            return inner.func.id
+    return None
 
 
 def main() -> None:
@@ -74,20 +86,25 @@ def main() -> None:
         fail("missing `from langgraph.types import interrupt`")
     print("OK: imports `interrupt` from langgraph.types")
 
-    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+(?:[^\n]*\bWaitTask\b|\([^)]*\bWaitTask\b)", text):
+    imported = re.search(
+        r"from\s+uipath\.platform\.common\s+import\s+(?:[^\n]*\b(WaitTask|WaitEscalation)\b|\([^)]*\b(WaitTask|WaitEscalation)\b)",
+        text,
+    )
+    if not imported:
         fail(
-            "missing `from uipath.platform.common import WaitTask`. "
-            "The scenario is `WaitTask` (wait on an existing Action Center task), "
+            "missing `from uipath.platform.common import WaitTask` (or `WaitEscalation`). "
+            "The scenario waits on an existing Action Center task, "
             "not `CreateTask` (which opens a new one)."
         )
-    print("OK: imports WaitTask from uipath.platform.common")
+    print(f"OK: imports {imported.group(1) or imported.group(2)} from uipath.platform.common")
 
-    if not has_interrupt_wait_task(tree):
+    wait_cls = find_interrupt_wait_class(tree)
+    if wait_cls is None:
         fail(
-            "no `interrupt(WaitTask(...))` call site found. "
+            "no `interrupt(WaitTask(...))` / `interrupt(WaitEscalation(...))` call site found. "
             "The agent must pause on the existing task via `interrupt(WaitTask(action=...))`."
         )
-    print("OK: graph node calls interrupt(WaitTask(...))")
+    print(f"OK: graph node calls interrupt({wait_cls}(...))")
 
     if re.search(r"\bCreateTask\s*\(", text) or re.search(r"\bCreateEscalation\s*\(", text):
         fail(
@@ -108,7 +125,7 @@ def main() -> None:
         fail("module-level UiPath* construction (C4): " + " | ".join(violations))
     print("OK: no module-level UiPath* construction")
 
-    print("OK: WaitTask HITL shape verified")
+    print(f"OK: {wait_cls} HITL shape verified")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/coded/hitl_wait_task/check_hitl_wait_task.py
+++ b/tests/tasks/uipath-agents/coded/hitl_wait_task/check_hitl_wait_task.py
@@ -70,11 +70,11 @@ def main() -> None:
     except SyntaxError as exc:
         fail(f"{module} has a syntax error: {exc}")
 
-    if not re.search(r"from\s+langgraph\.types\s+import\s+[^\n]*\binterrupt\b", text):
+    if not re.search(r"from\s+langgraph\.types\s+import\s+(?:[^\n]*\binterrupt\b|\([^)]*\binterrupt\b)", text):
         fail("missing `from langgraph.types import interrupt`")
     print("OK: imports `interrupt` from langgraph.types")
 
-    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bWaitTask\b", text):
+    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+(?:[^\n]*\bWaitTask\b|\([^)]*\bWaitTask\b)", text):
         fail(
             "missing `from uipath.platform.common import WaitTask`. "
             "The scenario is `WaitTask` (wait on an existing Action Center task), "

--- a/tests/tasks/uipath-agents/coded/hitl_wait_task/hitl_wait_task.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_wait_task/hitl_wait_task.yaml
@@ -2,11 +2,13 @@ task_id: skill-agent-coded-hitl-wait-task
 description: >
   Coded-agent HITL via `interrupt(WaitTask(...))` — the "wait for an
   already-created Action Center task" pattern. Verifies the agent
-  imports `interrupt` from `langgraph.types` and `WaitTask` from
-  `uipath.platform.common`, wires a graph node that pauses on a task
-  the caller passes in, and keeps the resume payload available for a
-  downstream node. Distinct from `CreateTask` / `CreateEscalation`
-  (those make a new task).
+  imports `interrupt` from `langgraph.types` and `WaitTask` (or its
+  SDK subclass `WaitEscalation` — same fields, resume returns the full
+  `Task` instead of `data`) from `uipath.platform.common`, wires a
+  graph node that pauses on a task the caller passes in, and keeps the
+  resume payload available for a downstream node. Either wait class is
+  accepted; the choice is not graded. Distinct from `CreateTask` /
+  `CreateEscalation` (those make a new task).
 tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:framework-langgraph, feature:hitl-coded]
 max_iterations: 1
 
@@ -42,7 +44,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "LangGraph config, interrupt(WaitTask) shape, correct imports, no CreateTask/CreateEscalation, graph exported"
+    description: "LangGraph config, interrupt(WaitTask|WaitEscalation) shape, correct imports, no CreateTask/CreateEscalation, graph exported"
     command: "python3 $TASK_DIR/check_hitl_wait_task.py"
     timeout: 30
     expected_exit_code: 0
@@ -50,5 +52,5 @@ success_criteria:
     pass_threshold: 1.0
 
 run_limits:
-  expected_turns: 36
+  expected_turns: 55
   turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/process_invoke/check_process_invoke.py
+++ b/tests/tasks/uipath-agents/coded/process_invoke/check_process_invoke.py
@@ -95,10 +95,10 @@ def _find_invoke_process_call(tree: ast.Module) -> ast.Call | None:
 
 
 def check_invocation(text: str, tree: ast.Module) -> None:
-    if not re.search(r"from\s+langgraph\.types\s+import\s+[^\n]*\binterrupt\b", text):
+    if not re.search(r"from\s+langgraph\.types\s+import\s+(?:[^\n]*\binterrupt\b|\([^)]*\binterrupt\b)", text):
         sys.exit("FAIL: missing `from langgraph.types import interrupt`")
     if not re.search(
-        r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bInvokeProcess\b",
+        r"from\s+uipath\.platform\.common\s+import\s+(?:[^\n]*\bInvokeProcess\b|\([^)]*\bInvokeProcess\b)",
         text,
     ):
         sys.exit("FAIL: missing `from uipath.platform.common import InvokeProcess`")

--- a/tests/tasks/uipath-agents/coded/rag_langgraph/check_rag_langgraph.py
+++ b/tests/tasks/uipath-agents/coded/rag_langgraph/check_rag_langgraph.py
@@ -61,7 +61,7 @@ def check_imports_and_calls(text: str) -> None:
 
     if uses_retriever:
         if not re.search(
-            r"from\s+uipath_langchain\.retrievers\s+import\s+[^\n]*\bContextGroundingRetriever\b",
+            r"from\s+uipath_langchain\.retrievers\s+import\s+(?:[^\n]*\bContextGroundingRetriever\b|\([^)]*\bContextGroundingRetriever\b)",
             text,
         ):
             sys.exit(

--- a/tests/tasks/uipath-agents/coded/subtype_credential_asset/_fixtures/billing-agent/entry-points.json
+++ b/tests/tasks/uipath-agents/coded/subtype_credential_asset/_fixtures/billing-agent/entry-points.json
@@ -6,8 +6,25 @@
       "filePath": "agent",
       "uniqueId": "aaa11111-2222-3333-4444-555566667777",
       "type": "agent",
-      "input": {"type": "object", "properties": {}, "required": []},
-      "output": {"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]}
+      "input": {
+        "type": "object"
+      },
+      "output": {
+        "type": "object"
+      },
+      "graph": {
+        "nodes": [
+          {
+            "id": "main.py:8",
+            "name": "main",
+            "type": "function",
+            "metadata": {
+              "file": "main.py"
+            }
+          }
+        ],
+        "edges": []
+      }
     }
   ]
 }

--- a/tests/tasks/uipath-agents/coded/subtype_credential_asset/_fixtures/billing-agent/pyproject.toml
+++ b/tests/tasks/uipath-agents/coded/subtype_credential_asset/_fixtures/billing-agent/pyproject.toml
@@ -1,4 +1,8 @@
 [project]
 name = "billing-agent"
 version = "0.1.0"
+description = "Billing agent"
 requires-python = ">=3.11"
+dependencies = [
+    "uipath>=2.10.58",
+]

--- a/tests/tasks/uipath-agents/coded/subtype_credential_asset/_fixtures/billing-agent/uipath.json
+++ b/tests/tasks/uipath-agents/coded/subtype_credential_asset/_fixtures/billing-agent/uipath.json
@@ -1,1 +1,1 @@
-{"projectType": "CodedAgent"}
+{"projectType": "CodedAgent", "agents": {"agent": "main.py:main"}}

--- a/tests/tasks/uipath-agents/lowcode/context_prompt_reference/context_prompt_reference.yaml
+++ b/tests/tasks/uipath-agents/lowcode/context_prompt_reference/context_prompt_reference.yaml
@@ -13,8 +13,8 @@ description: >
 tags: [uipath-agents, smoke, mode:build, low-code]
 
 run_limits:
-  expected_turns: 20
-  max_turns: 30
+  expected_turns: 30
+  max_turns: 50
   turn_timeout: 1200
 
 initial_prompt: |

--- a/tests/tasks/uipath-agents/lowcode/conversational/scaffold/check_conversational_scaffold.py
+++ b/tests/tasks/uipath-agents/lowcode/conversational/scaffold/check_conversational_scaffold.py
@@ -10,11 +10,14 @@ edits (model override, system prompt, etc.).
 Checks:
   1. metadata.isConversational == true
   2. settings.engine == "conversational-v1"
-  3. settings.maxIterations absent
-  4. outputSchema.properties is empty {} (Rule 26 — never populate)
-  5. messages[1] (user role) content has no {{input.*}} template, and
+  3. outputSchema.properties is empty {} (Rule 26 — never populate)
+  4. messages[1] (user role) content has no {{input.*}} template, and
      contentTokens contain no `variable` entries (§ Messages)
-  6. entry-points.json schemas mirror agent.json (Rule 4 sync)
+  5. entry-points.json schemas mirror agent.json (Rule 4 sync)
+
+`settings.maxIterations` is reported but not graded: released and dev CLI
+builds disagree on whether the conversational scaffold carries it, and the
+value comes from `uip agent init`, not from the agent under test.
 """
 
 import json
@@ -52,13 +55,15 @@ def assert_conversational_essentials(agent: dict) -> None:
         )
     print('OK: settings.engine == "conversational-v1"')
 
+    # `settings.maxIterations` is NOT graded. The released CLI (1.202.0) omits
+    # it for conversational scaffolds; the `dev` line (1.202.0-dev.8521, which
+    # the smoke runner installs) emits `maxIterations: 8`. The field is written
+    # by `uip agent init --conversational` itself, not by the agent under test,
+    # so asserting either way grades the CLI build, not the skill.
     if "maxIterations" in settings:
-        sys.exit(
-            f'FAIL: settings.maxIterations must be absent for conversational '
-            f'(CLI omits it; conversational has no iteration cap), '
-            f'got {settings.get("maxIterations")!r}'
-        )
-    print("OK: settings.maxIterations absent")
+        print(f"INFO: settings.maxIterations present ({settings['maxIterations']!r}) — CLI-emitted, not graded")
+    else:
+        print("INFO: settings.maxIterations absent — not graded")
 
     output_props = (agent.get("outputSchema") or {}).get("properties") or {}
     if output_props:

--- a/tests/tasks/uipath-agents/lowcode/local_escalation/local_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/local_escalation/local_escalation.yaml
@@ -13,7 +13,7 @@ description: >
 tags: [uipath-agents, e2e, mode:build, low-code, feature:escalation]
 
 run_limits:
-  expected_turns: 24
+  expected_turns: 40
   turn_timeout: 1200
 
 pre_run:
@@ -21,10 +21,11 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  Add an escalation resource named "ApprovalEscalation" to the existing
-  "Agent" agent inside the existing "AgentWithLocalEscalation" solution
-  (in the current directory). The escalation should use the Action Center
-  app that is already part of this solution.
+  Update the existing UiPath low-code agent "Agent" inside the existing
+  "AgentWithLocalEscalation" solution (in the current directory). Agent should
+  escalate cases it cannot decide on its own to a human approver through an
+  escalation named "ApprovalEscalation", using the existing "SimpleApprovalApp"
+  Action Center app that's already in the solution.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/solution_escalation/check_solution_escalation.py
+++ b/tests/tasks/uipath-agents/lowcode/solution_escalation/check_solution_escalation.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 """Solution escalation (solution-internal ActionCenter app) resource check.
 
-Validates:
-  1. resources/HumanReviewEscalation/resource.json declares an escalation:
+Validates that the agent authored an escalation wired to the solution-internal
+"HumanReviewEscalation" Action Center app, regardless of what it named the
+escalation resource folder:
+
+  1. Some resources/<Name>/resource.json under ModerationAgent declares an
+     escalation:
        - $resourceType == "escalation"
        - id is a UUID-shaped non-empty string
        - name is a non-empty string
@@ -20,6 +24,12 @@ Validates:
   4. agent.json.inputSchema  == entry-points.json entryPoints[0].input
      agent.json.outputSchema == entry-points.json entryPoints[0].output
      (Critical Rule 4 — schema sync.)
+
+The escalation resource folder name is the agent's choice (the prompt names
+the *app* "HumanReviewEscalation", not the resource, and the skill documents
+the path as resources/<EscalationName>/resource.json), so this check locates
+the escalation by content and verifies the app binding — it does NOT assume a
+specific folder name. Mirrors external_escalation/check_external_escalation.py.
 """
 
 import json
@@ -31,7 +41,7 @@ from pathlib import Path
 ROOT = Path(os.getcwd()) / "ReviewSol" / "ModerationAgent"
 AGENT = ROOT / "agent.json"
 ENTRY = ROOT / "entry-points.json"
-RESOURCE = ROOT / "resources" / "HumanReviewEscalation" / "resource.json"
+RESOURCES_DIR = ROOT / "resources"
 
 UUID_RE = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
@@ -50,25 +60,45 @@ def load(path: Path) -> dict:
         sys.exit(f"FAIL: {path} is not valid JSON: {e}")
 
 
-def assert_escalation_header(resource: dict) -> None:
-    rtype = resource.get("$resourceType")
-    if rtype != "escalation":
-        sys.exit(f'FAIL: $resourceType should be "escalation", got {rtype!r}')
+def find_escalation() -> tuple[Path, dict]:
+    if not RESOURCES_DIR.is_dir():
+        sys.exit(f"FAIL: no resources/ directory under {ROOT}")
+    candidates = sorted(RESOURCES_DIR.glob("*/resource.json"))
+    if not candidates:
+        sys.exit(f"FAIL: no resources/*/resource.json found under {RESOURCES_DIR}")
+    loaded = [(p, load(p)) for p in candidates]
+    escalations = [(p, d) for p, d in loaded if d.get("$resourceType") == "escalation"]
+    if not escalations:
+        found = ", ".join(sorted({str(d.get("$resourceType", "?")) for _, d in loaded}))
+        sys.exit(
+            f'FAIL: no resource.json with $resourceType=="escalation" under {RESOURCES_DIR} '
+            f"(found resource types: {found})"
+        )
+    return escalations[0]
+
+
+def assert_escalation_header(path: Path, resource: dict) -> None:
     eid = resource.get("id")
-    if not isinstance(eid, str) or "-" not in eid:
-        sys.exit(f"FAIL: escalation id missing or malformed: {eid!r}")
+    if not isinstance(eid, str) or not UUID_RE.match(eid):
+        sys.exit(f"FAIL: escalation id missing or malformed at {path}: {eid!r}")
     name = resource.get("name")
     if not isinstance(name, str) or not name.strip():
-        sys.exit(f"FAIL: escalation name missing or empty: {name!r}")
+        sys.exit(f"FAIL: escalation name missing or empty at {path}: {name!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: escalation isEnabled must be truthy, got {resource.get('isEnabled')!r}")
-    print(f'OK: resource.json is $resourceType="escalation" (id={eid}, name={name!r}, isEnabled=true)')
+        sys.exit(
+            f"FAIL: escalation isEnabled must be truthy at {path}, "
+            f"got {resource.get('isEnabled')!r}"
+        )
+    print(
+        f'OK: {path.parent.name}/resource.json is $resourceType="escalation" '
+        f"(id={eid}, name={name!r}, isEnabled=true)"
+    )
 
 
-def assert_actioncenter_channel(resource: dict) -> list:
+def assert_actioncenter_channel(path: Path, resource: dict) -> list:
     channels = resource.get("channels")
     if not isinstance(channels, list) or not channels:
-        sys.exit(f"FAIL: escalation.channels must be a non-empty list, got {channels!r}")
+        sys.exit(f"FAIL: escalation.channels must be a non-empty list at {path}, got {channels!r}")
     ac_channels = [
         c for c in channels
         if isinstance(c, dict)
@@ -79,22 +109,22 @@ def assert_actioncenter_channel(resource: dict) -> list:
     if not ac_channels:
         sys.exit(
             'FAIL: no channel with type=="actionCenter" and non-empty name '
-            f"in channels: {json.dumps(channels, indent=2)}"
+            f"in {path}: {json.dumps(channels, indent=2)}"
         )
     print(f"OK: found {len(ac_channels)} actionCenter channel(s)")
     return ac_channels
 
 
-def assert_solution_app_binding(ac_channels: list) -> None:
+def assert_solution_app_binding(path: Path, ac_channels: list) -> None:
     bound = [
         c for c in ac_channels
         if (c.get("properties") or {}).get("appName") == EXPECTED_APP_NAME
     ]
     if not bound:
+        got = [(c.get("properties") or {}).get("appName") for c in ac_channels]
         sys.exit(
-            f"FAIL: no actionCenter channel is bound to the solution-internal app "
-            f"{EXPECTED_APP_NAME!r} (properties.appName) — got appNames: "
-            f"{[(c.get('properties') or {}).get('appName') for c in ac_channels]}"
+            f"FAIL: no actionCenter channel in {path} is bound to the solution-internal app "
+            f"{EXPECTED_APP_NAME!r} (properties.appName) — got appNames: {got}"
         )
     props = bound[0].get("properties") or {}
     fname = props.get("folderName")
@@ -104,9 +134,9 @@ def assert_solution_app_binding(ac_channels: list) -> None:
             f"(solution-internal app), got {fname!r}"
         )
     rkey = props.get("resourceKey")
-    if not isinstance(rkey, str) or not rkey.strip():
+    if not isinstance(rkey, str) or not UUID_RE.match(rkey):
         sys.exit(
-            f"FAIL: channel properties.resourceKey must be a non-empty string "
+            f"FAIL: channel properties.resourceKey must be a UUID-shaped string "
             f"(Key from `uip solution resources list`), got {rkey!r}"
         )
     print(
@@ -130,11 +160,11 @@ def assert_schema_sync(agent: dict, entry: dict) -> None:
 def main() -> None:
     agent = load(AGENT)
     entry = load(ENTRY)
-    resource = load(RESOURCE)
+    path, resource = find_escalation()
 
-    assert_escalation_header(resource)
-    ac_channels = assert_actioncenter_channel(resource)
-    assert_solution_app_binding(ac_channels)
+    assert_escalation_header(path, resource)
+    ac_channels = assert_actioncenter_channel(path, resource)
+    assert_solution_app_binding(path, ac_channels)
     assert_schema_sync(agent, entry)
 
 

--- a/tests/tasks/uipath-agents/lowcode/solution_escalation/solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_escalation/solution_escalation.yaml
@@ -6,10 +6,12 @@ description: >
   The agent must add a NEW `ModerationAgent` project and wire the
   pre-existing `HumanReviewEscalation` app in as an escalation channel — reusing it,
   NOT re-creating it and NOT re-initializing the solution. Verifies the
-  `$resourceType: "escalation"` resource.json shape, the ActionCenter
-  channel bound to the solution-internal app (`folderName:
-  "solution_folder"`), and that `uip agent validate` accepts the
-  escalation after refresh regenerates derived files.
+  `$resourceType: "escalation"` resource.json shape (located by content —
+  the escalation folder name is the agent's choice, as in
+  `external_escalation`), the ActionCenter channel bound to the
+  solution-internal app (`folderName: "solution_folder"`), and that
+  `uip agent validate` accepts the escalation after refresh regenerates
+  derived files.
 tags: [uipath-agents, e2e, mode:build, low-code, feature:escalation]
 
 run_limits:
@@ -106,12 +108,10 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_exists
-    description: "HumanReviewEscalation escalation resource.json was created"
-    path: "ReviewSol/ModerationAgent/resources/HumanReviewEscalation/resource.json"
-    weight: 2.5
-    pass_threshold: 1.0
-
+  # Locates resources/*/resource.json with $resourceType=="escalation" by
+  # content (folder name is the agent's choice), then asserts the ActionCenter
+  # binding and schema sync. Absorbs the weight of the former hardcoded
+  # file_exists on resources/HumanReviewEscalation/resource.json.
   - type: run_command
     description: "Solution escalation resource shape: ActionCenter channel wired to solution-internal HumanReviewEscalation app"
     command: "python3 $TASK_DIR/check_solution_escalation.py"

--- a/tests/tasks/uipath-functions/deploy_tenant/deploy_tenant.yaml
+++ b/tests/tasks/uipath-functions/deploy_tenant/deploy_tenant.yaml
@@ -8,19 +8,26 @@ description: >
   non-interactive tenant-feed publish (pending uipath/cli#2778), so
   requiring an interactive `publish` made this task nondeterministic
   (the agent either fumbled the feed picker or exhausted its turns).
+  The prompt pins Python: grading (the `uip function init` criterion and
+  the pyproject.toml checker) is Python-specific, while TypeScript is the
+  CLI default — an unpinned prompt let a correct TS solution fail. The
+  prompt also states the pack success bar: without it, an agent that
+  set packOptions and ran locally stopped before ever packing.
 tags: [uipath-functions, e2e, mode:build, feature:deploy]
 max_iterations: 1
 
 initial_prompt: |
-  Build a UiPath Coded Function named `tenant-echo`
-  that takes a `message` (string) and returns
-  `{"echoed": message}`. No LLM, no SDK calls.
+  Build a UiPath Coded Function named `tenant-echo`,
+  implemented in Python, that takes a `message` (string) and
+  returns `{"echoed": message}`. No LLM, no SDK calls.
 
   Alongside the source, the project includes a `data/` directory
   with fixture JSON used during local development only — create it
   as `data/fixtures.json` containing `{"sample": "value"}`. The
   `data/` directory must NOT end up in the packaged output.
 
+  Package the project locally — the task is not complete until
+  packaging has produced the `.nupkg` artifact.
   Do NOT publish, upload, or deploy.
   Complete it in a single pass.
 


### PR DESCRIPTION
## Summary

Eight targeted fixes for coder-eval tasks that failed in the recent nightly runs. Each commit isolates one task (or one shared root cause), states the failure mode observed in the nightly artifacts, and records a passing local run. Three of the fixes also correct skill reference text that had drifted from the shipped CLI/SDK.

## Per-task fixes

| Task | Nightly failure | Fix | Local run claim |
|---|---|---|---|
| `coded/subtype_credential_asset` | Turns exhausted at 0.375; fixture failed `uip codedagent init` twice (no `project.description`, no entrypoint) | Fixture made init-ready: description + `uipath>=2.10.58` dependency, `agents` map (keeps agent-typed entrypoint), regenerated `entry-points.json` | claude-sonnet-5, 3/3, 9 tool calls |
| `lowcode/local_escalation` | 0.77; prompt routed to `uipath-human-in-the-loop`, whose `$UIP` idiom defeated the `uip\s+agent\s+(refresh\|validate)` graders | Prompt reworded to lead with "UiPath low-code agent", mirroring `solution_escalation`; `expected_turns` 24 → 40 | claude-sonnet-5, 6/6, routed to uipath-agents |
| `lowcode/solution_escalation` | Correct escalation authored under a different folder name; checker hardcoded `resources/HumanReviewEscalation/` | Checker locates the escalation by `$resourceType` content, as `external_escalation` already does; hardcoded `file_exists` dropped | claude-sonnet-5, 9/9 |
| `lowcode/context_prompt_reference` | Turns exhausted at 30 with correct artifacts; refresh/validate never ran | `max_turns` 30 → 50, `expected_turns` 20 → 30 | Local repro passed in 27 |
| `coded/eval_exact_match` | "No LLM, just arithmetic" prompt correctly routed to `uipath-functions`, so `uip codedagent` gates could never match | Recast as a LangGraph enum classifier so the task is unambiguously coded-agent | claude-sonnet-5, 3/3 |
| `coded/datafabric_*` (3 tasks) | `datafabric.md` taught removed SDK APIs; checker import regexes missed parenthesized imports; prompts left blocking decision points | Doc rewritten against current SDK; regexes accept paren form / `filter_group=`; prompts name the entity and status | claude-sonnet-5, 1.0 on all three |
| `coded/coded_in_flow_published` | Checker required literal `"Published"`; current registry marks published agents with `category: "agent.published"` | Checker accepts either marker, still rejects Pattern 1; doc lines aligned to the registry contract | claude-sonnet-5, 7/7 |
| `uipath-functions/deploy_tenant` | Language-neutral prompt while grading is Python-only; TS path capped at 2.5/7.5 | Prompt pins Python and states the pack success bar | Local rerun passes pack criteria |

## Skill reference changes

- `uipath-agents/references/coded/capabilities/datafabric.md`: `create_agent` import path and `messages=` kwarg; `retrieve_records` + `filter_group` replaces the removed `list_records_async(filter=…)`; tenant-level folder key documented.
- `uipath-agents/references/coded/flow-integration.md` and `uipath-maestro-flow/references/author/plugins/agent/impl.md`: published-agent marker no longer stated as unconditionally `model.section == "Published"`.

## Findings surfaced but not fixed here

- Both escalation fixtures' `resources/solution_folder/` trees are stale against CLI 1.202: `uip solution resources refresh` regenerates the app resources with new keys even on an untouched copy, which can leave an escalation's `resourceKey` dangling. Neither checker cross-checks the key. Regenerating the fixtures and adding that assertion is a follow-up.
- All 104 `uipath-agents` task YAMLs use plain `uip\s+…` command patterns; 144 tasks elsewhere use the `(uip|\$UIP)` tolerant form documented in tests/README. A sweep is a follow-up.
- The coder-eval plugin mount is the repo root, so `tests/` (including checker scripts) is readable by the agent under test. One nightly run located and read its own checker.

## Verification

- Each commit body carries its passing local run (harness, model, criteria count).
- `git merge-tree` against current `main` reports a clean merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
