### PR TITLE
fix(publish): give the bare `preview` dist-tag to the highest release line [PILOT-7474]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,6 +152,9 @@ jobs:
       # publishes the committed version. An explicit
       # `--tag preview` on a pre-release version never moves `latest`, so
       # `npm install @uipath/skills` still resolves the last stable release.
+      #
+      # Which preview tag depends on the line: only the highest release line
+      # owns the bare `preview`. See the guard in the step body.
       - name: Resolve dist-tag and stamp version
         id: dist
         env:
@@ -165,8 +168,29 @@ jobs:
             PREVIEW="${BASE}-preview.${RUN_NUMBER}"
             npm version "$PREVIEW" --no-git-tag-version --allow-same-version
             node scripts/sync-version.mjs
-            echo "tag=preview" >> "$GITHUB_OUTPUT"
-            echo "Publishing $PREVIEW to dist-tag preview"
+
+            # Only the highest release line owns the bare `preview` tag.
+            # `--tag preview` used to be unconditional, so whichever line
+            # published LAST took it regardless of version: on 2026-09-06,
+            # run 637 (release/v1.201) landed after run 635 (release/v1.202)
+            # and pointed `preview` back at the older line. That gets worse
+            # once a line goes stable while the next one previews -- every
+            # 1.201.x hotfix push would take `preview` from 1.202. A lower
+            # line publishes to `preview-v<M.N>` and leaves `preview` alone.
+            #
+            # Fails open: an unset tag or an unreachable registry keeps
+            # `preview`, which is the behaviour this guard replaced.
+            TAG=preview
+            CURRENT=$(npm view "@uipath/skills@preview" version --@uipath:registry=https://registry.npmjs.org/ 2>/dev/null || true)
+            if [ -n "$CURRENT" ]; then
+              # Compare release lines only; strip the -preview.<run> suffix.
+              HIGHEST=$({ echo "${CURRENT%%-*}"; echo "$BASE"; } | sort -V | tail -1)
+              if [ "$HIGHEST" != "$BASE" ]; then
+                TAG="preview-v${BASE%.*}"
+              fi
+            fi
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "Publishing $PREVIEW to dist-tag $TAG (preview is at ${CURRENT:-unset})"
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"
             echo "Publishing $(node -p "require('./package.json').version") to dist-tag latest"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -105,14 +105,16 @@ Registry follows channel — you pick a channel, not a registry.
 | Package | Trigger | Channel | Registry | dist-tag | Version | Provenance |
 |---------|---------|---------|----------|----------|---------|------------|
 | default | push to `main` (normally a merge) | `dev` | GitHub Packages | `dev` | `<base>-dev.<run_number>` | no¹ |
-| default | push to `release/v*` (normally a merge) | `preview` | npmjs | `preview` | `<base>-preview.<run_number>` | yes |
+| default | push to `release/v*` (normally a merge) | `preview` | npmjs | `preview`² | `<base>-preview.<run_number>` | yes |
 | default | `workflow_dispatch` (channel: `dev`) | `dev` | GitHub Packages | `dev` | `<base>-dev.<run_number>` | no¹ |
-| default | `workflow_dispatch` (channel: `preview`) | `preview` | npmjs | `preview` | `<base>-preview.<run_number>` | yes |
+| default | `workflow_dispatch` (channel: `preview`) | `preview` | npmjs | `preview`² | `<base>-preview.<run_number>` | yes |
 | default | `workflow_dispatch` (channel: `latest`) | `latest` | npmjs | `latest` | `package.json` version | yes |
 | Studio Web | push to `main` or dispatch `dev` | `dev` | GitHub Packages | `dev` | `<base>-dev.<run_number>` | no¹ |
 | Studio Web | push to `release/v*` or dispatch `preview` | `preview` | GitHub Packages | `preview` | `<base>-preview.<run_number>` | no¹ |
 
 ¹ GitHub Packages does not support npm provenance attestations; only the npmjs channels are signed.
+
+² Only the **highest** release line takes the bare `preview` tag. A lower line publishes to `preview-v<M.N>` instead — see [Which line owns `preview`](#which-line-owns-preview).
 
 **Two default-package channels publish automatically** (mirroring `UiPath/cli`): every push to `main` (normally a merge) publishes a default `dev` build to GitHub Packages, and every push to a `release/v*` branch publishes a default `preview` build to npmjs. When the custom-package gate is enabled after bootstrap, the same run invokes the isolated Studio Web publisher for its GitHub Packages `dev` or `preview` counterpart. `latest` (stable) is published **only** for the default package by an explicit `channel=latest` dispatch — there is no `release:` trigger, so creating a GitHub Release does not publish anything. `npm install @uipath/skills` (no tag, from npmjs) always resolves the last stable release. The `preview`/`dev` version suffix (`<base>-preview.<run_number>` / `<base>-dev.<run_number>`) matches the CLI's stamping scheme exactly.
 
@@ -124,7 +126,22 @@ Registry follows channel — you pick a channel, not a registry.
 gh workflow run publish.yml --ref release/v<minor> -f channel=preview
 ```
 
-Either way the default job stamps `<base>-preview.<run_number>` (never committed), runs `sync-version.mjs`, and publishes to the npmjs `preview` dist-tag with `--provenance` via the same OIDC job as `latest`. When the custom-package gate is enabled, the isolated Studio Web job derives the identical version and publishes it to the GitHub Packages `preview` tag without provenance. Consume the default with `npm install @uipath/skills@preview`. Each run gets a unique version from `run_number`; the tags advance to the newest one in their respective registries.
+Either way the default job stamps `<base>-preview.<run_number>` (never committed), runs `sync-version.mjs`, and publishes to npmjs with `--provenance` via the same OIDC job as `latest`. When the custom-package gate is enabled, the isolated Studio Web job derives the identical version and publishes it to the GitHub Packages `preview` tag without provenance. Each run gets a unique version from `run_number`.
+
+#### Which line owns `preview`
+
+Two release lines are live whenever one is stabilizing and the next has been cut. `publish.yml` gives the bare `preview` tag to the **highest** line only; a lower line publishes to `preview-v<M.N>`:
+
+| Publishing line | vs. current `preview` | dist-tag | Consume with |
+|---|---|---|---|
+| `release/v1.202` | higher or equal | `preview` | `npm install @uipath/skills@preview` |
+| `release/v1.201` | lower | `preview-v1.201` | `npm install @uipath/skills@preview-v1.201` |
+
+The tag is chosen at publish time by comparing `package.json`'s base version against whatever `preview` currently resolves to, so `npm publish --tag` never has to be undone. If the tag is unset or the registry is unreachable the job falls back to `preview`.
+
+> Without this, the tag followed **publish order** rather than version. On 2026-09-06 run 637 (`release/v1.201`) landed after run 635 (`release/v1.202`) and pointed `preview` at the older line. A promoted line makes it routine: every `M.N.x` hotfix push would take `preview` off the newer line.
+
+Studio Web's GitHub Packages `preview` tag is still unconditional — it has the same ordering exposure between two live lines.
 
 ### The `dev` channel (GitHub Packages)
 


### PR DESCRIPTION
## Issue

[PILOT-7474](https://uipath.atlassian.net/browse/PILOT-7474)

## Summary

- Give the bare `preview` npm dist-tag to the **highest** release line only; a lower line publishes to `preview-v<M.N>` and leaves `preview` alone
- Fixes `preview` following **publish order** instead of version — `--tag preview` was unconditional for every `release/v*` publish
- Tag is chosen at publish time, so this stays inside `npm publish` — the only registry write OIDC trusted publishing can authenticate
- Guard **fails open** to `preview` on an unset tag or unreachable registry: it cannot block a publish

## Why

Two release lines are live whenever one stabilizes and the next is cut. With an unconditional `--tag preview`, whichever line published last took the tag:

| when | run | branch | published | left `preview` at |
|---|---|---|---|---|
| Sep 6 06:31 | 635 | `release/v1.202` | `1.202.0-preview.635` | 1.202 ✅ |
| Sep 6 21:22 | 637 | `release/v1.201` | `1.201.0-preview.637` | **1.201** ❌ |
| Sep 7 08:50 | 642 | `release/v1.201` | `1.201.0-preview.642` | **1.201** ❌ |

`npm install @uipath/skills@preview` resolved 1.201 for ~15 h while 1.202 was the newer line. Promoting 1.201.0 to stable makes this routine rather than rare: hotfixes toward 1.201.1 land on `release/v1.201`, and every push would take `preview` off 1.202.

Only the tag was wrong — `uip skills install` matches on the CLI's own `MAJOR.MINOR` from the version list (`pickMatchingSkillsVersion`), not the dist-tag, so the CLI content path was unaffected throughout.

## Changes

### `.github/workflows/publish.yml`

- In `Resolve dist-tag and stamp version`, compare `package.json`'s base version against whatever `preview` currently resolves to on npmjs
- Lower line → `TAG="preview-v${BASE%.*}"`; equal or higher → `preview`
- `npm view` is scoped with `--@uipath:registry=` — plain `--registry` does **not** override a scoped registry mapping

### `docs/RELEASE.md`

- New `#### Which line owns preview` under **Cutting a preview**, with the consume-with table
- Footnote ² on the two `preview` rows of the publishing-tracks table

## Testing

- Guard logic extracted verbatim and run against 9 cases — all pass: the Sep 6 regression, a `1.201.1` hotfix vs. `preview`=1.202, same-line re-publish, a new higher line, recovery from an older line, empty `CURRENT` (fails open), a stable version on `preview`, and both directions of `1.210.0` vs `1.99.0` to confirm `sort -V` is not comparing lexically
- `publish.yml` parses cleanly; `steps[id=dist]` and the `--tag ${{ steps.dist.outputs.tag }}` consumer both intact
- No change to the `latest` or `dev` paths

## Known gap

Studio Web's GitHub Packages `preview` tag in `publish-skill-flavor.yml` is still unconditional and has the same ordering exposure. Left out of this PR: that workflow takes `channel` as its tag input and would need an authenticated GitHub Packages query. Noted in `RELEASE.md`.



[PILOT-7474]: https://uipath.atlassian.net/browse/PILOT-7474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