### PR TITLE
chore: refresh uip CLI catalog (1.203.0-dev.8556)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-09-06T04:06:44Z",
-  "cli_version": "1.202.0-dev.8552",
+  "generated_at": "2026-09-07T04:06:51Z",
+  "cli_version": "1.203.0-dev.8556",
   "verbs": [
     "admin",
     "admin audit",
@@ -1315,7 +1315,9 @@
     "rpa remote configure",
     "rpa remote download-file",
     "rpa remote exec",
-    "rpa remote show",
+    "rpa remote start",
+    "rpa remote status",
+    "rpa remote stop",
     "rpa remote upload-file",
     "rpa restore",
     "rpa run",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.203.0-dev.8556`. The catalog has 1558 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.