### PR TITLE
test(uipath-maestro-flow): recast DF e2e to linear CRUD chain (drop l…

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_e2e_contract_intake_pipeline.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/check_e2e_contract_intake_pipeline.py
@@ -1,20 +1,17 @@
 #!/usr/bin/env python3
-"""Verify the shrunk ContractRegistry bulk lifecycle:
+"""Verify the ContractRegistry linear CRUD chain — DF activity ownership only:
 
-- >=1 ForEach loop node in the flow
-- >=1 create-entity-record on ContractRegistry (typically single, inside a loop)
+- >=1 create-entity-record on ContractRegistry, body contains contractTitle
+- >=1 get-entity-record-by-id on ContractRegistry, recordId bound to create output
 - >=1 query-entity-records on ContractRegistry, sorted by priority DESC
-- >=1 update-entity-record on ContractRegistry touching `status`, with a
-  recordId expression bound to the query's output (not a hard-coded literal)
-- >=1 delete-entity-record on ContractRegistry (typically single, inside a loop)
+- >=1 update-entity-record on ContractRegistry, recordId bound to create output,
+      body contains ONLY the `status` key
+- >=1 delete-entity-record on ContractRegistry, recordId bound to create output
 
-Only what's UNIQUE to this e2e: the loop-driven bulk pattern + the query→update
-wiring. Single-node CRUD assertions live in smoke_update; multi-condition
-FilterBuilder in integration_query.
-"""
+Loop / branch / multi-node orchestration is intentionally NOT enforced —
+that's core-flow ownership, not the DF connector's."""
 import glob
 import json
-import re
 import sys
 
 ENTITY = "ContractRegistry"
@@ -25,8 +22,7 @@ def detail(node):
 
 
 def targets_entity(node):
-    pp = (detail(node).get("pathParameters") or {})
-    return pp.get("entityName") == ENTITY
+    return (detail(node).get("pathParameters") or {}).get("entityName") == ENTITY
 
 
 def qparams(node):
@@ -35,6 +31,13 @@ def qparams(node):
 
 def body(node):
     return detail(node).get("bodyParameters") or {}
+
+
+def record_id_expr(node):
+    """recordId lives in queryParameters for every activity except Create;
+    fall back to pathParameters for older CLI encodings."""
+    return str(qparams(node).get("recordId") or
+               (detail(node).get("pathParameters") or {}).get("recordId") or "")
 
 
 def has_priority_desc_sort(node):
@@ -58,18 +61,12 @@ def has_priority_desc_sort(node):
     return asc is False
 
 
-def update_wired_to_query(update_node, query_node_ids):
-    """The update's recordId must reference an upstream query output (not a
-    hard-coded literal). We accept any =js:$vars.<id>. expression whose <id>
-    matches a query node's id — that's the CLI-emitted binding form."""
-    pp = detail(update_node).get("pathParameters") or {}
-    rec = str(pp.get("recordId", ""))
-    if not rec.startswith("=js:"):
+def wired_to_create(node, create_ids):
+    """recordId must reference one of the create nodes' output ids."""
+    expr = record_id_expr(node)
+    if not expr.startswith("=js:"):
         return False
-    for qid in query_node_ids:
-        if qid and qid in rec:
-            return True
-    return False
+    return any(cid and cid in expr for cid in create_ids)
 
 
 def main() -> int:
@@ -81,15 +78,15 @@ def main() -> int:
     for path in flows:
         with open(path) as f:
             doc = json.load(f)
-        loops, creates, queries, updates, deletes = [], [], [], [], []
+        creates, gets, queries, updates, deletes = [], [], [], [], []
         for n in doc.get("nodes", []):
-            t = n.get("type", "")
-            if t.startswith("core.logic.loop"):
-                loops.append(n)
             if not targets_entity(n):
                 continue
+            t = n.get("type", "")
             if t.endswith(".create-entity-record"):
                 creates.append(n)
+            elif t.endswith(".get-entity-record-by-id"):
+                gets.append(n)
             elif t.endswith(".query-entity-records"):
                 queries.append(n)
             elif t.endswith(".update-entity-record"):
@@ -97,38 +94,56 @@ def main() -> int:
             elif t.endswith(".delete-entity-record"):
                 deletes.append(n)
 
-        if not loops:
-            print(f"FAIL: {path} — no ForEach loop; the bulk pattern requires >=1 loop", file=sys.stderr)
-            continue
         if not creates:
             print(f"FAIL: {path} — no create-entity-record on {ENTITY}", file=sys.stderr)
             continue
+        if not any("contractTitle" in body(c) for c in creates):
+            print(f"FAIL: {path} — create body missing contractTitle", file=sys.stderr)
+            continue
+
+        create_ids = [c.get("id") for c in creates]
+
+        if not gets:
+            print(f"FAIL: {path} — no get-entity-record-by-id on {ENTITY}", file=sys.stderr)
+            continue
+        if not any(wired_to_create(g, create_ids) for g in gets):
+            print(f"FAIL: {path} — get recordId not wired to create output", file=sys.stderr)
+            continue
+
         if not queries:
             print(f"FAIL: {path} — no query-entity-records on {ENTITY}", file=sys.stderr)
             continue
         if not any(has_priority_desc_sort(q) for q in queries):
             print(f"FAIL: {path} — no query with priority DESC sort", file=sys.stderr)
             continue
+
         if not updates:
             print(f"FAIL: {path} — no update-entity-record on {ENTITY}", file=sys.stderr)
             continue
-        if not any("status" in body(u) for u in updates):
-            print(f"FAIL: {path} — no update touching status", file=sys.stderr)
+        partial_status_update = [u for u in updates if set(body(u).keys()) == {"status"}]
+        if not partial_status_update:
+            keys_seen = [sorted(body(u).keys()) for u in updates]
+            print(f"FAIL: {path} — no update whose body is exactly {{'status'}} "
+                  f"(found: {keys_seen})", file=sys.stderr)
             continue
-        q_ids = [q.get("id") for q in queries]
-        if not any(update_wired_to_query(u, q_ids) for u in updates):
-            print(f"FAIL: {path} — update recordId not wired to a query output (found literals or unrelated references)", file=sys.stderr)
+        if not any(wired_to_create(u, create_ids) for u in partial_status_update):
+            print(f"FAIL: {path} — status-only update recordId not wired to create output",
+                  file=sys.stderr)
             continue
+
         if not deletes:
             print(f"FAIL: {path} — no delete-entity-record on {ENTITY}", file=sys.stderr)
             continue
+        if not any(wired_to_create(d, create_ids) for d in deletes):
+            print(f"FAIL: {path} — delete recordId not wired to create output", file=sys.stderr)
+            continue
 
-        print(f"OK: {path} — {len(loops)} loop(s), "
-              f"{len(creates)} create, {len(queries)} query (priority DESC), "
-              f"{len(updates)} update (status), {len(deletes)} delete on {ENTITY}")
+        print(f"OK: {path} — Create → Get → Query(priority DESC) → "
+              f"Update(status only) → Delete, all on {ENTITY}, recordId chained "
+              f"from create output")
         return 0
 
-    print("FAIL: no .flow satisfies the bulk-lifecycle shape", file=sys.stderr)
+    print("FAIL: no .flow satisfies the CRUD-chain shape", file=sys.stderr)
     return 1
 
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/e2e_contract_intake_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/e2e_contract_intake_pipeline.yaml
@@ -1,12 +1,12 @@
 task_id: skill-flow-datafabric-e2e-contract-intake-pipeline
 description: >
-  E2E test for the UiPath Data Fabric connector in Maestro Flow — the
-  loop-driven bulk-CRUD lifecycle that other DF tests don't cover. Single-node
-  CRUD is exercised by smoke_update; FilterBuilder queries by integration_query;
-  query→update wiring by contractregistry_crud_filters. Here we verify a Flow
-  can bulk-create N records with a ForEach loop, query them, update one via
-  the query output, and bulk-delete via a second ForEach. Static-validate
-  only; runtime `flow debug` skipped to avoid live tenant side effects.
+  E2E test for the UiPath Data Fabric connector — the full CRUD activity
+  surface exercised in one flow on a single ContractRegistry record.
+  Focus is on DF activity payloads and Create-output-Id chaining across
+  Get / Update / Delete; orchestration primitives (loops, decisions,
+  multi-branch fan-out) are covered by core-flow tests, not here.
+  Static-validate only; runtime `flow debug` skipped to avoid live tenant
+  side effects.
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, uipath-uipath-dataservice]
 
 run_limits:
