### PR TITLE
fix(case): stop naming an action catalog the SDD never asked for

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
@@ -31,15 +31,17 @@
 
 ## Action-Specific Fields
 
-> **Unresolved → `"data": {}`.** When `action-app-id` is `<UNRESOLVED>` (or `action-apps-index.json` returned 0 nodes), the entire shape collapses to `"data": {}`. **No exception** for `taskTitle`, `priority`, `recipient`, `labels`, `name`, `folderPath`, `inputs`, `outputs`, or optional `actionCatalogName` — omit every `data.*` key. See [placeholder-tasks.md](../../../placeholder-tasks.md).
+> **Unresolved → `"data": {}`.** When `action-app-id` is `<UNRESOLVED>` (or `action-apps-index.json` returned 0 nodes), the entire shape collapses to `"data": {}`. **No exception** for `taskTitle`, `priority`, `recipient`, `labels`, `name`, `folderPath`, `inputs`, or `outputs` — omit every `data.*` key. See [placeholder-tasks.md](../../../placeholder-tasks.md).
 
 | Field | Notes |
 |---|---|
 | `data.taskTitle` | Required on **resolved** action tasks — validator rejects empty. Placeholders omit it (along with every other `data.*` action-specific key); see [placeholder-tasks.md](../../../placeholder-tasks.md). |
 | `data.priority` | `"Low"` \| `"Medium"` (default) \| `"High"` \| `"Critical"` |
 | `data.recipient` | `ActionTaskAssignee` object: `{ "Type": <int>, "Value": "<id-or-email>" }`. See fallback below for unresolved-UUID handling. |
-| `data.actionCatalogName` | **Optional.** Must bind to an existing action catalog resource. Omit unless the SDD references a known catalog. |
+| `data.actionCatalogName` | **Omit the key.** See the note below. |
 | `data.labels` | Label set from the SDD |
+
+> **Omit `data.actionCatalogName`.** An sdd.md never names an action catalog, so there is nothing to write here. Do not derive a value from another SDD field. The key names an action catalog, an Orchestrator resource that exists per folder, and the platform resolves that name in the **app's deployment folder** (the folder `data.folderPath` binds), not in the folder the case runs in. A name that folder does not hold fails the task the moment it opens, with `No task catalog exists with name <value>`, and nothing before that reports it: the name resolves against tenant state, so `validate` cannot check it, and the task's own app bindings are correct, so the caseplan reads as complete. Omitting the key creates the task with no catalog; its folder, its assignee and its inputs are unaffected, because a catalog only groups tasks and carries their encryption and retention settings. When the USER names a catalog explicitly, confirm it exists in that folder before writing it: `uip tasks catalogs list --folder-path "<app deployment folder>" --output json`.
 
 `recipient.Type` values: `0` = user ID (sdd `User:`), `1` = group ID (sdd `UserGroup:` / `Role:`), `2` = email address, `3` = `"=vars.<varId>"` (sdd `Expression:`). **Fallback when sdd.md value is not a resolved UUID:** write `{ "Type": <picked>, "Value": "<sdd-string-as-is>" }` — schema-conformant placeholder, user resolves Value later. Drop `data.recipient` only when no Type maps. **Never invent a non-conforming shape** (`{ kind, id }`, `{ scope, target, value }`, etc.) — Studio Web canvas crashes silently; CLI validate misses it.
 
@@ -66,7 +68,7 @@ Dedup per [§ Deduplication](../../variables/bindings/impl-json.md).
 **Step 2 — Write task:**
 
 1. Generate `id` (`t` + 8 chars) and `elementId` (`<stageId>-<taskId>`)
-2. Set `data.taskTitle`, `data.priority`, `data.labels` from the SDD now (plain strings, not Phase-3 bindings); set `data.actionCatalogName` only when the SDD references an existing catalog. **`data.recipient` is an object, NEVER a bare string.** Wrap the SDD's recipient value as `{ "Type": <int>, "Value": <value> }`. `UserGroup:` is the one prefix planning keeps: strip it and emit `Type 1` with the **group name** in `Value`, never a UUID. Every other value arrives bare and its Type comes from its shape (`=vars.X` → `3`, email → `2`, user UUID → `0`). E.g. `recipient: =vars.assignedLoanOfficer` → `{ "Type": 3, "Value": "=vars.assignedLoanOfficer" }`, and `recipient: UserGroup: Compliance` → `{ "Type": 1, "Value": "Compliance" }`. Do not copy the bare value through as `data.recipient`.
+2. Set `data.taskTitle`, `data.priority`, `data.labels` from the SDD now (plain strings, not Phase-3 bindings); omit `data.actionCatalogName` (see the note under § Action-Specific Fields for the one case that writes it). **`data.recipient` is an object, NEVER a bare string.** Wrap the SDD's recipient value as `{ "Type": <int>, "Value": <value> }`. `UserGroup:` is the one prefix planning keeps: strip it and emit `Type 1` with the **group name** in `Value`, never a UUID. Every other value arrives bare and its Type comes from its shape (`=vars.X` → `3`, email → `2`, user UUID → `0`). E.g. `recipient: =vars.assignedLoanOfficer` → `{ "Type": 3, "Value": "=vars.assignedLoanOfficer" }`, and `recipient: UserGroup: Compliance` → `{ "Type": 1, "Value": "Compliance" }`. Do not copy the bare value through as `data.recipient`.
 3. Set `data.name` = `=bindings.<nameBindingId>`, `data.folderPath` = `=bindings.<folderPathBindingId>`
 4. Write `data.inputs[]` / `data.outputs[]` from Step 0 schema. Each input: `{ name, type, id, var, elementId, value: "" }`. Each output: `{ name, type, id, var, value, source, target, elementId }`.
 
