### PR TITLE
fix(tests): simplify ipe-enum flow task + repoint test recipient

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/check_enum_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_enum_flow.py
@@ -47,7 +47,7 @@ def _check_structure(flow_path: str, flow: dict[str, Any]) -> None:
 _JSONSTRING_PREFIX = "=jsonString:"
 
 _EXPECTED_BODY = {
-    "to": "baishali13@gmail.com",
+    "to": "is-test@uipath.com",
     "importance": "high", # this is the enum field under test
 }
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
@@ -3,7 +3,7 @@ description: >
   Tests the enum IS feature — configures a connector node with an enum
   importance field on the Gmail "Send Mail" activity. Recipient, subject, and
   body are fixed so the test can verify the enum value wiring.
-tags: [uipath-maestro-flow, integration, lifecycle-generate, shape-multi-node, connector, uipath-google-gmail, ipe, mode:build]
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, connector, uipath-google-gmail, ipe, mode:build]
 
 run_limits:
   expected_turns: 46
@@ -14,13 +14,10 @@ initial_prompt: |
   Create a new Flow project called "EnumTest" with a manual trigger.
   Build a flow that sends an email via the Gmail "Send Mail" connector
   activity. Use these exact values:
-    - to:        "baishali13@gmail.com"
+    - to:        "is-test@uipath.com"
     - subject:   "weather today"
     - body:      "Weather update for today."
     - importance: "high"
-  Add a Decision node to check whether the call succeeded.
-  Route failure to a Terminate node with error message "Enum test failed".
-  Route success to a final action that logs "Enum test passed".
   Validate the final flow file.
   Use the connection present in Shared/uipath-maestro-flow.
 
@@ -60,14 +57,6 @@ success_criteria:
   - type: run_command
     description: "Connector node has inputs.detail.bodyParameters with to and importance"
     command: "python3 $TASK_DIR/check_enum_flow.py '**/EnumTest*.flow' body_params"
-    timeout: 10
-    expected_exit_code: 0
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: run_command
-    description: "Flow has Decision and Terminate nodes"
-    command: "python3 $TASK_DIR/check_enum_flow.py '**/EnumTest*.flow' control"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0


### PR DESCRIPTION
## Why

`skill-flow-ipe-enum` **timed out** in the `2026-09-03_04-16-28` run — `agent_timeout` at `turn_timeout=1200s`, score 0.

**Root cause (from the run's `task.json`):** this is meant to be a focused *enum-wiring* feature test, but the prompt also demanded a **Decision node + Terminate node + success/failure routing + a final log action**. That control-flow requirement sent the agent into a multi-minute loop re-reading the maestro-flow skill's decision/terminate/merge/fan-in docs. It burned the full 20-minute turn budget — **96 assistant turns, 96k output tokens** — and never converged on a built flow. CLI commands cost only **~50s** of the 1200s.

## Changes

| Change | Detail |
|--------|--------|
| **Simplify prompt** | Drop the Decision / Terminate / success-log routing. Task now builds a single Gmail "Send Mail" connector node with the enum `importance` field. |
| **Drop `control` criterion** | The Decision+Terminate grading check is removed (would auto-fail the simplified task). `_check_control` stays in `check_enum_flow.py`, just unused. |
| **Tag form** | `lifecycle-generate` -> `lifecycle:generate`, `shape-multi-node` -> `shape:single-node`. |
| **Recipient** | Fixed `to` `baishali13@gmail.com` -> `is-test@uipath.com`, in both the prompt and the grader's `_EXPECTED_BODY`. |

**Unchanged:** `task_id` (`skill-flow-ipe-enum`), the `ipe` tag, and `expected_turns` (46).

## Validation
Run against coder evals thrice for both codex and claude, all runs passed 
https://github.com/UiPath/skills/actions/runs/33879208296 

🤖 Generated with [Claude Code](https://claude.com/claude-code)