### PR TITLE
docs(uipath-maestro-flow): connector params come from describe; reference fields take looked-up ids

### DIFF
--- a/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
@@ -107,7 +107,7 @@ Then run `cat <metadataFile path from response>` and read the full cached metada
 
 Read `availableOperations[].method` and `availableOperations[].path` for method and endpoint; `parameters[]` for query/path parameters and `reference` objects; `requestFields[]` for body names, types, required status, descriptions, and `reference` objects; and `responseFields[]` for the response schema.
 
-> **Write only parameter names that `describe` listed, in the bucket it listed them under.** `requestFields[]` → `bodyParameters`; `parameters[]` → `queryParameters` or `pathParameters` by `type`. When a name you expect is missing from the body fields, look in `parameters[]`. Never guess a key. Slack `send_message_to_channel_v2`: `send_as` is a query parameter, not a body field, and `username` does not exist.
+> **Write only parameter names that `describe` listed, in the bucket it listed them under.** Never guess a key. Slack `send_message_to_channel_v2`: `send_as` is a required query parameter, not a body field; `username` is the bot display name, not a send-as switch.
 
 ### Step 3a — Resolve parent-field-driven custom fields
 
@@ -123,7 +123,7 @@ Check **BOTH `requestFields` AND `parameters`** from the metadata for entries wi
 
 > **References are NOT body-field-only.** Query and path parameters carry `reference` objects too, and on some connectors the activity's PRIMARY input is a required **path parameter** whose `reference` is the design-time lookup behind a Studio Web dropdown. Scanning only `requestFields` misses it — the node then configures and passes `flow validate` with an unverified value and 404s at runtime. The same `reference` blocks appear on `connectorMethodInfo.parameters[]` in `registry get` output (with or without `--connection-id`) — when projecting parameter metadata for inspection, always include the `reference` key, not just `name`/`required`/`design.component`.
 
