### PR TITLE
fix: route v4 endpoints to objectName (#ENGCE-61098)

### DIFF
--- a/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
@@ -35,8 +35,8 @@ Definitions in `definitions[]` are CLI-owned. `uip maestro flow node add` copies
 
 An activity is `4.0.0` when its `configuration` JSON reports `"version":"4.0.0"`. Author it through the Configuration workflow below like any other connector activity; `describe`/version mechanics are in [/uipath:uipath-platform — resources.md § `--activity-version`](../../../../../uipath-platform/references/integration-service/resources.md#--activity-version). Four deltas:
 
-1. **No `objectName` in `--detail`** — resolved from the configuration's `activityName` (`model.context.objectName` is empty).
-2. **`method` / `endpoint`** — from `connectorMethodInfo` (`registry get`) or `availableOperations[]` (`is resources describe <connector-key> <activity-name> --activity-version 4.0.0`).
+1. **`objectName` source** — read the definition's `configuration` `objectName` (the `model.context[]` `objectName` entry is declared with no value). It is the `describe` positional, but do NOT pass it in `--detail` — `node configure` reads it from the definition itself. If configuration carries no `objectName`, the registry copy is stale: run `uip maestro flow registry pull --force`, delete the `definitions[]` entry, and re-add the node.
+2. **`method` / `endpoint`** — from `connectorMethodInfo` (`registry get`) or `availableOperations[]` (`is resources describe <connector-key> <object-name> --activity-version 4.0.0`).
 3. **Operation label ≠ HTTP verb** — a semantic operation (e.g. `Update`) pairs with any verb (e.g. `POST /usergroups.users.update`). `flow validate` accepts it; do not "fix" the method to match the label.
 4. **Not connection-scoped** — `--connection-id` on `registry get` adds no custom fields.
 
@@ -103,7 +103,7 @@ uip is resources describe "<connector-key>" "<objectName>" \
 
 Then run `cat <metadataFile path from response>` and read the full cached metadata. Pass `--operation` as the node definition's `model.context[].method` verbatim. E.g. Jira `curated_get_issue` → `GETBYID`; Data Service `QueryEntityRecordsCurated` → `POST`. Do not use `connectorMethodInfo.operation` or `connectorMethodInfo.method` as the describe lookup key.
 
-> **`4.0.0` activities** — positional is the `activityName`, `--activity-version 4.0.0` is mandatory, `--operation` takes the verb from `model.context[].method` (never a guessed semantic label), and `--connection-id` is ignored: `uip is resources describe "<connector-key>" "<activityName>" --activity-version 4.0.0 --operation <method> --output json`. See [§ 4.0.0 Activities](#400-activities).
+> **`4.0.0` activities** — positional is the `objectName`, `--activity-version 4.0.0` is mandatory, `--operation` takes the verb from `model.context[].method` (never a guessed semantic label), and `--connection-id` is ignored: `uip is resources describe "<connector-key>" "<objectName>" --activity-version 4.0.0 --operation <method> --output json`. See [§ 4.0.0 Activities](#400-activities).
 
 Read `availableOperations[].method` and `availableOperations[].path` for method and endpoint; `parameters[]` for query/path parameters and `reference` objects; `requestFields[]` for body names, types, required status, descriptions, and `reference` objects; and `responseFields[]` for the response schema.
 

--- a/skills/uipath-platform/references/integration-service/resources.md
+++ b/skills/uipath-platform/references/integration-service/resources.md
@@ -68,13 +68,13 @@ Results are cached locally. Use `--refresh` to bypass cache after re-auth or sch
 
 ### `--activity-version`
 
-Pass `--activity-version 4.0.0` only when the activity's `configuration` JSON reports `"version":"4.0.0"`. Otherwise do not pass the flag at all. Any value other than `1.0.0` (the default) or `4.0.0` fails with `Invalid --activity-version value`. `4.0.0` responses cache under a separate key (`<activity-name>.v4.schema.json`), so switching never serves the other version's metadata.
+Pass `--activity-version 4.0.0` only when the activity's `configuration` JSON reports `"version":"4.0.0"`. Otherwise do not pass the flag at all. Any value other than `1.0.0` (the default) or `4.0.0` fails with `Invalid --activity-version value`. `4.0.0` responses cache under a separate key (`<object-name>.v4.schema.json`), so switching never serves the other version's metadata.
 
-The resource argument follows the same rule: `4.0.0` activities are addressed by **activity name** — pass the `activityName` from the `configuration` JSON (`4.0.0` metadata has no `objectName`). Everything else uses the object name.
+The resource argument follows the same rule: `4.0.0` activities are addressed by **object name** — pass the `objectName` from the `configuration` JSON.
 
 ```bash
 uip is resources describe <connector-key> <object-name> --output json
-uip is resources describe <connector-key> <activity-name> --activity-version 4.0.0 --output json
+uip is resources describe <connector-key> <object-name> --activity-version 4.0.0 --output json
 ```
 
 ---


### PR DESCRIPTION
## Why

Both references said a `4.0.0` (v4) connector activity is addressed by its **activity name**. The CLI addresses it by **object name** — and always has. The flag's own help text says so:

```
--activity-version <version>
  Activity metadata version: 1.0.0 (default, v3 elements endpoints, connection-scoped)
  or 4.0.0 (v4 elements endpoints, not connection-scoped). Both are addressed by object name.
```
`integrationservice-tool/src/commands/resources.ts:756`

The describe handler is explicit — there is no v4 branch on the positional at all:

```ts
// The positional is the object name for both 1.0.0 and 4.0.0.
const resourceName = objectName;
```
`resources.ts:793`

And the command's own built-in example passes an object name (`resources.ts:94`):

```
uip is resources describe uipath-salesforce-slack add_users_to_usergroup --activity-version 4.0.0
```

An agent following the old docs derived the positional from the node type's activity-name suffix (`add-users-to-user-group-beta-`) instead of `add_users_to_usergroup`, so `describe` missed and the node was configured from no metadata.

## What

| File | Change |
|---|---|
| `uipath-platform/.../resources.md` § `--activity-version` | Resource argument and cache key are the **object name** for v4, not the activity name. Dropped the "`4.0.0` metadata has no `objectName`" claim — it does have one. |
| `uipath-maestro-flow/.../connector/impl.md` § 4.0.0 Activities, Step 3 | Same correction for delta 2 and the Step 3 describe blockquote; delta 1 rewritten (below). |

## Delta 1 — where the objectName actually comes from

The v4 `objectName` is real, but it is **not** in `model.context[]`, and it is **not** passed in `--detail`. `configureActivity` branches before the normal objectName resolution and reads it off the definition's `configuration` JSON:

```ts
const isV4Activity = isV4ActivityConfiguration(instanceParameters);
if (isV4Activity) {
    if (typeof instanceParameters.objectName !== "string" || !instanceParameters.objectName) {
        throw new InvalidDetailError(`"${node.type}" is a 4.0.0 activity but its definition's
            configuration carries no objectName — the local registry copy may be stale. …`);
    }
    objectName = instanceParameters.objectName;
} else {
    objectName = resolveObjectName(/* the --detail.objectName path */);
}
```
`flow-tool/src/services/connector-service.ts:1336-1348`

The v4 manifest declares the context entry with no value — which is exactly why the v4 path reads the configuration blob:

```ts
{ name: "objectName", type: "string" },   // connector-service.spec.ts:472
```

and the test states the contract directly:

> `configures without --detail.objectName, fetching metadata from the v4 endpoint by object name`
> `connector-service.spec.ts:557`

So delta 1 now says: read `configuration.objectName`; it is the `describe` positional; do not pass it in `--detail`; if it is absent the registry copy is stale (`registry pull --force`, drop the `definitions[]` entry, re-add).

## Verification

Grepped both files — no `activityName` / `activity-name` remains in a v4 addressing context. The one surviving `<activity-name>` (`impl.md:60`) is the node-type suffix `uipath.connector.<key>.<activity-name>`, a different thing and correct as written.

## Deliberately out of scope

Pre-existing v4 gaps this PR does not touch, all verified against the CLI:

- `is resources describe --field` is a hard exit-1 with `--activity-version 4.0.0` (`resources.ts:810-820`), but `impl.md` Step 3a still tells the agent to run it whenever an api-type ObjectAction is present.
- `node configure` rejects `--detail.filter` (`connector-service.ts:1443`) and `customFieldsRequestDetails` (`:1448`) for v4; Steps 6a/6c present both unconditionally.
- `detail.activityContext = { version, scriptRef }` (`connector-service.ts:1374`) — the v4 stand-in for `detail.objectName` — is absent from the `inputs.detail` field list.
- `resources.md`: v4 cache entries land under the no-connection key (`<connector-key>/_static/<object-name>.v4.schema.json`); `--connection-id` is warned-and-ignored for v4, against the section's blanket "Always pass `--connection-id`"; and `--activity-version` exists only on `describe`, not on `resources list` / `resources run`.
