### PR TITLE
chore: refresh uip CLI catalog (1.203.0-dev.8563)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-09-07T04:06:51Z",
-  "cli_version": "1.203.0-dev.8556",
+  "generated_at": "2026-09-08T04:07:47Z",
+  "cli_version": "1.203.0-dev.8563",
   "verbs": [
     "admin",
     "admin audit",
@@ -175,6 +175,8 @@
     "agent model list",
     "agent refresh",
     "agent review",
+    "agent review-history",
+    "agent review-history add",
     "agent tool",
     "agent tool list",
     "agent validate",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.203.0-dev.8563`. The catalog has 1560 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.