-> **A field with a `reference` takes a looked-up id, not a raw value.** Resolve it against `reference.path` and read `reference.lookupValue` from the result. Never pass an email address, a display name, or prompt text. Leave an optional reference field out when the prompt did not ask for it. Jira `fields.reporter.id` wants an `accountId`, not `jane.doe@acmecorp.com`.
+> **A field with a `reference` takes a value a live lookup returned, never a value you typed.** Resolve it per [reference-resolution.md — Reference Fields](../../../../../uipath-platform/references/integration-service/reference-resolution.md#reference-fields-critical). A plain word is right only when the lookup returns it (Slack `send_as` → `user` or `bot`). Jira `fields.reporter.id` wants the looked-up `accountId`, not `jane.doe@acmecorp.com`.
 
 > **Resolve every reference field freshly, against the current `--connection-id`, immediately before `node configure` (Step 6)** — even if you think you already know the ID from a previous flow. Reference IDs are connection-scoped and reused values fault silently at runtime. See [Reference IDs Are Connection-Scoped (CRITICAL)](../../../../../uipath-platform/references/integration-service/reference-resolution.md#reference-ids-are-connection-scoped-critical) for the full mechanism and failure mode, and the top-level Anti-Patterns in [SKILL.md](../../../../SKILL.md).
 

--- a/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
@@ -107,6 +107,8 @@ Then run `cat <metadataFile path from response>` and read the full cached metada
 
 Read `availableOperations[].method` and `availableOperations[].path` for method and endpoint; `parameters[]` for query/path parameters and `reference` objects; `requestFields[]` for body names, types, required status, descriptions, and `reference` objects; and `responseFields[]` for the response schema.
 
+> **Write only parameter names that `describe` listed, in the bucket it listed them under.** `requestFields[]` → `bodyParameters`; `parameters[]` → `queryParameters` or `pathParameters` by `type`. When a name you expect is missing from the body fields, look in `parameters[]`. Never guess a key. Slack `send_message_to_channel_v2`: `send_as` is a query parameter, not a body field, and `username` does not exist.
+
 ### Step 3a — Resolve parent-field-driven custom fields
 
 Run this whenever metadata contains an api-type ObjectAction in top-level `objectActions[]` or `connectorMethodInfo.design.actions[]`. This applies to every operation whose schema depends on parent fields, including Create/Edit/Update inputs and Get/Retrieve/Query response fields.
@@ -120,6 +122,8 @@ Do not skip this for Get/Retrieve: runtime may succeed while Studio Web lacks th
 Check **BOTH `requestFields` AND `parameters`** from the metadata for entries with a `reference` object — these require ID lookup from the connector's live data. Use `uip is resources run list` to resolve them:
 
 > **References are NOT body-field-only.** Query and path parameters carry `reference` objects too, and on some connectors the activity's PRIMARY input is a required **path parameter** whose `reference` is the design-time lookup behind a Studio Web dropdown. Scanning only `requestFields` misses it — the node then configures and passes `flow validate` with an unverified value and 404s at runtime. The same `reference` blocks appear on `connectorMethodInfo.parameters[]` in `registry get` output (with or without `--connection-id`) — when projecting parameter metadata for inspection, always include the `reference` key, not just `name`/`required`/`design.component`.
+
+> **A field with a `reference` takes a looked-up id, not a raw value.** Resolve it against `reference.path` and read `reference.lookupValue` from the result. Never pass an email address, a display name, or prompt text. Leave an optional reference field out when the prompt did not ask for it. Jira `fields.reporter.id` wants an `accountId`, not `jane.doe@acmecorp.com`.
 
 > **Resolve every reference field freshly, against the current `--connection-id`, immediately before `node configure` (Step 6)** — even if you think you already know the ID from a previous flow. Reference IDs are connection-scoped and reused values fault silently at runtime. See [Reference IDs Are Connection-Scoped (CRITICAL)](../../../../../uipath-platform/references/integration-service/reference-resolution.md#reference-ids-are-connection-scoped-critical) for the full mechanism and failure mode, and the top-level Anti-Patterns in [SKILL.md](../../../../SKILL.md).
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
@@ -45,7 +45,8 @@ initial_prompt: |
      productionDown AND NOT workaroundAvailable; Sev2 = productionDown AND
      workaroundAvailable; Sev3 otherwise) plus engineeringNeeded.
   2. Create a Jira issue using the Atlassian Jira "Create Issue" connector activity.
-     Use the `project_key` and `issuetype_id` from `seed.json`. The issue summary
+     Use the `project_key`, `issuetype_id`, and `reporter_id` from `seed.json`
+     (`reporter_id` is the issue's reporter field). The issue summary
      MUST include the `correlationId` verbatim (e.g. "[<severity>] <correlationId>
      <subject>"). Use the Atlassian Jira connection in the `Shared/uipath-maestro-flow`
      folder. If the Atlassian Jira connector isn't in your registry, STOP rather than

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
@@ -82,6 +82,14 @@ def connection_id() -> str:
     return by_name[0]["Id"]
 
 
+def myself(conn_id: str) -> str:
+    """Return the connection user's Atlassian accountId."""
+    return _run(
+        "is", "resources", "run", "get", CONNECTOR, "myself",
+        "--connection-id", conn_id,
+    )["Data"]["accountId"]
+
+
 def create_issue(conn_id: str, summary: str) -> str:
     body = {"fields": {"project": {"key": PROJECT_KEY}, "issuetype": {"id": ISSUETYPE_ID}, "summary": summary}}
     return _run(

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/seed.py
@@ -21,6 +21,9 @@ seed = {
     "tag": tag,
     "project_key": jira_is.PROJECT_KEY,
     "issuetype_id": jira_is.ISSUETYPE_ID,
+    # Jira's design-time schema marks fields.reporter.id as required for this
+    # project/issue type; pin it so agents never have to guess or ask.
+    "reporter_id": jira_is.myself(jira_is.connection_id()),
     "correlationId": correlation,
     "inputs": {
         "senderEmail": "jane.doe@acmecorp.com",


### PR DESCRIPTION
## Why

Two codereval e2e failures on 2026-09-04 (run `2026-09-04_04-15-47`, codex) failed at run time on a connector parameter that `flow validate` cannot check.

| Task | What the agent wrote | Runtime error |
|---|---|---|
| escalation-orchestrator-paths | `"username": "user"` in the Slack body; never ran `is resources describe` | `Value for required parameter 'send_as' not found` — `send_as` is a required query parameter |
| escalation-jira-ticket | `fields.reporter.id` = the sender's email, although `describe` showed a `reference` on `accountId` | `reporter: Specify a valid value for Reporter` |

## What this PR does

Doc, `references/author/plugins/connector/impl.md`, two blockquote rules:

- After the describe step: write only parameter names `describe` listed, in the bucket it listed them under; never guess a key. Slack facts, verified live: `send_as` is a required query parameter; `username` is the bot display name, not a send-as switch.
- In the reference-field step: a `reference` field takes a value a live lookup returned, never a typed value. Links to the platform reference-resolution section for the mechanic. A plain word is right only when the lookup returns it (Slack `send_as` → `user` or `bot`). Jira `fields.reporter.id` wants the looked-up `accountId`.

Test, `escalation_jira_ticket`: the seed now provides `reporter_id` through the same live `myself` lookup the `jira_create_issue` task uses, and the prompt names it. On the eval tenant the reporter field is required for this project and issue type, so a correct agent could not pass without it. Criteria and weights unchanged.

## What this PR does not do

It does not stop an agent that skips `describe`. The Slack agent never ran it, so no doc line reaches that agent. The check that closes that case belongs in `uip maestro flow node configure`, which already holds the activity metadata and can reject body keys the activity does not have. That is a separate CLI change.

## Review history

The first cut said `username` does not exist and told agents to leave optional reference fields out. Both were wrong against live `describe` and the eval tenant. Fixed in `d86bc9be5`.
