### PR TITLE
fix(tests): unique solution name per run in cloud_job_fault seed

### DIFF
--- a/tests/tasks/uipath-api-workflow/diagnose/cloud_job_fault/seed_faulted_job.py
+++ b/tests/tasks/uipath-api-workflow/diagnose/cloud_job_fault/seed_faulted_job.py
@@ -32,7 +32,6 @@ import sys
 import time
 from pathlib import Path
 
-SOLUTION_DIR = "FaultSolution"
 PROJECT_NAME = "OrderStatus"
 # The fixture faults on the first poll in practice (the throw is immediate), so a
 # short budget is plenty and keeps the phase inside coder-eval's 300s pre_run cap.
@@ -72,6 +71,12 @@ uuid8 = seed.get("uuid8")
 parent = seed.get("parent_folder_path") or "Shared"
 if not uuid8:
     die("seed.json has no uuid8")
+
+# The solution name becomes the deployed process key (`<solution>.api.<project>`).
+# A fixed name means every run deploys the same key, and a deployment left
+# standing by an interrupted run makes every later `deploy run` fail with
+# ValidationFailed. Suffixing uuid8 makes each run's key unique.
+SOLUTION_DIR = f"FaultSolution{uuid8}"
 
 package_name = f"apiwffault-pkg-{uuid8}"
 deploy_name = f"apiwffault-{uuid8}"


### PR DESCRIPTION
## Problem

`skill-api-workflow-diagnose-cloud-job-fault` has been **ERROR on every nightly since 2026-09-02** (green through 2026-08-31). It fails in `pre_run`, before the agent starts:

```
seed_faulted_job.py: FIXTURE SETUP FAILED — deploy failed: 'Deployment failed with status: ValidationFailed'
```

`seed_faulted_job.py` hardcoded `SOLUTION_DIR = "FaultSolution"`, so every run deployed a process with the same key, `FaultSolution.api.OrderStatus@1.0.0`. A deployment left standing by an interrupted run (killed before `post_run`) makes every later `uip solution deploy run` with that key fail. Reported by @CarlesUIPath while validating #3007.

## Fix

Suffix the run's `uuid8` to the solution name (`FaultSolution<uuid8>`), so the deployed process key is unique per run and a stale leftover can no longer block the next run. Cleanup step unchanged.

## Verification (local, alpha tenant, `--type claude-code --model claude-sonnet-5`)

| Run | Tenant state | Result |
|---|---|---|
| main, clean tenant | no leftovers | SUCCESS 1.0 |
| main, leftover `FaultSolution.api.OrderStatus` deployment standing | reproduces the nightly | ERROR — `ValidationFailed` in pre_run |
| **this branch**, same leftover scenario no longer possible | — | **SUCCESS 1.0**, pre_run deploy + fault OK, post_run uninstalled + deleted package |

## One-off needed on the CI tenant

The stray deployment currently blocking the nightly must be removed once (this PR prevents recurrence, it does not clean history):

```bash
uip solution deploy list --output json     # apiwffault-* row whose Operation != Uninstall
uip solution deploy uninstall <name> --yes --output json
uip solution packages delete <package-name> 1.0.0 --yes --output json
```

## Follow-ups (not in this PR)

- A failed deploy leaves an `Operation=Install / OperationStatus=Draft` deployment that blocks `packages delete`; cleanup should uninstall it.
- Because deploy dies before writing `.fault_fixture.json`, `cleanup_fault_deploy.py` skips and the just-published package leaks; cleanup should derive names from `seed.json`.
- Print the full deploy response on failure, not just `Message`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)