### PR TITLE
feat(uipath-review): use the CLI to record the review result

### DIFF
--- a/skills/uipath-review/SKILL.md
+++ b/skills/uipath-review/SKILL.md
@@ -15,7 +15,7 @@ Use for requests to review, audit, check, evaluate, improve, quality-gate, or un
 
 ## Critical Rules
 
-1. **Read-only.** Never manually modify files. The sole exception is mandatory `uip agent refresh` for low-code agents; it may update derived files, which must not be restored or cleaned up. Report fixes and route them to `uipath-rpa`, `uipath-agents`, `uipath-maestro-flow`, `uipath-maestro-bpmn`, `uipath-api-workflow`, `uipath-coded-apps`, `uipath-platform`, or `uipath-solution`.
+1. **Read-only.** Never manually modify files. The sole exceptions are mandatory `uip agent refresh` for low-code agents, which may update derived files that must not be restored or cleaned up, and `uip agent review-history add` (Step 6), which writes CLI-owned `review-history.json`. Report fixes and route them to `uipath-rpa`, `uipath-agents`, `uipath-maestro-flow`, `uipath-maestro-bpmn`, `uipath-api-workflow`, `uipath-coded-apps`, `uipath-platform`, or `uipath-solution`.
 2. **Validate first.** Every RPA entry point requires `uip rpa validate`, plus a project-level `uip rpa build` — `build` compiles the whole project, including entry points `validate` was never pointed at, so a clean per-file `validate` can still fail `build`. Low-code agents require `uip agent refresh` then `uip agent validate`; use `uip maestro flow validate`, `uip maestro bpmn validate`, and `uip api-workflow validate` as applicable. Every CLI validation command uses `--output json`. Report each command's Error, Warning, and Info counts; detail every Error and Warning, but add no detail lines for clean results. A review without both RPA `validate` and `build` is incomplete.
 3. Discover and classify every project before reviewing any project.
 4. Classify findings as **Critical** (blocks deployment), **Warning** (should fix), or **Info** (improvement opportunity).
@@ -266,6 +266,16 @@ Required sections, in order:
 8. `### Recommended Next Steps` — route fixes to the appropriate skill.
 9. `### Optimization Notes` — only when relevant.
 10. `**Final grade: <A–F>**` — agents only, on its own line as the **last line** of the report (nothing after it); the letter **must match** the Summary Agent Grade.
+
+### Step 6 — Record the Agent Grade
+
+Agent projects only, after the report. For each agent project, persist its per-agent final grade (Step 4.5) into the project's `review-history.json`:
+
+```bash
+uip agent review-history add <GRADE> "<PROJECT_DIR>" --errors <CRITICAL_COUNT> --warnings <WARNING_COUNT> --output json
+```
+
+The CLI owns `review-history.json`: never create, edit, or review the file; exclude it from the authored-file set. If the command fails, state that the grade was not recorded and stop — recording never changes the review outcome.
 
 Legacy validation status must say: `Use uipath-rpa (Legacy mode) for Legacy-specific validation`. Do not say “Could not run” or “Failed”. Legacy is supported indefinitely in Studio LTS and is not a Critical deployment blocker. Recommend migration based on actual needs. Overall Quality is **Good** for 0 Critical and 0–3 Warnings; **Needs Improvement** for 0 Critical and 4+ Warnings or 1 Critical with a clear fix; **Critical Issues** for 2+ Critical or 1 security/data-integrity Critical. For agents, A/B maps to Good, C/D to Needs Improvement, and F to Critical Issues. Never use “Mismatch” or “Aligned”.
 

--- a/skills/uipath-review/SKILL.md
+++ b/skills/uipath-review/SKILL.md
@@ -267,17 +267,11 @@ Required sections, in order:
 9. `### Optimization Notes` — only when relevant.
 10. `**Final grade: <A–F>**` — agents only, on its own line as the **last line** of the report (nothing after it); the letter **must match** the Summary Agent Grade.
 
+Legacy validation status must say: `Use uipath-rpa (Legacy mode) for Legacy-specific validation`. Do not say “Could not run” or “Failed”. Legacy is supported indefinitely in Studio LTS and is not a Critical deployment blocker. Recommend migration based on actual needs. Overall Quality is **Good** for 0 Critical and 0–3 Warnings; **Needs Improvement** for 0 Critical and 4+ Warnings or 1 Critical with a clear fix; **Critical Issues** for 2+ Critical or 1 security/data-integrity Critical. For agents, A/B maps to Good, C/D to Needs Improvement, and F to Critical Issues. Never use “Mismatch” or “Aligned”.
+
 ### Step 6 — Record the Agent Grade
 
