### PR TITLE
fix(tests): make the nightly pre_run parse under cmd.exe [PILOT-7460]

### DIFF
--- a/tests/experiments/nightly.yaml
+++ b/tests/experiments/nightly.yaml
@@ -53,11 +53,15 @@ defaults:
         api_base: CODEX_BASE_URL
         api_key: CODEX_API_KEY
 
+  # Leading `:;` and single line are load-bearing. coder-eval runs this through
+  # create_subprocess_shell, which is cmd.exe on the Windows split: cmd rejects
+  # `if [ ... ]` (`"${MAESTRO_FLOW_SDK_SETUP:-0}" was unexpected at this time.`,
+  # exit 1) and every task in the split ERRORs at setup. A line starting with `:`
+  # is a label to cmd — ignored, exit 0 — and a no-op to sh, which then runs the
+  # rest. Newlines would put the sh code back on cmd's first line, so keep it
+  # one line and never reformat this into a block scalar.
   pre_run:
-    - command: |-
-        if [ "${MAESTRO_FLOW_SDK_SETUP:-0}" = "1" ]; then
-          bash "$SKILLS_REPO_PATH/tests/scripts/stage-preview-sdk-workspace.sh"
-        fi
+    - command: ':; if [ "${MAESTRO_FLOW_SDK_SETUP:-0}" = "1" ]; then bash "$SKILLS_REPO_PATH/tests/scripts/stage-preview-sdk-workspace.sh"; fi'
       timeout: 30
 
   # Sandbox cleanup between tasks. Tasks that upload Studio Web solutions


### PR DESCRIPTION
## Issue

[PILOT-7460](https://uipath.atlassian.net/browse/PILOT-7460)

## Summary

- coder-eval runs `pre_run` through `create_subprocess_shell`, which is **cmd.exe** on the Windows split of `coder_eval_uipath`. cmd cannot parse `if [ … ]; then`, so the step died at setup and took **every task in the split** with it — build [13287278](https://dev.azure.com/uipath/coder_eval/_build/results?buildId=13287278&view=results): 7/7 tasks `status=ERROR score=0.000 iterations=0`.

  ```
  [pre_run stderr] "${MAESTRO_FLOW_SDK_SETUP:-0}" was unexpected at this time.
  Pre-run command failed (exit 1)
  ```

- Prefix the command with `:` and collapse it to one line. cmd reads a leading-`:` line as a **label** and ignores it (exit 0); sh reads `:` as the **no-op builtin** and runs the rest unchanged.
- Linux is unaffected — verified case-for-case against the previous command (table below).

## Implementation Notes

`MAESTRO_FLOW_SDK_SETUP=1` on that split was incidental. The shell *syntax* is the error, so the flag was never evaluated and `stage-preview-sdk-workspace.sh` never ran. No amount of extra gating (on the flag, on the SDK path, on the OS) can fix this: the failure happens before the first `[` is reached. The command has to stop being POSIX-sh-only.

Two properties are load-bearing, both noted in the comment above the step:

1. **The leading `:`** — this is what makes cmd skip the line.
2. **A single line** — cmd only parses the first line, so a `|-` block scalar puts the sh code right back where it chokes. Do not reformat this into a block scalar.

The alternative was translating `pre_run` in `coder_eval_uipath`'s `prepare_windows_experiment.py` (which already rewrites the POSIX `post_run` cleanup). That was prototyped and rejected: a two-repo change for a one-line problem, and the natural PowerShell translation resolves `bash` to the WSL launcher (`%SystemRoot%\System32\bash.exe` or its WindowsApps shim), which exits 1 with *"no installed distributions"* and re-breaks the split the same way.

## Testing

Command extracted from the parsed YAML, not retyped.

**Windows (`cmd /c`, the shell `create_subprocess_shell` uses there):**

| Case | Result |
|---|---|
| any env | exit 0, silent — label ignored |
| control: same command without the `:` | reproduces `"${MAESTRO_FLOW_SDK_SETUP:-0}" was unexpected at this time.`, exit 1 |

**Linux — old command vs. new, identical in every case** (`sh -c`, cwd = sandbox dir, staging script stubbed to exit on demand):

| Case | Old exit | New exit |
|---|---|---|
| flag unset | 0 | 0 |
| `MAESTRO_FLOW_SDK_SETUP=0` | 0 | 0 |
| `MAESTRO_FLOW_SDK_SETUP=1`, script exits 0 | 0 | 0 |
| `MAESTRO_FLOW_SDK_SETUP=1`, script exits 7 | **7** | **7** |

So the staging script still runs in the sandbox cwd when the flag is set, and a genuine staging failure still aborts the task with `FinalStatus.ERROR` — the loud path is intact, not swallowed. Same results under `sh`, `bash --posix`, and `bash`; `sh -n` clean. Every construct used (`:` builtin, `[`, `if/then/fi`) is POSIX-specified, so dash/busybox `/bin/sh` behave the same — though note the local `sh` here is bash-in-posix-mode, as no dash was available to test against.


[PILOT-7460]: https://uipath.atlassian.net/browse/PILOT-7460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