@@ -83,12 +85,14 @@ Dedup per [§ Deduplication](../../variables/bindings/impl-json.md).
 - the bindings array has 2 entries: `resource: "app"`, no `resourceSubType`, `propertyAttribute` = `name` / `folderPath`
 - `data.inputs` and `data.outputs` populated (unless placeholder)
 - `data.recipient` is an **object** `{ Type, Value }`, never a bare string — present whenever the SDD recorded a recipient (omitted only for Skip or no-Type-maps). A group/role is `Type 1` carrying the group **name**; dropping it leaves the task created and reaching nobody
+- `data.actionCatalogName` is absent (present only for a catalog the USER named and you confirmed in the app's deployment folder)
 - `entryConditions` is present and non-empty — a task with no entry condition is never triggered, and `validate` does NOT catch it (it accepts an empty array and a missing key). Use the activation the SDD declares (`current-stage-entered`, `runs-sequentially`, `adhoc`, `sla-status-change` for an SLA `start-task` response — see [sla-response-shapes.md](../../../sla-response-shapes.md))
 - `id` captured in `id-map.json`
 
 ## Anti-patterns
 
 - **Do NOT emit `data.recipient` as a bare string, drop it, or "resolve" it.** It is always the object `{ Type, Value }` written at Step 2 (not an io-binding target). The SDD value (`=vars.X`, email, UUID) is the `Value` — wrap it, don't pass it through. `Type 3` `=vars.X` is the finished runtime reference; copying it through as a string, deferring to Phase 3, or rewriting it to the var's email each break the task. Symptoms: `data.recipient` is a string, or missing while the SDD names a recipient.
+- **Do NOT derive `data.actionCatalogName` from the SDD.** An sdd.md names no catalog, so any value taken from it is invented, and a name the app's deployment folder does not hold faults the task on open (see the note above § Action-Specific Fields).
 - **CLI `validate` does NOT check `data.recipient`** — verify presence/shape explicitly (Post-Write Verification).
 
 <!-- END: impl-json.md -->


### PR DESCRIPTION
The sla criterion of [run 34088556384](https://github.com/UiPath/skills/actions/runs/34088556384), the supplier-onboarding coder-eval, ends on one line:

> instance a0dae00c-2b5d-446a-9588-73be639823a9 / waiting for the intake phase to breach and open 'Unblock a supplier application that has missed the Checking the application deadline' / incident on 't5MmNnOo6' (170000): No task catalog exists with name phase-escalation

That is the one criterion this change is about. The run lost 11 of its 23 criteria; the other ten fail on things this change does not touch, five of them on an Integration Services `400` raised by a single connector task.

The build had written `data.actionCatalogName` on eight action tasks. The skill told it to.

## What the guidance said

The action plugin's [field row](https://github.com/UiPath/skills/blob/5d6cd1a5bd36da1ea7a84afa93e9ac3191b1a549/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md#L41) called the key a binding and made writing it conditional on the SDD:

> **Optional.** Must bind to an existing action catalog resource. Omit unless the SDD references a known catalog.

Neither half holds. The key is not a binding the builder fills; it takes the name of an action catalog. And an SDD never references one: the word `catalog` appears zero times in the 636-line [case SDD template](https://github.com/UiPath/skills/blob/5d6cd1a5bd36da1ea7a84afa93e9ac3191b1a549/skills/uipath-planner/assets/templates/case/case-sdd-template.md) and zero times in the 2150-line SDD this run was given. So the condition reads as satisfied by whatever the SDD does say beside the app, which is its `**actionType:**` line. [Step 2](https://github.com/UiPath/skills/blob/5d6cd1a5bd36da1ea7a84afa93e9ac3191b1a549/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md#L69) repeated the same condition.

## Where the name goes, and in which folder

`data.actionCatalogName` is optional on the [HITL task schema](https://github.com/UiPath/PO.Frontend/blob/d7ccc4ff4168e1aa69dd2e2eb493a592d6e2a79b/src/types/case-mgmt-zod/tasks/CaseManagementJsonTaskHitlActionSchema.ts#L22) and the designer's control is `required={false}`, so omitting it is a shape the product itself accepts.

When it is written, it travels as the bpmn input the engine knows by [that name](https://github.com/UiPath/PO.BpmnEngine/blob/9820da6d409375a706848f1d72dbad1e02120ae2/src/Common/UiPath.PO.Models/Bpmn/WellKnownInputNames.cs#L58), an app-based task takes the [app-task create path](https://github.com/UiPath/PO.BpmnEngine/blob/9820da6d409375a706848f1d72dbad1e02120ae2/src/BpmnEngine/UiPath.PO.Worker/Facades/AppTasksFacade.cs#L151), and Orchestrator hands it to [the same catalog lookup](https://github.com/UiPath/Orchestrator/blob/45ea11f7ef3bafa85f8d16ec40559eb76f51ba5c/src/Tasks/Apis/Tasks/Services/TasksService.cs#L326-L337) on both of its create branches. The lookup is [scoped to one folder](https://github.com/UiPath/Orchestrator/blob/45ea11f7ef3bafa85f8d16ec40559eb76f51ba5c/src/Tasks/Core/Managers/TaskCatalogsManager.cs#L140-L147) and throws when that folder holds no catalog by that name.

Which folder is the part that is easy to get wrong. For an `Actions.HITL` `v2` activity it is the app's deployment folder, the one `data.folderPath` binds, unless an `actionCatalogFolderPath` input overrides it ([GetHitlTaskFolderContext](https://github.com/UiPath/PO.BpmnEngine/blob/9820da6d409375a706848f1d72dbad1e02120ae2/src/Common/UiPath.PO.Models/ProcessOrchestrationRuntime/OrchestratorFolderContext.cs#L38-L46), applied [here](https://github.com/UiPath/PO.BpmnEngine/blob/9820da6d409375a706848f1d72dbad1e02120ae2/src/BpmnEngine/UiPath.PO.Worker/Models/ProcessOrchestrationRuntime/AppTasksCreateArgs.cs#L325-L330)). This run's compiled `caseplan.json.bpmn` carries 15 `Actions.HITL` activities, all `version="v2"`, and no `actionCatalogFolderPath` input, so `phase-escalation` was looked up in `Shared/uipath-maestro-case`. That folder holds zero catalogs.

An absent or blank name skips the lookup and the task is created with no catalog. There is no default catalog: `TaskCatalogId` has two write sites on the create path and both are that lookup.

## The change

The field row reads **Omit the key**, Step 2 says to omit it, and Post-Write Verification and Anti-patterns each gain one line. A note under the table carries the reason: an sdd.md names no catalog, so a value taken from it is invented; the name is resolved in the app's deployment folder; a name that folder does not hold fails the task the moment it opens, while `validate` cannot see it and the task's own app bindings are correct, so the caseplan reads as complete. Omitting the key costs the task nothing, because a catalog only groups tasks and carries their encryption and retention settings.

A catalog the USER names explicitly stays writable. The note carries the command that confirms it first:

```
uip tasks catalogs list --folder-path "<app deployment folder>" --output json
```

and Post-Write Verification allows that one case, so a build does not delete its own correct value. The anti-pattern is deriving the value from the SDD, not writing one a user asked for.

One file, one field. The unresolved-placeholder note drops its `actionCatalogName` exception, because a key that is never derived needs no exception.

`uipath-human-in-the-loop` still instructs this key for an app-based action task, and makes it a verification condition against the app's `deploymentTitle`. An action catalog is not an app, so that guidance writes an app title into a folder-resolved catalog name and fails the same way. It is a second skill with separate owners in CODEOWNERS, and it needs the same correction.

## Verification

Three builds of the same SDD on this branch, against the live tenant. The third one read the wording this PR ships, anti-pattern and user-named exception included, and still wrote nothing:

| run | agent | action tasks | resolved | naming a catalog |
|---|---|---|---|---|
| [34269869187](https://github.com/UiPath/skills/actions/runs/34269869187) | codex | 15 | 15 | 0 |
| [34288417554](https://github.com/UiPath/skills/actions/runs/34288417554) | claude | 15 | 15 | 0 |
| [34297907453](https://github.com/UiPath/skills/actions/runs/34297907453) | claude | 15 | 15 | 0 |
| [34088556384](https://github.com/UiPath/skills/actions/runs/34088556384) before this change | claude | 15 | 15 | 8 |

The resolved column is load-bearing: an action task whose app does not resolve collapses to an empty `data`, which would carry no catalog name while proving nothing. All 15 resolved in every run.

All three post-change runs used a build-only replicate of the supplier-onboarding task that stops at validate, so what they observe is the moment the key is decided. The full task's execution routes are unaffected by this change and are not what these runs measure.

Across 199 caseplans from 37 coder-eval runs, 50 of 398 action tasks write this key, and every one of the 50 repeats its own SDD `actionType`. No binding in any of those caseplans declares the value, and no caseplan in the corpus carries a `taskCatalog` binding at all.

**The backstop.** [cli#4045](https://github.com/UiPath/cli/pull/4045) reports the same defect from the caseplan alone, as a warning, so a build that does not follow this paragraph is still named before it runs. This text is what stops the key being written; that check is what reports the runs where the text does not take, and it also covers a caseplan authored by hand.

`npm run skills:validate`: default 27 skills and 1764 files, studioweb 27 and 1764 with 264 replacements. The file carries no flavor marker and no flavor overrides its path, so the canonical text is what every flavor ships.

