### PR TITLE
fix(uipath-maestro-flow): assert one project after scaffold, and stop the task demanding two

### DIFF
--- a/skills/uipath-maestro-flow/references/author/greenfield.md
+++ b/skills/uipath-maestro-flow/references/author/greenfield.md
@@ -198,6 +198,14 @@ Equivalent: use the absolute project dir reported by `flow init` in `Data.Path` 
 
 If the file does not exist at the absolute double-nested path, Step 2 is wrong. Delete the partial scaffold and restart from Step 2a — do not try to patch the layout by hand.
 
+**Then assert it is the only one.** `cd` does not persist between tool calls, so a later `uip maestro flow init` issued outside the solution auto-scaffolds `<Project>Solution/` beside the real project rather than failing. Nothing downstream objects: `flow validate` passes on either file, `format` and `node configure` operate on whichever path you hand them, and the duplicate surfaces only when something globs and resolves to two.
+
+```bash
+find . -name project.uiproj -o -name '*.flow' | sort   # expect exactly one of each
+```
+
+More than one → **delete the stray scaffold.** Do not `mv` it into place: moving the auto-created project leaves the original where it was, which is how one build ends up shipping two `.flow` files that both validate. This check is rule #6's "finish with one `project.uiproj`; remove strays".
+
 See [shared/file-format.md](../shared/file-format.md) for the full project structure.
 <!--skill-flavor:project-creation:end-->
 

--- a/tests/tasks/uipath-maestro-flow/bindings/no_duplicate_connection_bindings.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/no_duplicate_connection_bindings.yaml
@@ -18,8 +18,8 @@ run_limits:
 
 initial_prompt: |
   Build a flow named "BindingsRegression" — Manual Trigger → IS connector
-  node → End — saved as `BindingsRegression/flow_files/BindingsRegression.flow`
-  with `BindingsRegression/project.uiproj`.
+  node → End — in a solution of the same name, so the layout is the canonical
+  `BindingsRegression/BindingsRegression/BindingsRegression.flow`.
 
   Configure the connector node exactly once. Do not invoke any "refresh
   schema" workaround afterwards — the bindings shape immediately after


### PR DESCRIPTION
**Stacked on #3090 → #3088.** Retarget as those land.

## Problem

`skill-flow-bindings-no-duplicates` failed on 2026-09-04 with all four structural criteria reporting the same thing:

```
FAIL: Multiple files found for '**/BindingsRegression*.flow':
  ['BindingsRegression/BindingsRegression/BindingsRegression.flow',
   'BindingsRegression/flow_files/BindingsRegression.flow']
```

**The regression it exists to catch passed.** No empty-keyed Connection bindings, no duplicate `(name, propertyAttribute)` rows, `resourceKey` matching the default. The bindings were clean. It failed on housekeeping, and the real result was invisible behind it.

Two causes, one on each side.

## 1. The skill checks the flow exists, never that it is the only one

`cd` does not persist between tool calls, so a later `uip maestro flow init` issued outside the solution **auto-scaffolds `<Project>Solution/` beside the real project rather than failing**. Nothing downstream objects — `flow validate` passes on either file, `format` and `node configure` operate on whichever path they are handed. The duplicate surfaces only when something globs and resolves to two.

Step 2c now asserts it:

```bash
find . -name project.uiproj -o -name '*.flow' | sort   # expect exactly one of each
```

and says to **delete** the stray rather than `mv` it into place. Moving the auto-created project leaves the original where it was, which is exactly how this run ended up with two files that both validate.

`SKILL.md` rule #6 already said "finish with one `project.uiproj`; remove strays" — Step 2c is where that becomes checkable.

## 2. The task asked for a layout the skill forbids

The prompt demanded:

> saved as `BindingsRegression/flow_files/BindingsRegression.flow` with `BindingsRegression/project.uiproj`

That is not the canonical `<Solution>/<Project>/<Project>.flow`, and it puts `project.uiproj` at the solution root instead of in the project directory. `flow validate` said so during the run — *"does not match canonical"* and *"not registered as a project of solution"*.

So the agent scaffolded correctly, then hand-moved to satisfy the prompt, which is the one thing Step 2c tells it not to do. **The task set up the failure the skill then got blamed for.**

The layout was never load-bearing for a bindings regression, so the prompt now asks for the canonical one. The checker glob `**/BindingsRegression*.flow` matches it unchanged.

## Verification

- 775 pytest pass.
- Glob still resolves the canonical path.
- The prompt keeps its actual subject: *"Configure the connector node exactly once. Do not invoke any refresh schema workaround afterwards."*
- All maintenance checkers clean apart from the anchor pre-existing on `main`; both flavors compose.

## Note

This is the one of the eight nightly failures where the skill was already right and the eval was wrong. Worth flagging as a pattern: a task that asks for something the skill forbids will produce a failure that reads as a skill defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