-Low-code agent projects only (`uip agent` verbs do not apply to coded agents), after the report. For each low-code agent project, persist its per-agent final grade (Step 4.5) into the project's `review-history.json`:
-
-```bash
-uip agent review-history add <GRADE> "<PROJECT_DIR>" --errors <CRITICAL_COUNT> --warnings <WARNING_COUNT> --output json
-```
-
-The CLI owns `review-history.json`: never create, edit, or review the file; exclude it from the authored-file set. If the command fails, state that the grade was not recorded and stop — recording never changes the review outcome.
-
-Legacy validation status must say: `Use uipath-rpa (Legacy mode) for Legacy-specific validation`. Do not say “Could not run” or “Failed”. Legacy is supported indefinitely in Studio LTS and is not a Critical deployment blocker. Recommend migration based on actual needs. Overall Quality is **Good** for 0 Critical and 0–3 Warnings; **Needs Improvement** for 0 Critical and 4+ Warnings or 1 Critical with a clear fix; **Critical Issues** for 2+ Critical or 1 security/data-integrity Critical. For agents, A/B maps to Good, C/D to Needs Improvement, and F to Critical Issues. Never use “Mismatch” or “Aligned”.
+Low-code agents only: persist the final grade with `uip agent review-history add` per [agent-grading-rubric.md § Record the grade](references/agents/agent-grading-rubric.md#record-the-grade-step-6).
 
 ## Task Navigation
 

--- a/skills/uipath-review/SKILL.md
+++ b/skills/uipath-review/SKILL.md
@@ -15,19 +15,15 @@ Use for requests to review, audit, check, evaluate, improve, quality-gate, or un
 
 ## Critical Rules
 
-1. **Read-only.** Never manually modify files. The sole exceptions are mandatory `uip agent refresh` for low-code agents, which may update derived files that must not be restored or cleaned up, and `uip agent review-history add` (Step 6), which writes CLI-owned `review-history.json`. Report fixes and route them to `uipath-rpa`, `uipath-agents`, `uipath-maestro-flow`, `uipath-maestro-bpmn`, `uipath-api-workflow`, `uipath-coded-apps`, `uipath-platform`, or `uipath-solution`.
-2. **Validate first.** Every RPA entry point requires `uip rpa validate`, plus a project-level `uip rpa build` — `build` compiles the whole project, including entry points `validate` was never pointed at, so a clean per-file `validate` can still fail `build`. Low-code agents require `uip agent refresh` then `uip agent validate`; use `uip maestro flow validate`, `uip maestro bpmn validate`, and `uip api-workflow validate` as applicable. Every CLI validation command uses `--output json`. Report each command's Error, Warning, and Info counts; detail every Error and Warning, but add no detail lines for clean results. A review without both RPA `validate` and `build` is incomplete.
+1. **Read-only.** Never manually modify files. The sole exceptions are the CLI-owned writes of an agent review, `uip agent refresh` and `uip agent review-history add` ([agent-review-guide.md](references/agents/agent-review-guide.md)); they are mandatory; never restore or clean up what they change. Report fixes and route them to `uipath-rpa`, `uipath-agents`, `uipath-maestro-flow`, `uipath-maestro-bpmn`, `uipath-api-workflow`, `uipath-coded-apps`, `uipath-platform`, or `uipath-solution`.
+2. **Validate first.** Every RPA entry point requires `uip rpa validate`, plus a project-level `uip rpa build` — `build` compiles the whole project, including entry points `validate` was never pointed at, so a clean per-file `validate` can still fail `build`. Use `uip maestro flow validate`, `uip maestro bpmn validate`, and `uip api-workflow validate` as applicable. Every CLI validation command uses `--output json`. Report each command's Error, Warning, and Info counts; detail every Error and Warning, but add no detail lines for clean results. A review without both RPA `validate` and `build` is incomplete.
 3. Discover and classify every project before reviewing any project.
 4. Classify findings as **Critical** (blocks deployment), **Warning** (should fix), or **Info** (improvement opportunity).
 5. Establish or infer business context before optimization; queues and additional components are not automatically better.
 6. Do not duplicate validation findings. Reference the output rule ID and message rather than restating checks or passes. Counts include all results; Errors and Warnings also receive detail lines.
 7. Limit analysis to 30 minutes. For solutions with 10+ projects, provide a summary and deep dives for the three highest-risk projects, offering the remainder separately.
-8. Every agent requires `uip agent review` or `uip codedagent review` first, followed by the applicable judgment catalog, including when review began before this skill loaded; merge prior findings only after both passes.
-9. Review-CLI findings are authoritative. Preserve `RuleId`, `Severity`, `Description`, `File`, and `SuggestedFix` verbatim. Format `Recommendation` as `<File>: <Description>. <SuggestedFix>`. Judgment findings use the same format. Map `error` to Critical, `warning` to Warning, and `info` to Info; `judgment` defaults to Warning and may change only with reasoning in the finding description.
-10. Put intended but unapplied rules in **Rules Skipped**, including missing tooling/files, unavailable review CLI, and `status: deferred`. Do not list non-applicable rules.
-11. Never invent `rule_id` values. Each cited ID must occur verbatim in a loaded `references/agents/agents-*-rules.md` catalog or review-CLI JSON. Verify every ID before reporting. A real Critical issue covered by neither source is reported without a `rule_id`; unrule'd Warnings and Infos are dropped. This governs agent findings.
-12. Grade agent projects only with `A`, `B`, `C`, `D`, or `F`, with no `+`/`-`, per agent and overall: `min(G_det, G_jud)`. Read `G_det` from review CLI `Data.Grade`; do not recompute it. Compute `G_jud` from judgment findings only. Show the binding constraint for every grade; low-code reports omit the printed derivation as required by the rubric. A security or data-integrity judgment Critical forces F. The skill grade cannot exceed `Data.Grade`; report both. Do not grade RPA, flows, or coded apps. See [references/agents/agent-grading-rubric.md](references/agents/agent-grading-rubric.md).
-13. `uip agent refresh` owns `.agent-builder/`, `.local/build/`, and, for low-code agents, regenerated root `entry-points.json` from `agent.json`. Do not open these contents. Exclude them from classification, authored-file selection, structural metrics, and manual checks. Report a defect only if refresh fails to fix them. Read low-code schemas from `agent.json` `.inputSchema` and `.outputSchema`.
+8. **Agent projects follow [agent-review-guide.md](references/agents/agent-review-guide.md).** Once Step 1 classifies a project as Agent (Low-Code) or Agent (Coded), read that guide and run its Critical Rules and Steps 2–6 for that project; the steps below apply to it only where the guide points back to them.
+9. Put intended but unapplied rules in **Rules Skipped**, including missing tooling/files, unavailable review CLI, and `status: deferred`. Do not list non-applicable rules.
 
 ## Review Workflow
 
@@ -80,8 +76,8 @@ For every project, read `project.json.expressionLanguage` for RPA (`VisualBasic`
 | absent `targetFramework` or `Legacy` | RPA (Windows-Legacy) | [rpa-review-checklist.md](references/rpa/rpa-review-checklist.md) §10; recommend `uipath-rpa` Legacy mode |
 | both `.cs` and `.xaml` | RPA (Hybrid) | RPA checklist |
 | DU packages `UiPath.IntelligentOCR.Activities` or `UiPath.DocumentUnderstanding.ML.Activities` | RPA + Document Understanding | RPA + [du-review-checklist.md](references/document-understanding/du-review-checklist.md) |
-| `agent.json.type == lowCode` | Agent (Low-Code) | [agents-lowcode-rules.md](references/agents/agents-lowcode-rules.md) |
-| Python coded-agent signals, including `agent.json.type == coded` | Agent (Coded) | [agents-coded-rules.md](references/agents/agents-coded-rules.md) |
+| `agent.json.type == lowCode` | Agent (Low-Code) | [agent-review-guide.md](references/agents/agent-review-guide.md) |
+| Python coded-agent signals, including `agent.json.type == coded` | Agent (Coded) | [agent-review-guide.md](references/agents/agent-review-guide.md) |
 | `*.flow` + `project.uiproj.ProjectType == Flow` | Flow | [flow-review-checklist.md](references/flows/flow-review-checklist.md) |
 | `*.bpmn` + `ProjectType == ProcessOrchestration` | Maestro BPMN | [bpmn-review-checklist.md](references/bpmn/bpmn-review-checklist.md) |
 | `Workflow.json` with `document.dsl` and `do[]` + `ProjectType == Api` | API Workflow | [api-workflow-review-checklist.md](references/api-workflows/api-workflow-review-checklist.md) |
@@ -122,7 +118,6 @@ If unavailable, use Analyzer results included by `uip rpa validate`. Report ever
 
 | Type | Command |
 |---|---|
-| Agent (Low-Code) | `uip agent refresh "<PROJECT_DIR>" --output json`; then `uip agent validate "<PROJECT_DIR>" --output json` |
 | Flow | `uip maestro flow validate "<PROJECT_NAME>.flow" --output json` |
 | Maestro BPMN | `uip maestro bpmn validate "<FILE>.bpmn" --output json` |
 | API Workflow | `uip api-workflow validate "<WORKFLOW_JSON>" --output json` |
@@ -149,41 +144,6 @@ Every report includes:
 
 Include counts for every command. Detail Errors and Warnings only. Do not narrate clean results, passes, zero issues, drift status, scores, regeneration counts, or schema status; the table is sufficient.
 
-### Step 2.5 — Run the Review CLI, Then Apply the Judgment Catalog
-
-Apply to every encountered agent, including late-invoked reviews.
-
-#### 2.5a. Deterministic CLI pass
-
-Run once and capture JSON:
-
-| Type | Command |
-|---|---|
-| Low-Code | `uip agent review "<PROJECT_DIR>" --output json` |
-| Coded | `uip codedagent review "<PROJECT_DIR>" --output json` |
-
-Parse `Data.Issues[]` objects `{RuleId, Category, Severity, Description, File, SuggestedFix}` and carry them verbatim. Guardrail configuration validity is CLI-only: run the review CLI or `--checks guardrails` when appropriate, including every emitted `GUARDRAIL_*` finding verbatim; do not eyeball or re-flag CLI guardrail findings.
-
-#### 2.5b. Judgment pass
-
-Load each applicable catalog fully and apply every rule's `detection_method` to its named source material, including prompts, tools, eval datapoints, and schemas. Track intended rules that cannot be applied.
-
-| Signal | Catalog |
-|---|---|
-| `agent.json.type == lowCode` | `references/agents/agents-lowcode-rules.md` |
-| Python coded-agent or `agent.json.type == coded` | `references/agents/agents-coded-rules.md` |
-| `pyproject.toml` + `main.py` + `uipath.json[functions]` without framework config | coded catalog |
-| `package.json` + `uipath.json[functions]` (no `pyproject.toml`) — Coded Function (JS/TS) | phase 2; no agent catalog |
-| RPA, Flow, Coded App | phase 2; no agent catalog |
-
-For guardrails, running the guardrail workflow is **mandatory** whenever `guardrails[]` is non-empty or the use case calls for guardrails — do not eyeball `agent.json`:
-
-- Low-code: **open [guardrails-review.md](references/agents/guardrails/guardrails-review.md) and follow its Step 0 — you MUST run `uip agent guardrails catalog --output json` (30-min cache) and the never-cached tenant `uip agent guardrails list`** before auditing, then apply Audit Mode and Recommend Mode. Emit `LC_GUARDRAIL_ACTION_INEFFECTIVE`, `LC_GUARDRAIL_MISAPPLIED`, and `LC_GUARDRAIL_RECOMMENDED` as applicable.
-- Coded: **open [coded-guardrails-review.md](references/agents/guardrails/coded-guardrails-review.md) and follow it** when middleware/decorators are wired or the use case calls for guardrails. Public Python SDK docs may be fetched only when a finding must name classes not visible in source. Emit `CODED_GUARDRAIL_ACTION_INEFFECTIVE`, `CODED_GUARDRAIL_MISAPPLIED`, and `CODED_GUARDRAIL_RECOMMENDED`; do not duplicate CLI IDs `CODED_GUARDRAIL_WRONG_IMPORT`, `CODED_GUARDRAIL_TOOL_SCOPE_NO_TOOLS`, or `CODED_GUARDRAIL_INVALID_CONTRACT`.
-- If the guardrail catalog is unavailable, put Audit-Mode rules in Rules Skipped and retain source-only Recommend Mode detection.
-
-Before merging, verify every `rule_id` against a loaded catalog or CLI JSON. Remove absent IDs and retain only a Critical observation; drop unrule'd Warnings and Infos. Merge one row per finding into the Step 5 severity table using `C-D-`, `W-D-`, or `I-D-` prefixes as described in [references/rule-format.md](references/rule-format.md).
-
 ### Step 3 — Manual Quality Review
 
 For each project, load its type-specific checklist and inspect only authored files.
@@ -198,8 +158,6 @@ Derive both the declared contract unit and actual execution unit; do not ask the
 | RPA without queue | `Main.xaml` input arguments |
 | Flow | `.flow.variables.globals` entries with `in`/`inout` direction |
 | Maestro BPMN | Start-event payload/process inputs |
-| Low-code agent | `agent.json.inputSchema` |
-| Coded agent | `Input` Pydantic `BaseModel` in `main.py` |
 | API workflow | `Workflow.json` request schema |
 | Coded app | Entry-point schema in `operate.json`/`entry-points.json` |
 
@@ -240,16 +198,6 @@ Consult as applicable: [rpa-advanced-checklist.md](references/rpa/rpa-advanced-c
 
 Only after validation and manual review, assess business suitability, architecture, dependencies, queue usage, bulk operations, transaction/error recovery, redundant calls, logging, selectors, files, data handling, configuration consistency, environment separation, and performance. For solutions assess cross-project architecture, pinned libraries, circular dependencies, dispatcher/performer suitability, and shared configuration. For single projects assess queues for more than 50 independent items, batching, REFramework/equivalent retry, resource efficiency, and selector/data patterns. Read [review-workflow-guide.md](references/review-workflow-guide.md) and [architecture-assessment-guide.md](references/architecture-assessment-guide.md).
 
-### Step 4.5 — Compute Agent Grade
-
-Agents only:
-
-```text
-Final grade = min(G_det, G_jud)
-```
-
-`G_det` is the letter in CLI `Data.Grade`; never recompute it from issue counts. For judgment findings only, calculate `100 − (15 × Criticals) − (4 × Warnings) − (1 × Infos)`, floored at 0; map `85–100 A`, `65–84 B`, `45–64 C`, `25–44 D`, `0–24 F`. Any unmitigated judgment Critical caps at D; a security/data-integrity judgment Critical forces F. Architecture-principle scores do not affect the grade. For multiple agents use the worst grade, never an average. Show the binding constraint, for example `B — gated by G_det = CLI Data.Grade B; judgment clean (G_jud A)`. Use [agent-grading-rubric.md](references/agents/agent-grading-rubric.md) for omissions, edge cases, no-PDD/CLI/no-eval handling, and examples.
-
 ### Step 5 — Produce the Review Report
 
 Write the report in chat; **and when the task asks you to save it to a path (e.g. `./_review_report.md`), also write it to that exact path** (≥500 bytes). The read-only rule forbids creating or editing files **inside the project under review** — it does NOT forbid writing the requested report file. Do not use internal labels such as “Path A”, “Path B”, “Step 3a”, or “Step 0c”; do not use “Mismatch”, “Aligned”, “disqualifying criteria”, or “verdict”. Use one-to-one, one-to-many, or unclear. Do not create a Unit of Work Analysis section.
@@ -257,26 +205,24 @@ Write the report in chat; **and when the task asks you to save it to a path (e.g
 Required sections, in order:
 
 1. `## Review Report: <name>`
-2. `### Summary` — render as a **bullet list, not a table**. Bullets: Overall Quality; **Agent Grade** (agents only — exact form `- **Agent Grade:** <A–F> — <verdict>`, letter only, no `+`/`-`, keep any commentary in a later clause); Business Value; Review Scope; Project Types Found; Validation Status; PDD Available; Transaction Shape per project.
+2. `### Summary` — render as a **bullet list, not a table**. Bullets: Overall Quality; Business Value; Review Scope; Project Types Found; Validation Status; PDD Available; Transaction Shape per project.
 3. `### PDD Alignment` — only when a PDD is available.
 4. `### Automated Validation Results` — counts table and Error/Warning details only.
 5. `### Rules Skipped` — intended but unapplied rules only.
 6. `### Critical Findings`, `### Warnings`, `### Improvement Opportunities` — one row per finding: `| <id> | <rule> | <file>: <issue>. <fix>. |`; use `—` when no `rule_id`; never duplicate or split findings by source.
-7. `### Per-Project Summary` — Grade for agents and `—` otherwise; Quality for all. Report size as structural counts, never lines: `.xaml` activity/nesting/variable/argument counts, `.cs` method/statement counts, `.flow` node/gateway/depth counts, `.py` function/statement/import counts, config entry/nesting counts.
+7. `### Per-Project Summary` — Quality per project. Report size as structural counts, never lines: `.xaml` activity/nesting/variable/argument counts, `.cs` method/statement counts, `.flow` node/gateway/depth counts, `.py` function/statement/import counts, config entry/nesting counts.
 8. `### Recommended Next Steps` — route fixes to the appropriate skill.
 9. `### Optimization Notes` — only when relevant.
-10. `**Final grade: <A–F>**` — agents only, on its own line as the **last line** of the report (nothing after it); the letter **must match** the Summary Agent Grade.
 
-Legacy validation status must say: `Use uipath-rpa (Legacy mode) for Legacy-specific validation`. Do not say “Could not run” or “Failed”. Legacy is supported indefinitely in Studio LTS and is not a Critical deployment blocker. Recommend migration based on actual needs. Overall Quality is **Good** for 0 Critical and 0–3 Warnings; **Needs Improvement** for 0 Critical and 4+ Warnings or 1 Critical with a clear fix; **Critical Issues** for 2+ Critical or 1 security/data-integrity Critical. For agents, A/B maps to Good, C/D to Needs Improvement, and F to Critical Issues. Never use “Mismatch” or “Aligned”.
+Agent projects add the Summary grade bullet, Grade column, and final-grade line from [agent-review-guide.md § Step 5](references/agents/agent-review-guide.md#step-5--report-additions).
 
-### Step 6 — Record the Agent Grade
-
-Low-code agents only: persist the final grade with `uip agent review-history add` per [agent-grading-rubric.md § Record the grade](references/agents/agent-grading-rubric.md#record-the-grade-step-6).
+Legacy validation status must say: `Use uipath-rpa (Legacy mode) for Legacy-specific validation`. Do not say “Could not run” or “Failed”. Legacy is supported indefinitely in Studio LTS and is not a Critical deployment blocker. Recommend migration based on actual needs. Overall Quality is **Good** for 0 Critical and 0–3 Warnings; **Needs Improvement** for 0 Critical and 4+ Warnings or 1 Critical with a clear fix; **Critical Issues** for 2+ Critical or 1 security/data-integrity Critical. Never use “Mismatch” or “Aligned”.
 
 ## Task Navigation
 
 | Need | Reference |
 |---|---|
+| Agent review workflow | [agent-review-guide.md](references/agents/agent-review-guide.md) |
 | Agent grade | [agent-grading-rubric.md](references/agents/agent-grading-rubric.md) |
 | Rule schema | [rule-format.md](references/rule-format.md) |
 | Review CLI/catalog workflow | [rule-catalog-workflow.md](references/rule-catalog-workflow.md) |
@@ -304,4 +250,4 @@ Low-code agents only: persist the final grade with `uip agent review-history add
 1. **Never flag Windows-Legacy (absent or `Legacy` `targetFramework`) as a Critical issue** — the Legacy targetFramework itself is never a Critical finding or deployment blocker; it is supported indefinitely in Studio LTS. Flag Warning only when relevant capabilities are missing; otherwise Info. Recommend migration based on actual needs, especially Healing Agent, Unified Target/Modern UIA, Object Repository, ScreenPlay, coded test cases, Autopilot, or Agents/Maestro. Route deep validation to `uipath-rpa` Legacy mode. **On a clean Legacy project, do not let Overall Quality read as "Critical Issues" on account of the Legacy runtime, an incomplete/stubbed integration, or a design gap — those are Warnings unless you have concrete evidence of a shipped security or data-integrity defect. If you do cite a genuine Critical, its recommendation must state plainly that it is unrelated to the Windows-Legacy targetFramework** (never place the Legacy label and a Critical rating together without that disclaimer).
 2. Do not recommend removing a dependency until usages have been searched and no consumers remain.
 3. Do not flag `-preview` package versions; address stability through activity-owner channels rather than the user-facing report.
-4. Do not run scripts or install Python packages. Deterministic checks belong in `uip agent review` or `uip codedagent review`; the skill ships no executable code.
+4. Do not run scripts or install Python packages. Deterministic checks belong in the review CLI; the skill ships no executable code.

--- a/skills/uipath-review/SKILL.md
+++ b/skills/uipath-review/SKILL.md
@@ -269,7 +269,7 @@ Required sections, in order:
 
 ### Step 6 — Record the Agent Grade
 
-Agent projects only, after the report. For each agent project, persist its per-agent final grade (Step 4.5) into the project's `review-history.json`:
+Low-code agent projects only (`uip agent` verbs do not apply to coded agents), after the report. For each low-code agent project, persist its per-agent final grade (Step 4.5) into the project's `review-history.json`:
 
 ```bash
 uip agent review-history add <GRADE> "<PROJECT_DIR>" --errors <CRITICAL_COUNT> --warnings <WARNING_COUNT> --output json

--- a/skills/uipath-review/references/agents/agent-grading-rubric.md
+++ b/skills/uipath-review/references/agents/agent-grading-rubric.md
@@ -82,6 +82,16 @@ Map the letter to the verdict word (this is the only place the letter→word map
 - **Single-agent review:** the overall Agent Grade IS the agent's grade.
 - **Solution with multiple agents:** the overall Agent Grade = the **worst** per-agent grade. A solution is only as deployable as its weakest agent — do not average grades. Non-agent projects do not contribute a grade (phase 1).
 
+## Record the grade (Step 6)
+
+Low-code agent projects only (`uip agent` verbs do not apply to coded agents), after the report. For each low-code agent project, persist its per-agent final grade into the project's `review-history.json`:
+
+```bash
+uip agent review-history add <GRADE> "<PROJECT_DIR>" --errors <CRITICAL_COUNT> --warnings <WARNING_COUNT> --output json
+```
+
+The CLI owns `review-history.json`: never create, edit, or review the file; exclude it from the authored-file set. If the command fails, state that the grade was not recorded and stop — recording never changes the review outcome.
+
 ## Low-code agent reports — omit these sections
 
 Low-code agent review (`agent.json`): omit entirely — no placeholder, no "not applicable" note.

--- a/skills/uipath-review/references/agents/agent-grading-rubric.md
+++ b/skills/uipath-review/references/agents/agent-grading-rubric.md
@@ -82,16 +82,6 @@ Map the letter to the verdict word (this is the only place the letter→word map
 - **Single-agent review:** the overall Agent Grade IS the agent's grade.
 - **Solution with multiple agents:** the overall Agent Grade = the **worst** per-agent grade. A solution is only as deployable as its weakest agent — do not average grades. Non-agent projects do not contribute a grade (phase 1).
 
-## Record the grade (Step 6)
-
-Low-code agent projects only (`uip agent` verbs do not apply to coded agents), after the report. For each low-code agent project, persist its per-agent final grade into the project's `review-history.json`:
-
-```bash
-uip agent review-history add <GRADE> "<PROJECT_DIR>" --errors <CRITICAL_COUNT> --warnings <WARNING_COUNT> --output json
-```
-
-The CLI owns `review-history.json`: never create, edit, or review the file; exclude it from the authored-file set. If the command fails, state that the grade was not recorded and stop — recording never changes the review outcome.
-
 ## Low-code agent reports — omit these sections
 
 Low-code agent review (`agent.json`): omit entirely — no placeholder, no "not applicable" note.

--- a/skills/uipath-review/references/agents/agent-review-guide.md
+++ b/skills/uipath-review/references/agents/agent-review-guide.md
@@ -1,0 +1,96 @@
+# Agent Review Workflow
+
+Steps for reviewing an agent project: low-code (`agent.json`) or coded (`main.py` plus framework config or `uipath.json`). Enter from SKILL.md once Step 1 classifies the project. Step 0 (discovery, PDD, scope), Step 1, Steps 3b–3c, Step 4, and the Step 5 report skeleton are shared and stay in SKILL.md; step numbers here match SKILL.md. In a mixed solution, apply this guide to each agent project and keep one report.
+
+> **Important:** a user's read-only or "do not modify the project" instruction covers manual edits only. It never covers `uip agent refresh` (Step 2) or `uip agent review-history add` (Step 6): the CLI owns the files they write. Run both even when the user asked for a read-only review; never move the project to a copy to avoid them.
+
+## Critical Rules
+
+1. Every agent requires `uip agent review` or `uip codedagent review` first, followed by the applicable judgment catalog, including when review began before this skill loaded; merge prior findings only after both passes.
+2. Review-CLI findings are authoritative. Preserve `RuleId`, `Severity`, `Description`, `File`, and `SuggestedFix` verbatim. Format `Recommendation` as `<File>: <Description>. <SuggestedFix>`. Judgment findings use the same format. Map `error` to Critical, `warning` to Warning, and `info` to Info; `judgment` defaults to Warning and may change only with reasoning in the finding description.
+3. Never invent `rule_id` values. Each cited ID must occur verbatim in a loaded `agents-*-rules.md` catalog or review-CLI JSON. Verify every ID before reporting. A real Critical issue covered by neither source is reported without a `rule_id`; unrule'd Warnings and Infos are dropped.
+4. Grade agent projects only with `A`, `B`, `C`, `D`, or `F`, with no `+`/`-`, per agent and overall: `min(G_det, G_jud)`. Read `G_det` from review CLI `Data.Grade`; do not recompute it. Compute `G_jud` from judgment findings only. Show the binding constraint for every grade; low-code reports omit the printed derivation as required by the rubric. A security or data-integrity judgment Critical forces F. The skill grade cannot exceed `Data.Grade`; report both. Do not grade RPA, flows, or coded apps. See [agent-grading-rubric.md](agent-grading-rubric.md).
+5. `uip agent refresh` owns `.agent-builder/`, `.local/build/`, and, for low-code agents, regenerated root `entry-points.json` from `agent.json`. Do not open these contents. Exclude them from classification, authored-file selection, structural metrics, and manual checks. Report a defect only if refresh fails to fix them. Read low-code schemas from `agent.json` `.inputSchema` and `.outputSchema`.
+6. The only writes are `uip agent refresh` (Step 2) and `uip agent review-history add` (Step 6); both write CLI-owned files. Everything else stays read-only per SKILL.md Critical Rule 1.
+
+## Step 2 — Validate
+
+| Type | Command |
+|---|---|
+| Low-Code | `uip agent refresh "<PROJECT_DIR>" --output json`; then `uip agent validate "<PROJECT_DIR>" --output json` |
+| Coded | No validate verb; the Step 2.5 `uip codedagent review` pass is the first CLI check |
+
+Record counts in the Automated Validation Results table (SKILL.md Step 2d).
+
+## Step 2.5 — Run the Review CLI, Then Apply the Judgment Catalog
+
+Apply to every encountered agent, including late-invoked reviews.
+
+### 2.5a. Deterministic CLI pass
+
+Run once and capture JSON:
+
+| Type | Command |
+|---|---|
+| Low-Code | `uip agent review "<PROJECT_DIR>" --output json` |
+| Coded | `uip codedagent review "<PROJECT_DIR>" --output json` |
+
+Parse `Data.Issues[]` objects `{RuleId, Category, Severity, Description, File, SuggestedFix}` and carry them verbatim. Guardrail configuration validity is CLI-only: run the review CLI or `--checks guardrails` when appropriate, including every emitted `GUARDRAIL_*` finding verbatim; do not eyeball or re-flag CLI guardrail findings.
+
+### 2.5b. Judgment pass
+
+Load each applicable catalog fully and apply every rule's `detection_method` to its named source material, including prompts, tools, eval datapoints, and schemas. Track intended rules that cannot be applied.
+
+| Signal | Catalog |
+|---|---|
+| `agent.json.type == lowCode` | `agents-lowcode-rules.md` |
+| Python coded-agent or `agent.json.type == coded` | `agents-coded-rules.md` |
+| `pyproject.toml` + `main.py` + `uipath.json[functions]` without framework config | coded catalog |
+| `package.json` + `uipath.json[functions]` (no `pyproject.toml`) — Coded Function (JS/TS) | phase 2; no agent catalog |
+| RPA, Flow, Coded App | phase 2; no agent catalog |
+
+For guardrails, running the guardrail workflow is **mandatory** whenever `guardrails[]` is non-empty or the use case calls for guardrails — do not eyeball `agent.json`:
+
+- Low-code: **open [guardrails-review.md](guardrails/guardrails-review.md) and follow its Step 0 — you MUST run `uip agent guardrails catalog --output json` (30-min cache) and the never-cached tenant `uip agent guardrails list`** before auditing, then apply Audit Mode and Recommend Mode. Emit `LC_GUARDRAIL_ACTION_INEFFECTIVE`, `LC_GUARDRAIL_MISAPPLIED`, and `LC_GUARDRAIL_RECOMMENDED` as applicable.
+- Coded: **open [coded-guardrails-review.md](guardrails/coded-guardrails-review.md) and follow it** when middleware/decorators are wired or the use case calls for guardrails. Public Python SDK docs may be fetched only when a finding must name classes not visible in source. Emit `CODED_GUARDRAIL_ACTION_INEFFECTIVE`, `CODED_GUARDRAIL_MISAPPLIED`, and `CODED_GUARDRAIL_RECOMMENDED`; do not duplicate CLI IDs `CODED_GUARDRAIL_WRONG_IMPORT`, `CODED_GUARDRAIL_TOOL_SCOPE_NO_TOOLS`, or `CODED_GUARDRAIL_INVALID_CONTRACT`.
+- If the guardrail catalog is unavailable, put Audit-Mode rules in Rules Skipped and retain source-only Recommend Mode detection.
+
+Before merging, verify every `rule_id` against a loaded catalog or CLI JSON. Remove absent IDs and retain only a Critical observation; drop unrule'd Warnings and Infos. Merge one row per finding into the Step 5 severity tables using `C-D-`, `W-D-`, or `I-D-` prefixes as described in [rule-format.md](../rule-format.md).
+
+## Step 3 — Manual Quality Review
+
+Unit of Work (SKILL.md Step 3a): the declared unit is `agent.json.inputSchema` for low-code and the `Input` Pydantic `BaseModel` in `main.py` for coded; derive the execution unit from `for`/`while` loops and external I/O. PDD alignment and the technical review follow SKILL.md Steps 3b–3c, with the judgment catalog as the checklist and only authored files in scope.
+
+## Step 4 — Evaluate Optimization
+
+As SKILL.md Step 4. Architecture-principle scores inform this step and never feed the grade.
+
+## Step 4.5 — Compute Agent Grade
+
+Agents only:
+
+```text
+Final grade = min(G_det, G_jud)
+```
+
+`G_det` is the letter in CLI `Data.Grade`; never recompute it from issue counts. For judgment findings only, calculate `100 − (15 × Criticals) − (4 × Warnings) − (1 × Infos)`, floored at 0; map `85–100 A`, `65–84 B`, `45–64 C`, `25–44 D`, `0–24 F`. Any unmitigated judgment Critical caps at D; a security/data-integrity judgment Critical forces F. Architecture-principle scores do not affect the grade. For multiple agents use the worst grade, never an average. Show the binding constraint, for example `B — gated by G_det = CLI Data.Grade B; judgment clean (G_jud A)`. Use [agent-grading-rubric.md](agent-grading-rubric.md) for omissions, edge cases, no-PDD/CLI/no-eval handling, and examples.
+
+## Step 5 — Report Additions
+
+Produce the report per SKILL.md Step 5 and add:
+
+1. `### Summary` bullet after Overall Quality, exact form `- **Agent Grade:** <A–F> — <verdict>` — letter only, no `+`/`-`; keep any commentary in a later clause. A/B maps Overall Quality to Good, C/D to Needs Improvement, F to Critical Issues.
+2. `### Per-Project Summary` Grade column: the per-agent grade; `—` for non-agent projects.
+3. `**Final grade: <A–F>**` on its own line as the **last line** of the report (nothing after it); the letter **must match** the Summary Agent Grade.
+
+Low-code reports omit the sections listed in [agent-grading-rubric.md § Low-code agent reports](agent-grading-rubric.md#low-code-agent-reports--omit-these-sections).
+
+## Step 6 — Record the Agent Grade
+
+Low-code agent projects only, after the report. For each low-code agent project, persist its per-agent final grade (Step 4.5) into the project's `review-history.json`:
+
+```bash
+uip agent review-history add <GRADE> "<PROJECT_DIR>" --errors <CRITICAL_COUNT> --warnings <WARNING_COUNT> --output json
+```
+
+The CLI owns `review-history.json`: never create, edit, or review the file; exclude it from the authored-file set. If the command fails, state that the grade was not recorded and stop — recording never changes the review outcome.

--- a/skills/uipath-review/references/agents/agents-coded-rules.md
+++ b/skills/uipath-review/references/agents/agents-coded-rules.md
@@ -2,7 +2,7 @@
 
 Judgment rules for **coded** agents (Python — `main.py` + framework config). Each rule requires the agent to read source and reason — what a regex/AST-emulation/file-walk cannot decide reliably. Same row schema as elsewhere — see [`../rule-format.md`](../rule-format.md).
 
-> **This catalog is judgment-only.** Run `uip codedagent review "<PROJECT_DIR>" --output json` **first** (SKILL.md Step 2.5) — it returns the deterministic coded findings (pyproject/dependency/python-version gates, import & secret regex, framework symbol existence, bare-except, eval-run analysis, `.venv` packaging, git-tracked secrets) in the same rule format. Then apply the rules below, which the CLI cannot do.
+> **This catalog is judgment-only.** Run `uip codedagent review "<PROJECT_DIR>" --output json` **first** (agent-review-guide.md Step 2.5) — it returns the deterministic coded findings (pyproject/dependency/python-version gates, import & secret regex, framework symbol existence, bare-except, eval-run analysis, `.venv` packaging, git-tracked secrets) in the same rule format. Then apply the rules below, which the CLI cannot do.
 
 Read [`../rule-format.md`](../rule-format.md) and [`../rule-catalog-workflow.md`](../rule-catalog-workflow.md) first.
 

--- a/skills/uipath-review/references/agents/agents-lowcode-rules.md
+++ b/skills/uipath-review/references/agents/agents-lowcode-rules.md
@@ -2,7 +2,7 @@
 
 Judgment rules for **low-code** agents (`agent.json`). Each rule requires reading source and reasoning; regex/count/schema-walk checks are insufficient. Use the row schema in [`../rule-format.md`](../rule-format.md).
 
-> **Judgment-only catalog.** Run `uip agent review "<PROJECT_DIR>" --output json` **first** (SKILL.md Step 2.5). It returns deterministic low-code findings—structural gates, schema-property presence, placeholder cross-refs, eval-set structure and schema cross-refs, and guardrail configuration validity—in the same rule format. Then apply these rules.
+> **Judgment-only catalog.** Run `uip agent review "<PROJECT_DIR>" --output json` **first** (agent-review-guide.md Step 2.5). It returns deterministic low-code findings—structural gates, schema-property presence, placeholder cross-refs, eval-set structure and schema cross-refs, and guardrail configuration validity—in the same rule format. Then apply these rules.
 
 Read [`../rule-format.md`](../rule-format.md) and [`../rule-catalog-workflow.md`](../rule-catalog-workflow.md) first.
 

--- a/skills/uipath-review/references/agents/guardrails/coded-guardrails-review.md
+++ b/skills/uipath-review/references/agents/guardrails/coded-guardrails-review.md
@@ -2,7 +2,7 @@
 
 The read-only **review** counterpart of the `uipath-agents` coded guardrail recommend/validate capability. It
 powers the coded guardrail judgment rules in [`../agents-coded-rules.md`](../agents-coded-rules.md)
-§GuardrailsChecker. Run it during a **coded** agent review (SKILL.md Step 2.5b) **after** `uip codedagent review` <!-- uip-check-skip -->
+§GuardrailsChecker. Run it during a **coded** agent review (agent-review-guide.md Step 2.5b) **after** `uip codedagent review` <!-- uip-check-skip -->
 (Step 2.5a). Two modes:
 
 - **Audit Mode** — the agent already wires guardrails → are they *effective, appropriate, and actually wired*?
@@ -306,7 +306,7 @@ recommended action with the protection-vs-audit signal. Examples:
 
 ## Report
 
-Merge findings into the Step 5 Critical / Warning / Info findings tables (SKILL.md Step 2.5b), one row per finding:
+Merge findings into the Step 5 Critical / Warning / Info findings tables (agent-review-guide.md Step 2.5b), one row per finding:
 
 ```
 | <id> | `<rule_id>` | `<file>`: <message>. <suggested_fix>. |

--- a/skills/uipath-review/references/agents/guardrails/guardrails-review.md
+++ b/skills/uipath-review/references/agents/guardrails/guardrails-review.md
@@ -1,6 +1,6 @@
 # Guardrail Review — LLM-as-judge (audit + recommend)
 
-The read-only **review** counterpart of the `uipath-agents` guardrail recommend/validate capability. It powers [`../agents-lowcode-rules.md`](../agents-lowcode-rules.md) §GuardrailsChecker and runs during low-code agent review (SKILL.md Step 2.5b), **after** `uip agent review` (Step 2.5a).
+The read-only **review** counterpart of the `uipath-agents` guardrail recommend/validate capability. It powers [`../agents-lowcode-rules.md`](../agents-lowcode-rules.md) §GuardrailsChecker and runs during low-code agent review (agent-review-guide.md Step 2.5b), **after** `uip agent review` (Step 2.5a).
 
 Modes:
 - **Audit Mode:** existing guardrails → effective and appropriate? Emit **defects**.
@@ -77,7 +77,7 @@ Build `{ validatorId: status }` from the `Data` array, using only `Status == "Av
 
 If output contains `"Code": "GuardrailCatalogUnavailable"` or the CLI is unavailable, do not guess:
 
-- **Audit Mode:** put catalog-dependent `LC_GUARDRAIL_ACTION_INEFFECTIVE` and `LC_GUARDRAIL_MISAPPLIED` under the report's **Rules Skipped** subsection with reason `"guardrails catalog unavailable"` (SKILL.md Critical Rule 10 — Rules Skipped). Emit no catalog-grounded effectiveness/relevance verdict.
+- **Audit Mode:** put catalog-dependent `LC_GUARDRAIL_ACTION_INEFFECTIVE` and `LC_GUARDRAIL_MISAPPLIED` under the report's **Rules Skipped** subsection with reason `"guardrails catalog unavailable"` (SKILL.md Critical Rule 9 — Rules Skipped). Emit no catalog-grounded effectiveness/relevance verdict.
 - **Recommend Mode:** continue `agent.json`-only schema/prompt/tool inference; use generic scope/action wording and note `catalog-limited`.
 
 ## Audit Mode — existing guardrails (defects)
@@ -133,7 +133,7 @@ Do not name platform-documented validators (`harmful_content`, `intellectual_pro
 
 ## Report
 
-Merge findings into the Step 5 Critical / Warning / Info findings tables (SKILL.md Step 2.5b), one row per finding:
+Merge findings into the Step 5 Critical / Warning / Info findings tables (agent-review-guide.md Step 2.5b), one row per finding:
 
 ```text
 | <id> | `<rule_id>` | `<file>`: <message>. <suggested_fix>. |

--- a/skills/uipath-review/references/review-workflow-guide.md
+++ b/skills/uipath-review/references/review-workflow-guide.md
@@ -313,7 +313,7 @@ The review report follows a fixed markdown structure. Produce it in chat; **and 
 
 ### Summary
 - **Overall Quality:** Good / Needs Improvement / Critical Issues
-- **Agent Grade:** <A–F> — <verdict label> (<binding constraint>) — *agent projects only; see SKILL.md Step 4.5 + [agent-grading-rubric.md](agents/agent-grading-rubric.md). Omit if no agent projects.*
+- **Agent Grade:** <A–F> — <verdict label> (<binding constraint>) — *agent projects only; see [agent-review-guide.md](agents/agent-review-guide.md) Step 4.5 + [agent-grading-rubric.md](agents/agent-grading-rubric.md). Omit if no agent projects.*
 - **Business Value:** <1-2 sentence description of what this solution does>
 - **Project Types Found:** <list with counts>
 - **Validation Status:** <pass/fail per project>
@@ -368,14 +368,14 @@ The review report follows a fixed markdown structure. Produce it in chat; **and 
 **Final grade: <A–F>**
 ```
 
-> **`Final grade:` is the report's last line — nothing follows it.** No notes, caveats, or commentary, inside the report or after it. It restates the Summary's `Agent Grade` letter (the two must match) so the grade stays visible at the tail. Letter only — no label, no derivation. Agent projects only; omit when the review has no agent projects. See SKILL.md Step 4.5 + [agent-grading-rubric.md](agents/agent-grading-rubric.md).
+> **`Final grade:` is the report's last line — nothing follows it.** No notes, caveats, or commentary, inside the report or after it. It restates the Summary's `Agent Grade` letter (the two must match) so the grade stays visible at the tail. Letter only — no label, no derivation. Agent projects only; omit when the review has no agent projects. See [agent-review-guide.md](agents/agent-review-guide.md) Step 4.5 + [agent-grading-rubric.md](agents/agent-grading-rubric.md).
 
 **Overall Quality determination** (all project types):
 - **Good** — 0 Critical findings, 0-3 Warnings
 - **Needs Improvement** — 0 Critical findings, 4+ Warnings OR 1 Critical with clear fix
 - **Critical Issues** — 2+ Critical findings OR 1 Critical with security implications
 
-**Agent Grade** (agent projects only): the A–F letter is `min(G_det, G_jud)` computed in SKILL.md Step 4.5 — full rubric, bands, edge cases, and worked examples in [agent-grading-rubric.md](agents/agent-grading-rubric.md). It maps to the same verdict labels (A/B = Good, C/D = Needs Improvement, F = Critical Issues). Non-agent projects carry the Quality verdict only (grading for RPA / flows / coded apps is a future phase).
+**Agent Grade** (agent projects only): the A–F letter is `min(G_det, G_jud)` computed in [agent-review-guide.md](agents/agent-review-guide.md) Step 4.5 — full rubric, bands, edge cases, and worked examples in [agent-grading-rubric.md](agents/agent-grading-rubric.md). It maps to the same verdict labels (A/B = Good, C/D = Needs Improvement, F = Critical Issues). Non-agent projects carry the Quality verdict only (grading for RPA / flows / coded apps is a future phase).
 
 ## Optimization Evaluation Framework
 

--- a/skills/uipath-review/references/rule-catalog-workflow.md
+++ b/skills/uipath-review/references/rule-catalog-workflow.md
@@ -1,4 +1,4 @@
-# Rule Catalog — Workflow (SKILL.md Step 2.5)
+# Rule Catalog — Workflow (agent-review-guide.md Step 2.5)
 
 Step 2.5 runs after Step 2 (`uip agent refresh` then `uip agent validate` for low-code agents, plus related CLI validation) and before Step 3 (manual checklist review). It adds rule-ID findings from the review CLI, then the judgment catalog.
 
@@ -6,7 +6,7 @@ Step 2.5 runs after Step 2 (`uip agent refresh` then `uip agent validate` for lo
 
 ### 2.5a — Run the review CLI first
 
-Run the applicable review command once, even if another review pass already produced findings (SKILL.md Critical Rule 8 — run the review CLI first), and capture JSON:
+Run the applicable review command once, even if another review pass already produced findings (agent-review-guide.md Critical Rule 1 — run the review CLI first), and capture JSON:
 
 | Agent type | Command |
 |---|---|
@@ -24,7 +24,7 @@ If the CLI is unavailable (not installed or lacking `agent review` / `codedagent
 1. Use the detection table to identify applicable catalog files.
 2. Read every applicable catalog file in full.
 3. Apply each rule's `detection_method` in its judgment form: read the named source, reason about it, and emit a finding when criteria hold. Log the reasoning in the finding's `description`.
-4. Track every intended rule that cannot be applied (`status: deferred`, review CLI unavailable, guardrail catalog unavailable, or required source unreadable) in the report's "Rules Skipped" subsection with `rule_id` and reason. Never silently skip. An empty subject set is not a skip (SKILL.md Critical Rule 10 — Rules Skipped).
+4. Track every intended rule that cannot be applied (`status: deferred`, review CLI unavailable, guardrail catalog unavailable, or required source unreadable) in the report's "Rules Skipped" subsection with `rule_id` and reason. Never silently skip. An empty subject set is not a skip (SKILL.md Critical Rule 9 — Rules Skipped).
 5. Merge findings into the Step 5 report's Critical / Warning / Info tables, one row per finding:
 
    ```
@@ -63,7 +63,7 @@ Sort findings by `(severity, category, rule_id, file, line)`, never discovery or
 
 ## Anti-patterns
 
-1. Do not invent rule IDs. If a real critical issue is covered by neither the CLI nor catalog, report it under Critical Findings as a normal finding, not with a `rule_id`; only critical issues qualify (SKILL.md Critical Rule 11 — never invent `rule_id`).
+1. Do not invent rule IDs. If a real critical issue is covered by neither the CLI nor catalog, report it under Critical Findings as a normal finding, not with a `rule_id`; only critical issues qualify (agent-review-guide.md Critical Rule 3 — never invent `rule_id`).
 2. Do not re-rank severities. CLI `Severity` and catalog `severity` are authoritative for `error` / `warning` / `info`. For `judgment` rows, log the reasoning used to select the report band.
 3. Do not silently skip rules. Record every skip in "Rules Skipped" with its reason.
 4. Do not run the catalog before the CLI. Run `uip agent review` / `uip codedagent review` first (2.5a). For low-code agents, run `uip agent refresh` then `uip agent validate` during Step 2; the catalog handles only reasoning the CLI cannot perform.

--- a/skills/uipath-review/references/rule-format.md
+++ b/skills/uipath-review/references/rule-format.md
@@ -2,7 +2,7 @@
 
 Schema for every row in `agents-*-rules.md` judgment catalogs. The catalog is the contract: reason about each rule and emit findings with its `rule_id`, `severity`, and `suggested_fix`.
 
-The catalog is **judgment-only**. Read source and reason about prompt quality, tool-selection ambiguity, framework fit, and semantic schema/eval mismatches. Put deterministic checks (file presence, schema walks, counts, regex, and run-artifact analysis) in the `uip agent review` / `uip codedagent review` CLI (SKILL.md Step 2.5a), which emits `RuleId`, `Severity`, `Category`, `Description`, `File`, and `SuggestedFix`.
+The catalog is **judgment-only**. Read source and reason about prompt quality, tool-selection ambiguity, framework fit, and semantic schema/eval mismatches. Put deterministic checks (file presence, schema walks, counts, regex, and run-artifact analysis) in the `uip agent review` / `uip codedagent review` CLI (agent-review-guide.md Step 2.5a), which emits `RuleId`, `Severity`, `Category`, `Description`, `File`, and `SuggestedFix`.
 
 ## Row schema
 

--- a/tests/tasks/uipath-review/_shared/check_review_cli_provenance.py
+++ b/tests/tasks/uipath-review/_shared/check_review_cli_provenance.py
@@ -44,7 +44,7 @@ from pathlib import Path
 from report_evidence import cli_identity, declares_unavailable
 
 # Names the report may use for the review CLI, for the shared
-# `declares_unavailable` contract check (SKILL.md Critical Rule 11).
+# `declares_unavailable` contract check (agent-review-guide.md Critical Rule 3).
 REVIEW_CLI_SUBJECT = r"review\s+CLI|uip\s+agent\s+review|uip\s+codedagent\s+review"
 
 # Anchors that attribute a nearby grade letter to the CLI rather than to the

--- a/tests/tasks/uipath-review/_shared/check_review_history.py
+++ b/tests/tasks/uipath-review/_shared/check_review_history.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Verify Step 6 recorded the final grade in CLI-owned review-history.json.
 
-The review skill's Step 6 (SKILL.md; detailed in
-`references/agents/agent-grading-rubric.md`) has the reviewer run, per low-code
-agent project after the report:
+The review skill's agent-review-guide.md Step 6 has the reviewer run, per
+low-code agent project after the report:
 
     uip agent review-history add <GRADE> "<PROJECT_DIR>" --errors <N> --warnings <N> --output json
 

--- a/tests/tasks/uipath-review/_shared/check_review_history.py
+++ b/tests/tasks/uipath-review/_shared/check_review_history.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Verify Step 6 recorded the final grade in CLI-owned review-history.json.
+
+SKILL.md Step 6 has the reviewer run, per low-code agent project after the
+report:
+
+    uip agent review-history add <GRADE> "<PROJECT_DIR>" --errors <N> --warnings <N> --output json
+
+which appends `{grade, runAt, errors, warnings}` to
+`<PROJECT_DIR>/review-history.json`. This checker grades the OUTCOME (the file
+the CLI wrote) rather than command telemetry, for the reasons documented in
+`check_review_cli_provenance.py`: batched shell scripts make `command_executed`
+criteria blind to both the call and its exit code.
+
+The recorded grade must equal the report's `**Final grade: <A-F>**` footer --
+Step 6 persists the Step 4.5 final grade, not some other letter.
+
+Step 6's own failure contract ("state that the grade was not recorded and
+stop") is spoken to the user after the report is saved, so it leaves no
+artifact this checker can read. When review-history.json is missing, ground
+truth comes from probing the CLI itself: a `uip` that does not know the
+`agent review-history` verb makes recording impossible (WARN + PASS -- same
+environment caveat as the provenance checker: agent and checker can resolve
+different `uip` binaries), while a `uip` that does know it means Step 6 was
+skipped (FAIL).
+
+Exit 0 on PASS; sys.exit(str) on failure.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from report_evidence import cli_identity
+
+FINAL_GRADE = re.compile(r"(?m)^\*\*Final grade: ([ABCDF])\*\*\Z")
+GRADES = frozenset("ABCDF")
+
+
+def _verb_available(uip: str) -> tuple[bool, str]:
+    """Probe whether this `uip` knows `agent review-history`."""
+    try:
+        proc = subprocess.run(
+            [uip, "agent", "review-history", "--help"],
+            capture_output=True, text=True, timeout=60,
+        )
+    except FileNotFoundError:
+        return False, f"{uip} not on PATH"
+    except subprocess.SubprocessError as error:
+        return False, f"probe failed: {error}"
+    if proc.returncode != 0:
+        tail = (proc.stderr or proc.stdout or "").strip()[-200:]
+        return False, f"exit {proc.returncode}: {tail}"
+    return True, ""
+
+
+def _int_field(entry: dict, key: str) -> int:
+    value = entry.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        sys.exit(f"FAIL: review-history entry `{key}` must be a non-negative integer, got {value!r}")
+    return value
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--project", default="ReviewSol/SampleAgent")
+    ap.add_argument("--report", default="_review_report.md")
+    args = ap.parse_args()
+
+    report_path = Path(os.getcwd()) / args.report
+    if not report_path.is_file():
+        sys.exit(f"FAIL: {report_path} not found")
+    report = report_path.read_text(encoding="utf-8", errors="replace")
+    footer = FINAL_GRADE.search(report.rstrip())
+    if not footer:
+        sys.exit(
+            "FAIL: report does not end with '**Final grade: <A-F>**' -- without it there "
+            "is no ground truth for the grade Step 6 must record."
+        )
+    final_grade = footer.group(1)
+
+    history_path = Path(os.getcwd()) / args.project / "review-history.json"
+    if not history_path.is_file():
+        uip = os.environ.get("UIP", "uip")
+        print(f"Checker resolved `{uip}` -> {cli_identity(uip)}")
+        available, why = _verb_available(uip)
+        if available:
+            sys.exit(
+                f"FAIL: {history_path} does not exist, but `{uip} agent review-history` is "
+                "available -- Step 6 (record the agent grade) was skipped."
+            )
+        print(
+            f"WARN: {history_path} does not exist and `{uip} agent review-history` is "
+            f"unavailable ({why}) -- recording was impossible in this environment, so Step 6 "
+            "cannot be graded. If the agent resolved a different `uip`, compare `which -a uip`."
+        )
+        print("PASS")
+        return
+
+    try:
+        history = json.loads(history_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        sys.exit(f"FAIL: {history_path} is not valid JSON: {error}")
+    if not isinstance(history, list) or not history:
+        sys.exit(f"FAIL: {history_path} must be a non-empty JSON array of review entries")
+    entry = history[-1]
+    if not isinstance(entry, dict):
+        sys.exit(f"FAIL: last review-history entry must be a JSON object, got {entry!r}")
+
+    grade = entry.get("grade")
+    if grade not in GRADES:
+        sys.exit(f"FAIL: last review-history entry has invalid grade {grade!r}")
+    if grade != final_grade:
+        sys.exit(
+            f"FAIL: recorded grade {grade} does not match the report's final grade "
+            f"{final_grade} -- Step 6 must persist the Step 4.5 final grade."
+        )
+    errors = _int_field(entry, "errors")
+    warnings = _int_field(entry, "warnings")
+    run_at = entry.get("runAt")
+    if not isinstance(run_at, str) or not run_at.strip():
+        sys.exit(f"FAIL: last review-history entry has no `runAt` timestamp, got {run_at!r}")
+
+    print(
+        f"OK: {history_path} records grade {grade} (errors={errors}, warnings={warnings}, "
+        f"runAt={run_at}), matching the report's final grade."
+    )
+    print("PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-review/_shared/check_review_history.py
+++ b/tests/tasks/uipath-review/_shared/check_review_history.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Verify Step 6 recorded the final grade in CLI-owned review-history.json.
 
-SKILL.md Step 6 has the reviewer run, per low-code agent project after the
-report:
+The review skill's Step 6 (SKILL.md; detailed in
+`references/agents/agent-grading-rubric.md`) has the reviewer run, per low-code
+agent project after the report:
 
     uip agent review-history add <GRADE> "<PROJECT_DIR>" --errors <N> --warnings <N> --output json
 

--- a/tests/tasks/uipath-review/_shared/report_evidence.py
+++ b/tests/tasks/uipath-review/_shared/report_evidence.py
@@ -11,7 +11,7 @@ import re
 import shutil
 import subprocess
 
-# SKILL.md Critical Rule 11 / rule-catalog-workflow.md 2.5a: when a required
+# agent-review-guide.md Critical Rule 3 / rule-catalog-workflow.md 2.5a: when a required
 # input genuinely cannot be obtained, the report must say so HERE and not just
 # anywhere in prose ("the CLI was unavailable, so I guessed" must not count).
 SKIPPED_HEADING = re.compile(r"^#+\s*Rules Skipped\s*$", re.MULTILINE)

--- a/tests/tasks/uipath-review/_shared/test_check_review_history.py
+++ b/tests/tasks/uipath-review/_shared/test_check_review_history.py
@@ -1,0 +1,165 @@
+"""Unit tests for check_review_history.py.
+
+The checker's verdict tracks two artifacts -- the CLI-owned review-history.json
+and the report's final-grade footer -- never the shape of the agent's shell
+calls. The CLI probe (used only when the history file is missing) is driven
+through a stubbed `uip` via the `UIP` env var, exactly like the provenance
+checker's tests.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CHECKER = HERE / "check_review_history.py"
+
+PROJECT = "ReviewSol/SampleAgent"
+
+REPORT = textwrap.dedent(
+    """\
+    # Review Report — ReviewSol / SampleAgent
+
+    ## Summary
+
+    - **Agent Grade:** C
+
+    ## Warning Findings
+
+    | ID | Rule | Finding |
+    |---|---|---|
+    | W-J-001 | `LC_TOOL_OVERLAP` | Interchangeable tools. Merge them. |
+
+    **Final grade: C**
+    """
+)
+
+ENTRY = {"grade": "C", "runAt": "2026-09-03T14:02:35.127Z", "errors": 1, "warnings": 2}
+
+
+def _fake_uip(tmp_path: Path, *, exit_code: int) -> Path:
+    launcher = tmp_path / "fake_uip"
+    launcher.write_text(f"#!/bin/sh\nexit {exit_code}\n", encoding="utf-8")
+    launcher.chmod(0o755)
+    return launcher
+
+
+def _write_history(tmp_path: Path, payload: object) -> None:
+    project = tmp_path / PROJECT
+    project.mkdir(parents=True, exist_ok=True)
+    body = payload if isinstance(payload, str) else json.dumps(payload)
+    (project / "review-history.json").write_text(body, encoding="utf-8")
+
+
+def run(tmp_path: Path, report: str | None = REPORT, uip: Path | None = None) -> subprocess.CompletedProcess:
+    if report is not None:
+        (tmp_path / "_review_report.md").write_text(report, encoding="utf-8")
+    env = {**os.environ, "UIP": str(uip) if uip else "uip-that-does-not-exist"}
+    return subprocess.run(
+        [sys.executable, str(CHECKER)],
+        cwd=tmp_path, env=env, capture_output=True, text=True,
+    )
+
+
+# --- the grade was recorded --------------------------------------------------
+
+def test_passes_when_recorded_grade_matches_final_grade(tmp_path):
+    _write_history(tmp_path, [ENTRY])
+    r = run(tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "records grade C" in r.stdout
+
+
+def test_last_entry_wins_when_history_has_multiple_entries(tmp_path):
+    older = {**ENTRY, "grade": "F", "runAt": "2026-09-01T00:00:00.000Z"}
+    _write_history(tmp_path, [older, ENTRY])
+    r = run(tmp_path)
+    assert r.returncode == 0, r.stderr
+
+
+def test_fails_when_recorded_grade_differs_from_final_grade(tmp_path):
+    _write_history(tmp_path, [{**ENTRY, "grade": "A"}])
+    r = run(tmp_path)
+    assert r.returncode != 0
+    assert "does not match the report's final grade" in r.stderr
+
+
+# --- entry shape --------------------------------------------------------------
+
+def test_fails_on_invalid_json(tmp_path):
+    _write_history(tmp_path, "not json")
+    r = run(tmp_path)
+    assert r.returncode != 0
+    assert "not valid JSON" in r.stderr
+
+
+def test_fails_on_empty_history(tmp_path):
+    _write_history(tmp_path, [])
+    r = run(tmp_path)
+    assert r.returncode != 0
+    assert "non-empty JSON array" in r.stderr
+
+
+def test_fails_on_invalid_grade_letter(tmp_path):
+    _write_history(tmp_path, [{**ENTRY, "grade": "C+"}])
+    r = run(tmp_path)
+    assert r.returncode != 0
+    assert "invalid grade" in r.stderr
+
+
+def test_fails_when_counts_are_not_non_negative_integers(tmp_path):
+    _write_history(tmp_path, [{**ENTRY, "errors": "1"}])
+    r = run(tmp_path)
+    assert r.returncode != 0
+    assert "non-negative integer" in r.stderr
+
+
+def test_fails_when_run_at_is_missing(tmp_path):
+    entry = {k: v for k, v in ENTRY.items() if k != "runAt"}
+    _write_history(tmp_path, [entry])
+    r = run(tmp_path)
+    assert r.returncode != 0
+    assert "runAt" in r.stderr
+
+
+# --- the grade was not recorded ------------------------------------------------
+
+def test_fails_when_history_missing_and_cli_supports_the_verb(tmp_path):
+    uip = _fake_uip(tmp_path, exit_code=0)
+    r = run(tmp_path, uip=uip)
+    assert r.returncode != 0
+    assert "Step 6" in r.stderr
+
+
+def test_passes_with_warning_when_cli_lacks_the_verb(tmp_path):
+    uip = _fake_uip(tmp_path, exit_code=2)
+    r = run(tmp_path, uip=uip)
+    assert r.returncode == 0, r.stderr
+    assert "unavailable" in r.stdout
+    assert "WARN" in r.stdout
+
+
+def test_passes_with_warning_when_uip_is_not_on_path(tmp_path):
+    r = run(tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "WARN" in r.stdout
+
+
+# --- report plumbing -----------------------------------------------------------
+
+def test_fails_when_report_missing(tmp_path):
+    _write_history(tmp_path, [ENTRY])
+    r = run(tmp_path, report=None)
+    assert r.returncode != 0
+    assert "not found" in r.stderr
+
+
+def test_fails_when_report_has_no_final_grade_footer(tmp_path):
+    _write_history(tmp_path, [ENTRY])
+    r = run(tmp_path, report="# Review Report\n\nNo footer here.\n")
+    assert r.returncode != 0
+    assert "Final grade" in r.stderr

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_action_ineffective/lowcode_review_guardrail_action_ineffective.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_action_ineffective/lowcode_review_guardrail_action_ineffective.yaml
@@ -30,7 +30,7 @@ initial_prompt: |
   solution `ReviewSol`. Review the agent project for issues and save your review
   report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review — do not modify anything inside `ReviewSol/`.
+  Do not manually edit files inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_action_ineffective/lowcode_review_guardrail_action_ineffective.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_action_ineffective/lowcode_review_guardrail_action_ineffective.yaml
@@ -93,3 +93,11 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+  - type: run_command
+    description: "Step 6 recorded the final grade in CLI-owned review-history.json"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_history.py --project ReviewSol/SampleAgent --report _review_report.md'
+    timeout: 120
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
@@ -26,7 +26,7 @@ initial_prompt: |
   solution `ReviewSol`. Review the agent project for issues and save your review
   report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review — do not modify anything inside `ReviewSol/`.
+  Do not manually edit files inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
@@ -87,3 +87,11 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+  - type: run_command
+    description: "Step 6 recorded the final grade in CLI-owned review-history.json"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_history.py --project ReviewSol/SampleAgent --report _review_report.md'
+    timeout: 120
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
@@ -25,7 +25,7 @@ initial_prompt: |
   solution `ReviewSol`. Review the agent project for issues and save your review
   report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review — do not modify anything inside `ReviewSol/`.
+  Do not manually edit files inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
@@ -86,3 +86,11 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+  - type: run_command
+    description: "Step 6 recorded the final grade in CLI-owned review-history.json"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_history.py --project ReviewSol/SampleAgent --report _review_report.md'
+    timeout: 120
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
@@ -27,7 +27,7 @@ initial_prompt: |
   solution `ReviewSol`. Review the agent project for issues and save your review
   report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review — do not modify anything inside `ReviewSol/`.
+  Do not manually edit files inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
@@ -88,3 +88,11 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+  - type: run_command
+    description: "Step 6 recorded the final grade in CLI-owned review-history.json"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_history.py --project ReviewSol/SampleAgent --report _review_report.md'
+    timeout: 120
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_pii_missing/lowcode_review_guardrail_pii_missing.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_pii_missing/lowcode_review_guardrail_pii_missing.yaml
@@ -34,7 +34,7 @@ initial_prompt: |
   including its guardrail configuration. Save the report to
   `./_review_report.md` at the sandbox root.
 
-  This is a read-only review — do not modify anything inside `ReviewSol/`.
+  Do not manually edit files inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_pii_missing/lowcode_review_guardrail_pii_missing.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_pii_missing/lowcode_review_guardrail_pii_missing.yaml
@@ -71,3 +71,11 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+  - type: run_command
+    description: "Step 6 recorded the final grade in CLI-owned review-history.json"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_history.py --project ReviewSol/SampleAgent --report _review_report.md'
+    timeout: 120
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_unknown_validator/lowcode_review_guardrail_unknown_validator.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_unknown_validator/lowcode_review_guardrail_unknown_validator.yaml
@@ -27,7 +27,7 @@ initial_prompt: |
   solution `ReviewSol`. Review the agent project for issues and save your review
   report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review — do not modify anything inside `ReviewSol/`.
+  Do not manually edit files inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_unknown_validator/lowcode_review_guardrail_unknown_validator.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_unknown_validator/lowcode_review_guardrail_unknown_validator.yaml
@@ -78,3 +78,11 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+  - type: run_command
+    description: "Step 6 recorded the final grade in CLI-owned review-history.json"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_history.py --project ReviewSol/SampleAgent --report _review_report.md'
+    timeout: 120
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-review/agents/lowcode_review_prompt_instruction_conflicts/lowcode_review_prompt_instruction_conflicts.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_prompt_instruction_conflicts/lowcode_review_prompt_instruction_conflicts.yaml
@@ -26,7 +26,7 @@ initial_prompt: |
   solution `ReviewSol`. Review the agent project for issues and save your review
   report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review — do not modify anything inside `ReviewSol/`.
+  Do not manually edit files inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_prompt_instruction_conflicts/lowcode_review_prompt_instruction_conflicts.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_prompt_instruction_conflicts/lowcode_review_prompt_instruction_conflicts.yaml
@@ -63,3 +63,11 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+  - type: run_command
+    description: "Step 6 recorded the final grade in CLI-owned review-history.json"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_history.py --project ReviewSol/SampleAgent --report _review_report.md'
+    timeout: 120
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-review/agents/lowcode_review_tool_overlap/lowcode_review_tool_overlap.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_tool_overlap/lowcode_review_tool_overlap.yaml
@@ -26,7 +26,7 @@ initial_prompt: |
   solution `ReviewSol`. Review the agent project for issues and save your review
   report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review — do not modify anything inside `ReviewSol/`.
+  Do not manually edit files inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_tool_overlap/lowcode_review_tool_overlap.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_tool_overlap/lowcode_review_tool_overlap.yaml
@@ -63,3 +63,11 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+  - type: run_command
+    description: "Step 6 recorded the final grade in CLI-owned review-history.json"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_history.py --project ReviewSol/SampleAgent --report _review_report.md'
+    timeout: 120
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-review/agents/lowcode_review_vague_tool_description/lowcode_review_vague_tool_description.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_vague_tool_description/lowcode_review_vague_tool_description.yaml
@@ -27,7 +27,7 @@ initial_prompt: |
   solution `ReviewSol`. Review the agent project for issues and save your review
   report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review — do not modify anything inside `ReviewSol/`.
+  Do not manually edit files inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_vague_tool_description/lowcode_review_vague_tool_description.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_vague_tool_description/lowcode_review_vague_tool_description.yaml
@@ -64,3 +64,11 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+  - type: run_command
+    description: "Step 6 recorded the final grade in CLI-owned review-history.json"
+    command: 'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-review/_shared/check_review_history.py --project ReviewSol/SampleAgent --report _review_report.md'
+    timeout: 120
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0


### PR DESCRIPTION
Use the new `review-history add` command (https://github.com/UiPath/cli/pull/3981) to store the grade in the agent project files, at the end of the review.

Also moved details specific to agent reviewing out of SKILL.md and into a new agent-review-guide.md.

Verification: ran the modified tests locally and they passed, asserting that the history entry is written via CLI

Note for claude reviewer:
- Step 6 check is excluded from lowcode_review_with_stale_generated_files because that test's purpose is to verify the agent refreshes files first; the other tests are happy-path review tests, and storing the grade is part of the happy path