@@ -23,23 +23,28 @@ initial_prompt: |
   Build a UiPath Flow against the `ContractRegistry` Data Fabric entity
   (fields: contractTitle STRING, status STRING, priority INTEGER,
   dueDate DATE, value DECIMAL, isUrgent BOOLEAN) that exercises the
-  bulk-CRUD lifecycle with ForEach loops:
+  connector's CRUD surface on ONE record. All downstream activities bind
+  recordId to the create output — do NOT hard-code any Id.
 
-  1. A ForEach loop that reads a list of contracts from the start input
-     and calls Create Entity Record ONCE inside the loop, binding
-     contractTitle / status / priority from the loop item. Do NOT unroll
-     into multiple Create nodes.
+  Chain the five activities in this order:
 
-  2. A single Query Entity Records on ContractRegistry, sorted by
-     priority descending.
+  1. Create Entity Record on ContractRegistry. Populate the body with
+     contractTitle, status='Draft', priority (any integer 1-10),
+     dueDate (any valid date), value (any decimal), isUrgent (boolean).
 
-  3. An Update Entity Record on the top result from the query — bind
-     recordId to the first element of the query output and set status
-     to "In Review". Do NOT hard-code the Id.
+  2. Get Entity Record By Id — bind recordId to the create activity's
+     output Id.
 
