### PR TITLE
fix(uipath-maestro-flow): run a script body against the real payload, not just a parser

### DIFF
--- a/skills/uipath-maestro-flow/references/author/plugins/script/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/script/impl.md
@@ -40,18 +40,7 @@ See [Action Node Structure — Adding and editing procedures](../../../shared/ac
 6. **No external calls** — use the HTTP node or a connector node for API calls.
 7. **30-second timeout** — long-running computations will be killed.
 8. **Never name a variable `aggregate`** — reserved host global. On any `Identifier 'X' has already been declared`, rename `X`.
-9. **Run the body against the real upstream payload before shipping it.** Any script that indexes, slices, splits, or maps is one off-by-one away from a fault that `flow validate` cannot see and a syntax check passes. You already have the payload: the `uip is resources run` / `registry get` call that told you the field names is the same shape `$vars.<nodeId>.output` carries at runtime. Feed it to the body.
-
-   ```bash
-   # $vars is a global at runtime; supply it as the one parameter to test.
-   node -e '
-     const payload = require("/tmp/upstream.json");                    # the real response, not a hand-written stub
-     const body    = require("fs").readFileSync("/tmp/script.js", "utf8");
-     console.log(new Function("$vars", body)({ myNode: { output: payload } }));
-   '
-   ```
-
-   A hand-written stub tests the script against what you assumed the field held, which is the thing being checked. `"700 Bellevue Way NE, Suite 2000, Bellevue, WA 98004".split(",")[length - 3]` is `"Suite 2000"`, not the city — correct-looking, syntactically fine, and a runtime fault two nodes later when the lookup it feeds finds nothing.
+9. **Run the body against the real upstream payload before shipping.** An index or key that is wrong for the actual shape parses cleanly and faults at runtime — `flow validate` does not execute script bodies, and neither does a `new Function` parse check. Use the payload the `uip is resources run` / `registry get` call already returned, not a stub: a stub tests the script against what you assumed the field held.
 
 ## Common patterns
 

--- a/skills/uipath-maestro-flow/references/author/plugins/script/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/script/impl.md
@@ -40,6 +40,18 @@ See [Action Node Structure — Adding and editing procedures](../../../shared/ac
 6. **No external calls** — use the HTTP node or a connector node for API calls.
 7. **30-second timeout** — long-running computations will be killed.
 8. **Never name a variable `aggregate`** — reserved host global. On any `Identifier 'X' has already been declared`, rename `X`.
+9. **Run the body against the real upstream payload before shipping it.** Any script that indexes, slices, splits, or maps is one off-by-one away from a fault that `flow validate` cannot see and a syntax check passes. You already have the payload: the `uip is resources run` / `registry get` call that told you the field names is the same shape `$vars.<nodeId>.output` carries at runtime. Feed it to the body.
+
+   ```bash
+   # $vars is a global at runtime; supply it as the one parameter to test.
+   node -e '
+     const payload = require("/tmp/upstream.json");                    # the real response, not a hand-written stub
+     const body    = require("fs").readFileSync("/tmp/script.js", "utf8");
+     console.log(new Function("$vars", body)({ myNode: { output: payload } }));
+   '
+   ```
+
+   A hand-written stub tests the script against what you assumed the field held, which is the thing being checked. `"700 Bellevue Way NE, Suite 2000, Bellevue, WA 98004".split(",")[length - 3]` is `"Suite 2000"`, not the city — correct-looking, syntactically fine, and a runtime fault two nodes later when the lookup it feeds finds nothing.
 
 ## Common patterns
 
@@ -91,6 +103,7 @@ Property access is **case-sensitive** — these casings resolve: `.FullName`, `.
 | Return value is not an object | Returned a scalar (`return 42`) | Wrap in object: `return { value: 42 }` |
 | `$vars.nodeId` is undefined | Upstream node not connected or wrong ID | Check edges and node IDs |
 | Timeout after 30s | Script too expensive | Simplify logic or split into multiple scripts |
+| `[300501] Error invoking script task` with **no** `Unexpected token` | Logic, not syntax: an index, key, or guard that is wrong for the real payload. The script parses, runs, and throws — or returns a value that faults a downstream node | Run the body against the real upstream response (rule 9), not a stub |
 | `console is not defined` | Used `console.log()` | Remove — use `return { debug: val }` instead |
 | `fetch is not defined` | Tried to make HTTP call | Use an HTTP node or connector node instead |
 | `[300501] Error invoking script task` with `Unexpected token` | Malformed JavaScript — `flow validate` does not parse script bodies, so syntax errors surface only at runtime. Common slip: one missing `)` in chained `(((a \|\| {}).b \|\| {}).c \|\| [])` guards | Balance parentheses; check with `node -e "new Function(<script>)"` before validate |


### PR DESCRIPTION
Independent of #3091 and #3093 — different file, based on `main`.

## Problem

`skill-flow-slack-weather-pipeline` faulted with `[300501] Error invoking script task (element extractOfficeCity1)`:

```js
const parts = description.split(',').map(p => p.trim());
const city  = parts[parts.length - 3];
```

Against `"700 Bellevue Way NE, Suite 2000, Bellevue, WA 98004"` that is `"Suite 2000"`, not `"Bellevue"`. The coordinate lookup it feeds found nothing and threw.

`impl.md` already told the agent to syntax-check with `node -e "new Function(<script>)"`. **Confirmed that passes this script unchanged** — the bug is invisible to a parser, and `flow validate` does not read script bodies at all. Nothing between authoring and a live debug run says a word.

## Fix

Rule 9 extends the existing check from *parse* to *execute*, against a payload the agent already has: the `uip is resources run` / `registry get` call that told it the field names returns the same shape `$vars.<nodeId>.output` carries at runtime.

```bash
# $vars is a global at runtime; supply it as the one parameter to test.
node -e '
  const payload = require("/tmp/upstream.json");                    # the real response, not a hand-written stub
  const body    = require("fs").readFileSync("/tmp/script.js", "utf8");
  console.log(new Function("$vars", body)({ myNode: { output: payload } }));
'
```

A hand-written stub is ruled out explicitly — it tests the script against what you *assumed* the field held, which is the thing under test.

## Verified both directions

Against the real Slack payload:

```
shipped script  → Error: No Open-Meteo coordinate mapping for city: Suite 2000
                    at <anonymous>:9:25
parts.length-2  → { city: 'Bellevue', latitude: 47.6101, longitude: -122.2015 }
```

The check reproduces the exact runtime fault at author time, with a line number and the wrong value named — and it does not fire on the corrected script, so it discriminates rather than just failing loudly.

## Also

The Debug table gains the row that routes there: `[300501]` with **no** `Unexpected token` is logic, not syntax. The existing entry only covers the `Unexpected token` case, so a logic fault currently sends you looking for an unbalanced paren.

## Scope

One file, docs only. All maintenance checkers clean apart from the anchor pre-existing on `main`; both flavors compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
