### PR TITLE
fix(uipath-test): stop advertising the list-steps alias, document steps list only [TMHUB-33224]

### DIFF
--- a/skills/uipath-test/SKILL.md
+++ b/skills/uipath-test/SKILL.md
@@ -80,7 +80,7 @@ Common `uip tm` commands organized by resource type.
 | `uip tm testcases unlink-automation --project-key <PROJECT_KEY> --test-case-key <TEST_CASE_KEY>` | Unlink the automation from a test case. |
 | `uip tm testcases list-automations --project-key <PROJECT_KEY> --folder-key <FOLDER_KEY>` | List test entry points available in an Orchestrator folder (optional: `--package-name <PACKAGE_NAME>` to filter). |
 | `uip tm testcases list-testsets --project-key <PROJECT_KEY> --test-case-key <TEST_CASE_KEY>` | List test sets that contain a given test case. |
-| `uip tm testcases steps list --project-key <PROJECT_KEY> --test-case-id <TEST_CASE_ID>` | List manual test steps for a test case. **Uses `--test-case-id <UUID>`, not `--test-case-key`.** `uip tm testcases list-steps` is a supported alias. |
+| `uip tm testcases steps list --project-key <PROJECT_KEY> --test-case-id <TEST_CASE_ID>` | List manual test steps for a test case. **Uses `--test-case-id <UUID>`, not `--test-case-key`.** |
 | `uip tm testcases steps get --project-key <PROJECT_KEY> --step-id <UUID>` | Get a single test step by its UUID. |
 | `uip tm testcases steps add --project-key <PROJECT_KEY> --test-case-id <UUID> --description <text>` | Add a step using flags (`--description` required). |
 | `uip tm testcases steps add --project-key <PROJECT_KEY> --test-case-id <UUID> --step '<json>' [--step '<json>' ...]` | Add multiple steps by repeating `--step '<json>'`. Mutually exclusive with flag mode. **Not atomic** — earlier steps persist if a later one fails. |

--- a/skills/uipath-test/references/publish-and-link-guide.md
+++ b/skills/uipath-test/references/publish-and-link-guide.md
@@ -102,7 +102,7 @@ For result download, attachment download, and report generation: see [/uipath:ui
 
 ## Common pitfalls
 
-- **`--test-case-id` (UUID) vs `--test-case-key` (`PROJECT_KEY:NUMBER`) vs `--test-case-keys` (plural, comma-separated).** Use `--test-case-key` for `update`, `delete`, `link-automation`, `unlink-automation`, `list-testsets`. Use `--test-case-id` for `run`, `list-steps`, `list-result-history`. Use `--test-case-keys` (plural) for the bulk-association verbs `testcases add` / `testcases remove`. They are NOT interchangeable.
+- **`--test-case-id` (UUID) vs `--test-case-key` (`PROJECT_KEY:NUMBER`) vs `--test-case-keys` (plural, comma-separated).** Use `--test-case-key` for `update`, `delete`, `link-automation`, `unlink-automation`, `list-testsets`. Use `--test-case-id` for `run`, `steps list`, `list-result-history`. Use `--test-case-keys` (plural) for the bulk-association verbs `testcases add` / `testcases remove`. They are NOT interchangeable.
 - **Wrong folder identifier.** `link-automation` requires the UUID. A folder name or path passed in `--folder-key` fails silently with "folder not found" or links to the wrong folder.
 - **Re-uploading the same package version.** Orchestrator rejects duplicates. Bump `--package-version` (or `project.json` `projectVersion`) on every change.
 - **Linking before upload.** `link-automation` does not validate the package exists on Orchestrator at link time — it only validates at run time. A stale `--package-name` value silently links to nothing and the next run fails with `package not found`. Always discover via `list-automations` (Step 4) before linking.

--- a/tests/tasks/uipath-test/testcase_steps_lifecycle_integration.yaml
+++ b/tests/tasks/uipath-test/testcase_steps_lifecycle_integration.yaml
@@ -102,7 +102,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed the steps (`steps list --test-case-id` + --output json)"
     tool_name: "Bash"
-    command_pattern: '(?=[\s\S]*--project-key\s+\S)(?=[\s\S]*--test-case-id\s+\S)(?=[\s\S]*--output\s+json)uip\s+tm\s+testcases?\s+(steps\s+list|list-steps)\b'
+    command_pattern: '(?=[\s\S]*--project-key\s+\S)(?=[\s\S]*--test-case-id\s+\S)(?=[\s\S]*--output\s+json)uip\s+tm\s+testcases?\s+steps\s+list\b'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0


### PR DESCRIPTION
Follow-up to [UiPath/cli#4036](https://github.com/UiPath/cli/pull/4036) / [TMHUB-33224](https://uipath.atlassian.net/browse/TMHUB-33224), which hides the `uip tm testcases list-steps` alias from `--help`. The alias still runs, but `steps list` is now the only documented spelling, so the skill should stop advertising the alias.

## What changed

- `skills/uipath-test/SKILL.md`: dropped the "`uip tm testcases list-steps` is a supported alias" note from the `steps list` row.
- `skills/uipath-test/references/publish-and-link-guide.md`: the `--test-case-id` pitfall now names `steps list` instead of `list-steps`.
- `tests/tasks/uipath-test/testcase_steps_lifecycle_integration.yaml`: the "agent listed the steps" grader accepts `steps list` only. It used to accept either spelling; with the alias hidden, an agent that reaches for `list-steps` is not following the skill.

`assets/uip-catalog-snapshot.json` still lists `tm testcases list-steps`. Left alone on purpose: the daily refresh workflow rebuilds it from `@uipath/cli@alpha` and already excludes hidden commands, so the row drops out on its own once the CLI PR merges.

## Checks

- Ran `skill-test-testcase-steps-lifecycle-integration` locally with the tightened regex (`coder-eval run tasks/uipath-test/testcase_steps_lifecycle_integration.yaml -e experiments/default.yaml`, claude-sonnet-4-6, alpha tenant): status SUCCESS, 10/10 criteria passed, weighted score 1.000, 1 iteration, 221s.
- `node scripts/check-skill-links.mjs`: 6689 links resolve.
- `node scripts/compose-skill-flavor.mjs validate`: OK, 27 skills both flavors.

Docs and one grader regex only; no hooks touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TMHUB-33224]: https://uipath.atlassian.net/browse/TMHUB-33224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