-  4. A second ForEach loop over the query output that calls Delete
-     Entity Record ONCE inside the loop, binding recordId to the loop
-     item's Id.
+  3. Query Entity Records — filter contractTitle equals the literal
+     value used in step 1 (author it as a FilterBuilder tree, not a raw
+     CEQL string). Sort by priority descending.
+
+  4. Update Entity Record — bind recordId to the create activity's
+     output Id. The update body must contain ONLY the `status` key set
+     to "In Review"; no other fields.
+
+  5. Delete Entity Record — bind recordId to the create activity's
+     output Id.
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a
@@ -56,7 +61,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Flow uses ForEach loops for bulk create + bulk delete on ContractRegistry, with a sort-query and a targeted update wired to the query output"
+    description: "Flow chains Create → Get/Update/Delete on ContractRegistry with recordId bound to create.output, plus one Query with priority-desc sort and a partial Update body"
     command: "python3 $TASK_DIR/check_e2e_contract_intake_pipeline.py"
     timeout: 30
     expected_exit_code: 0


### PR DESCRIPTION
…oop orchestration)

Data Fabric connector ownership is the activity surface, not flow orchestration. The previous e2e required a ForEach-loop bulk pattern + query→update wiring, which repeatedly failed because agents got stuck on loop `inputMetadata` (currentItem schema not declared → expression validation fails) — a core-flow concern, not a DF concern.

Recast to a linear 5-activity chain on one record:

  Create → Get → Query → Update → Delete

All wired via `=js:$vars.<createNodeId>.output.Id`. Proves the DF activity payloads + Create's output.Id contract propagation to Get / Update / Delete — the unique DF concerns not covered by sibling smokes.

Verifier changes:
- Reads `recordId` from `queryParameters` (matches connector registry and Web-built encoding); pathParameters kept as fallback.
- Drops the ForEach-loop requirement.
- Drops the update-wired-to-query check (update now wires to create output, which is where the DF-owned Id contract lives).
- Adds partial-update body check: Update body must be exactly {status}.
- Validated with 8 tests: 1 passing shape + 7 negative mutations (each breaking one criterion) — every mutation trips the correct branch.

Budget shrunk: turn_timeout 4500 → 1800, task_timeout 5400 → 2400, expected_turns 100 → 40, max_turns 200 → 100. No loops = far less authoring work.