### PR TITLE
chore(tests): drop undocumented 'ipe' tag and rename task_ids for jira e2e tasks

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/jira_lifecycle/jira_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_lifecycle/jira_lifecycle.yaml
@@ -1,4 +1,4 @@
-task_id: skill-flow-ipe-jira-lifecycle
+task_id: skill-flow-jira-lifecycle
 description: >
   E2E live Jira coverage of a composite loop-and-switch flow. The agent builds
   ONE Flow (manual trigger) that iterates a seeded batch of issues and, per
@@ -16,7 +16,7 @@ description: >
   `Shared/uipath-maestro-flow` (currently the single Jira connection there),
   reaching the `CE` / "Coder Eval" project (issue type Task). Targets live in
   the task's `jira_is.py`.
-tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:loop, node:switch, node:decision, connector, e2e, uipath-atlassian-jira, ipe, mode:build]
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:loop, node:switch, node:decision, connector, e2e, uipath-atlassian-jira, mode:build]
 
 run_limits:
   expected_turns: 55

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_search_triage/jira_search_triage.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_search_triage/jira_search_triage.yaml
@@ -1,4 +1,4 @@
-task_id: skill-flow-ipe-jira-search-triage
+task_id: skill-flow-jira-search-triage
 description: >
   E2E live Jira coverage of a JQL-search-driven triage flow: a manual-trigger
   Flow that searches for issues matching a seeded JQL and, for each match, adds
@@ -9,7 +9,7 @@ description: >
   Tenant prerequisite: a `uipath-atlassian-jira` connection in folder
   `Shared/uipath-maestro-flow` reaching the `CE` / "Coder Eval" project, with
   issue-search scope. Targets live in `jira_is.py`.
-tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:loop, connector, e2e, uipath-atlassian-jira, ipe, mode:build]
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:loop, connector, e2e, uipath-atlassian-jira, mode:build]
 
 run_limits:
   expected_turns: 45


### PR DESCRIPTION

The `ipe` tag is not  CORRECT for these two tasks as its not owned by IS.

- skill-flow-ipe-jira-search-triage → skill-flow-jira-search-triage
- skill-flow-ipe-jira-lifecycle     → skill-flow-jira-lifecycle