### PR TITLE
perf(uipath-human-in-the-loop): whole-bundle token reduction (−34% bundle, −59% body, 0 regressions)

### DIFF
--- a/skills/uipath-human-in-the-loop/SKILL.md
+++ b/skills/uipath-human-in-the-loop/SKILL.md
@@ -6,261 +6,142 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 
 # UiPath Human-in-the-Loop Assistant
 
-Recognizes when a business process needs a human decision point, designs the task schema through conversation, and wires the HITL node into the automation — Flow, Maestro, Case Management, or Agent.
+Recognizes processes requiring human decisions, designs task schemas conversationally, and wires HITL into Flow, Maestro, Case Management, or an Agent.
 
-> **Coded agents:** for wiring HITL inside a coded agent, use the `uipath-agents` skill — see `skills/uipath-agents/references/coded/capabilities/human-in-the-loop.md`.
+> **Coded agents:** use the `uipath-agents` skill for coded-agent HITL wiring: `skills/uipath-agents/references/coded/capabilities/human-in-the-loop.md`.
 
 ## When to Use This Skill
 
-- User describes **approval gates** — invoice approval, offer letter review, compliance sign-off, PO authorization
-- User describes **exception escalation** — "if confidence is low, escalate to a human", fraud alert review
-- User describes **write-back validation** — "human approves before agent writes to ServiceNow / SAP / CRM"
-- User describes **data enrichment** — human fills in missing fields the automation cannot resolve
-- User describes **agentic output review** — "review AI-generated email/RCA/summary before it goes out"
-- User describes **IT change or access approval** — CAB gate, runbook sign-off, access provisioning review
-- User describes **HR or contract workflow** — offer letter review, contract approval, termination sign-off
-- User describes **financial transaction approval** — payment release, price override, expense over limit
-- User describes **customer communication approval** — agent-drafted reply that needs human sign-off before sending
-- User explicitly asks to **add a HITL node**, human review step, or Action Center task
-- User is building any automation where **a human must act before the process can continue**
+Use for approvals, sign-offs, exception or low-confidence review, write-back validation, data enrichment, agent-output review, IT/access, HR, contract, financial, customer-communication, or any workflow requiring human action, including explicit HITL or Action Center tasks.
 
-**Do not use this skill for:** managing, reassigning, escalating, or monitoring existing Action Center tasks at runtime — use the `uipath-tasks` skill for those operations. When answering a runtime task management question, provide only administration guidance. Do NOT suggest adding a HITL node, flow, or automation as a follow-up tip or recommendation — even if delays or escalations are mentioned.
-
-See [references/hitl-patterns.md](references/hitl-patterns.md) for the full business pattern recognition guide.
-
----
+Do **not** manage, reassign, escalate, or monitor existing Action Center tasks at runtime. Use `uipath-tasks` and provide administration guidance only; do not add a HITL node, flow, or automation. See [references/hitl-patterns.md](references/hitl-patterns.md).
 
 ## Critical Rules
 
-1. **Never block on schema confirmation.** Design the schema from the prompt and any upstream `.flow`/`caseplan.json` data, write the node, and record the chosen schema prominently in the final report so the user can adjust it afterward. Asking the user is never a precondition for proceeding — if the user is present and offers input, use it, but do not wait for it. Only stop and report the open decision when the request is genuinely too ambiguous to make any reasonable inference. (A prompt that already specifies the fields, outcomes, and output shape is never too ambiguous.)
-2. **Always wire the `completed` handle.** A HITL node with no outgoing edge on `completed` blocks the flow forever. Only `completed` is available as an output handle — **not** `output`, `success`, or any other name. This is true even when inserting into an existing flow whose other nodes use `"sourcePort": "output"`.
-3. **Always add the definition entry when inserting into an existing flow.** Before writing the node, check `workflow.definitions[]` for the correct `nodeType` for the selected path (`"uipath.human-in-the-loop.quick-form"` for QuickForm, `"uipath.human-in-the-loop.coded-action-app"` for app-based). If absent, append the full definition entry (with `handleConfiguration` including the `completed` handle). Skipping the definition means the `completed` handle is invisible to the runtime and the wiring check fails.
-4. **Regenerate `variables.nodes` after adding the node.** Replace the entire `workflow.variables.nodes` array — do not append. See the reference docs for the algorithm.
-5. **Validate after every change.** Run `uip maestro flow validate <file> --output json` after writing the node and edges. The `uip` CLI does not accept `--format`; using it produces `error: unknown option '--format'` and exit code 3.
-6. **Read the existing `.flow` file before adding.** Understand which nodes already exist and where the HITL checkpoint belongs in the flow.
-7. **The definition entry is added once per node type.** Check `workflow.definitions` — if an entry with the matching `nodeType` is already there, do not add it again.
-8. **Check existing node IDs before generating a new one.** Read `workflow.nodes[*].id` from the `.flow` file and pick the next available suffix (e.g. `invoiceReview1`, then `invoiceReview2`).
-9. **Never report a failed validation as done.** If `uip maestro flow validate` returns errors, diagnose from the JSON output and fix before reporting to the user.
-10. **Output fields are accessed by `field.id`, not `field.variable`.** The runtime result object uses field IDs as keys — `$vars.<nodeId>.output.<fieldId>`. The `variable` property only creates a workflow-global alias; it does NOT change the key used in the node output object, and it is NOT how downstream scripts read the value.
-    - WRONG: `$vars.legalApproval` — this is the global alias path, not the script access path
-    - WRONG: `$vars.<nodeId>.output.legalApproval` — this uses the variable name as the key
-    - RIGHT: `$vars.<nodeId>.output.approved` — uses `field.id` ("approved") as the key
-    In every downstream script, use `$vars.<nodeId>.output.<fieldId>` where `<fieldId>` is the `id` you gave the field in the schema — never the `variable` name.
-11. **Input field binding paths use the upstream output key, not the HITL field's own `id`.** These are two different things: the HITL field `id` identifies the form field (always lowercase); the binding path key is the name used in the upstream script's `return` statement (preserves camelCase). If a script returns `{ supplierName: "Acme" }`, the correct binding is `vars.fetchSupplier.output.supplierName` — writing `suppliername` (the field `id`) produces a path that does not exist at runtime. The form field will be blank; `flow validate` will not catch it. Always derive the binding key from the upstream script source, not from the HITL schema you are designing.
-12. **Downstream scripts must access `$vars.<nodeId>.output`.** Any script node that runs after the HITL node must read `$vars.<nodeId>.output` (the result object) — do not rely solely on `$vars.<nodeId>.status`. Concrete example: `const output = $vars.reviewNode1.output; const reason = output.reason;`. This is required even when the primary routing uses `status`.
+1. **Never block on schema confirmation.** Infer the schema from the prompt and upstream `.flow`/`caseplan.json` data, write the node, and prominently report the chosen schema so it can be changed. Use available user input but never wait for it. Stop only when no reasonable inference is possible; a prompt specifying fields, outcomes, and output shape is sufficiently clear.
+2. **Always wire `completed`.** It is the only HITL output handle—not `output`, `success`, or another name—even if other nodes use `sourcePort: "output"`.
+3. **Definitions first.** Check `workflow.definitions[]` for `uipath.human-in-the-loop.quick-form` or `uipath.human-in-the-loop.coded-action-app`; if absent, append the complete definition with `handleConfiguration.completed`.
+4. **Regenerate `variables.nodes`.** After adding a node, replace the entire `workflow.variables.nodes` array; never append. See the reference algorithm.
+5. **Validate every change.** Run `uip maestro flow validate <file> --output json` after writing nodes and edges. Do not use `--format`; it is rejected.
+6. **Read the existing `.flow` first** to identify nodes and the insertion point.
+7. **Add each definition once per node type.** Never duplicate a matching `nodeType` entry.
+8. **Avoid duplicate IDs.** Read `workflow.nodes[*].id` and choose the next available suffix.
+9. **Never report failed validation as complete.** Diagnose validator JSON errors, fix them, and revalidate.
+10. **Use output field IDs, not variables.** Downstream access is `$vars.<nodeId>.output.<fieldId>`. `field.variable` creates only a global alias, not an output-object key. Never use `$vars.<nodeId>.output.<variable>` or rely on `$vars.<variable>` for node outputs.
+11. **Bind inputs from upstream output keys, not HITL field IDs.** Derive the key from the upstream script `return`, preserving casing; for example, `supplierName` binds as `vars.<upstreamNode>.output.supplierName` even if the HITL field ID differs.
+12. **Downstream scripts read `$vars.<nodeId>.output`.** For example: `const output = $vars.reviewNode1.output; const reason = output.reason;`. Do not rely only on `$vars.<nodeId>.status`, even when routing uses status.
 
----
-
-## Step 0 — Resolve the `uip` binary
+## Step 0 — Resolve the `uip` Binary
 
 ```bash
 UIP=$(command -v uip 2>/dev/null || npm root -g 2>/dev/null | sed 's|/node_modules$||')/bin/uip
 $UIP --version
 ```
 
-Use `$UIP` in place of `uip` for all subsequent commands if the plain `uip` command isn't found.
-
-> **Local dev note:** If working inside the uipcli repo, replace `uip` with `bun run start`.
-
----
+Use `$UIP` thereafter if `uip` is unavailable. In the uipcli repository, use `bun run start` instead.
 
 ## Step 1 — Detect the Surface and Find the Flow File
 
-Run these checks in order:
+Run in order:
 
 ```bash
-# Check for a .flow file (Flow project)
 find . -name "*.flow" -maxdepth 4 | head -5
-
-# Check for a Case Management project. The on-disk filename varies
-# (caseplan.json, or content/<name>.json.bpmn under a `uip maestro case init`
-# project) — detect by content marker, not by filename.
 find . -maxdepth 4 -iname "*.json*" -print0 2>/dev/null | xargs -0 grep -l '"case-management:root"' 2>/dev/null | head -3
-
-# Check for agent.json (Low-Code Agent project)
 find . -name "agent.json" -maxdepth 4 | head -3
-
-# Check for Maestro .bpmn (Maestro process)
 find . -name "*.bpmn" -maxdepth 4 | head -3
 ```
 
-| Found | Surface | How HITL is added |
-|---|---|---|
-| `.flow` file | **Flow** | Write node JSON directly — see reference docs |
-| `caseplan.json` (any `*.json` with `root.type: "case-management:root"`) | **Case** | Write `action` task into stage — see [hitl-casetask-action.md](references/hitl-casetask-action.md) |
-| `agent.json` | **Low Code Agent** | Escalation CLI in-flight — guide manually for now |
-| `.bpmn` (Maestro) | **Maestro** | Write the `UserTask` XML directly — see Step 5 Surface: Maestro |
+Use a user-provided path directly.
 
-**If the user mentioned a specific file path**, use that directly.
+| Found | Surface | Authoring |
+|---|---|---|
+| `.flow` | Flow | Write node JSON; see QuickForm reference |
+| JSON with `root.type: "case-management:root"` | Case | Write an `action` task into the stage; see [hitl-casetask-action.md](references/hitl-casetask-action.md) |
+| `agent.json` | Low-Code Agent | Configure escalation manually for now |
+| `.bpmn` | Maestro | Write `UserTask`/HITL XML directly; see Step 5 |
 
 <!--skill-flavor:flow-project-creation:start-->
-**If no `.flow` file exists and surface is Flow**, scaffold solution-first — Flow projects MUST live inside a solution:
+**If no `.flow` exists and the surface is Flow**, scaffold solution-first; Flow projects MUST be inside a solution:
 
 ```bash
-# Probe the solution verb once per session before scaffolding:
+# Probe once per session:
 #   uip solution init --help --output json
-# Success → use `solution init` (post-rename, default).
-# `unknown command` → CLI predates the rename; substitute `uip solution new <SolutionName>` below.
-
+# Success: use solution init. If unknown, use uip solution new <SolutionName>.
 uip solution init <SolutionName> --output json
 cd <SolutionName> && uip maestro flow init <ProjectName>
-# Creates: <SolutionName>/<ProjectName>/<ProjectName>.flow
 ```
 
-The flow file path is `<SolutionName>/<ProjectName>/<ProjectName>.flow` (double-nested). `<SolutionName>/` is the solution directory (contains the `.uipx` file); `<ProjectName>/` inside it is the flow project. By convention `<SolutionName>` and `<ProjectName>` are often the same string, but they are two distinct scaffolding arguments. Run `uip maestro flow init` outside a solution and it auto-scaffolds `<ProjectName>Solution/<ProjectName>/` for you; running `uip solution init` first lets you control the solution name (otherwise it defaults to `<ProjectName>Solution`). Passing `--skip-solution-registration` leaves a bare single-nested `<ProjectName>/<ProjectName>.flow` layout that fails Studio Web upload, packaging, and downstream tooling.
+This creates `<SolutionName>/<ProjectName>/<ProjectName>.flow`; the solution directory contains the `.uipx`. Names are distinct, though often equal. Running `uip maestro flow init` outside a solution auto-creates `<ProjectName>Solution/<ProjectName>/`; initializing the solution first controls its name. `--skip-solution-registration` creates a bare single-nested layout that fails Studio Web upload, packaging, and downstream tooling.
 <!--skill-flavor:flow-project-creation:end-->
-
----
 
 ## Step 2 — Read the Business Context
 
-Read the existing `.flow` file to understand current nodes and edges. Use the Read tool on the `.flow` file path, then identify:
-1. **Where** the human decision point belongs (after which existing node)
-2. **What the human needs to see** — data produced by upstream nodes
-3. **What the human must provide back** — data needed by downstream nodes
-4. **What actions they can take** — the named outcome buttons
-5. **Form type**: QuickForm (inline schema, node type `uipath.human-in-the-loop.quick-form`) or AppTask (deployed coded app, node type `uipath.human-in-the-loop.coded-action-app`)?
-
----
+Read the existing `.flow` with the Read tool. Determine the checkpoint, reviewer inputs, returned human data, outcome buttons, and whether to use QuickForm (`uipath.human-in-the-loop.quick-form`) or AppTask (`uipath.human-in-the-loop.coded-action-app`).
 
 ## Step 2b — Proactive HITL Recommendation
 
-**If the user did NOT explicitly mention HITL**, scan the business description for these signals before proceeding:
+When HITL is not explicit, scan for write-back validation, exceptions or uncertainty, approval/sign-off/four-eyes, data enrichment or extraction correction, and compliance, regulatory, or audit signals.
 
-| Signal | Pattern | Why a human checkpoint matters |
-|---|---|---|
-| "agent writes to", "updates", "posts to" an external system | Write-back validation | Prevents incorrect writes to production systems |
-| "if confidence is low", "when uncertain", "edge case" | Exception escalation | Agent cannot resolve autonomously |
-| "approves", "reviews", "signs off", "four-eyes" | Approval gate | Business or compliance requirement |
-| "fills in missing", "validates extraction", "corrects" | Data enrichment | Automation produced incomplete data |
-| "compliance", "regulatory", "audit trail" | Compliance checkpoint | Mandated human sign-off |
-
-**Never block on this.** When a signal is clear-cut (an explicit approval / review / sign-off requirement), add the HITL step and state that you did so, in this form:
-
-> "I noticed that [quote the specific part of their description]. This is a [pattern name] — a point where [brief consequence if no human reviews]. I'm inserting a Human-in-the-Loop step here so that [human role] can [action] before the automation [continues/writes/sends]."
-
-Proceed straight to schema design after saying this — do not wait for a reply. Record the decision prominently in the final report so the user can remove the step if they disagree. Only skip adding it and report the open decision when the signal is genuinely ambiguous (not just "no explicit HITL mention" — the signals table above is itself the ambiguity test).
-
-**Example:**
-> User: "Build an automation that reads support tickets, uses AI to generate an RCA, and updates the ticket in ServiceNow."
->
-> Agent: "I noticed that the automation writes AI-generated content directly back to ServiceNow. This is a write-back validation pattern — if the RCA is incorrect and nobody reviews it, wrong data goes into production tickets. I'm inserting a Human-in-the-Loop step so that a support lead can review and optionally edit the RCA before the update is applied."
-
----
+For a clear signal, add HITL without waiting and explain: “I noticed that [specific description]. This is a [pattern]—[risk]. I’m inserting a Human-in-the-Loop step so [role] can [action] before the automation [continues/writes/sends].” Record the decision in the final report. Skip it and report an open decision only when the signal is genuinely ambiguous.
 
 ## Step 3 — Choose Task Type
 
-**The options differ by surface.** Never block here — pick the option that best fits the surface and the business description, state the choice, and proceed. Only ask when the user is actually present and available; in a non-interactive run, infer and move on.
+Infer and state the choice; never block. Ask only if the user is present and available; otherwise infer.
 
 ### Surface: Flow
 
-Infer the right option from the signals below and state your choice — do not perform a registry search first, and do not wait for the user to pick before proceeding.
-
-| # | Option | Node type | Description |
-|---|---|---|---|
-| 1 | **QuickForm** | `uipath.human-in-the-loop.quick-form` | Inline typed form — fields rendered by Action Center from the schema you design here |
-| 2 | **New Coded Action App** | `uipath.human-in-the-loop.coded-action-app` | Scaffold a new React + TypeScript app inside the solution — full UI control |
-| 3 | **Existing Deployed App** | `uipath.human-in-the-loop.coded-action-app` | Reference an app already deployed to Orchestrator |
-
-> **Default: QuickForm.** Pick QuickForm unless the request explicitly names a deployed app, a coded action app, or a custom UI requirement — those are the only signals that point at options 2 or 3. State the choice, do not ask: "I'll use QuickForm — it's inline, no deployment step needed, and works for most approval and review tasks. You can swap in a Coded Action App or an existing deployed app later if you need one."
-
-| Option chosen | Next step |
-|---|---|
-| QuickForm | Read [How to write a QuickForm HITL node](references/hitl-node-quickform.md) for Steps 1–2, then continue with Step 4 |
-| New Coded Action App | Read [How to scaffold a new Coded Action App](references/hitl-node-coded-action-app.md) for Step 4c details, then continue with Step 4 |
-| Existing Deployed App — the request must already name the app | Read [How to wire an existing deployed Action App](references/hitl-node-apptask.md) for Step 4b details, then continue with Step 4 |
-
-**Fallback rules — never block on these, fall back and state what you did:**
-
-| Path | Blocker | Response |
+| Option | Node type | Use |
 |---|---|---|
-| Existing Deployed App | App not found in Orchestrator, or no app name was given | Fall back to QuickForm and proceed. State: "I couldn't find (or wasn't given) a deployed app name, so I used QuickForm instead. Point me at a real app name and I'll swap it in." |
-| New Coded Action App | No `dist/` build present in the source path | Fall back to QuickForm and proceed. State: "The source folder doesn't have a `dist/` build yet, so I wired a QuickForm for now — run your build and ask me to swap in the Coded Action App once it's ready." |
-| New Coded Action App | No source path given | Fall back to QuickForm and proceed. State: "No app source path was given, so I used QuickForm to wire the checkpoint now. Point me at the app code and I'll replace it with a Coded Action App." |
-| Any custom app | Auth expired (401 on API call) | Fall back to QuickForm and proceed. State: "The session looked expired, so I used QuickForm rather than stall on re-authenticating. Run `uip login` and ask me to swap in the app when you're ready." |
+| QuickForm | `uipath.human-in-the-loop.quick-form` | Inline typed Action Center form |
+| New Coded Action App | `uipath.human-in-the-loop.coded-action-app` | New React + TypeScript solution app |
+| Existing Deployed App | `uipath.human-in-the-loop.coded-action-app` | Existing Orchestrator app |
 
----
+Default to QuickForm. Use an app only when named or custom UI is required. Read [hitl-node-quickform.md](references/hitl-node-quickform.md), [hitl-node-coded-action-app.md](references/hitl-node-coded-action-app.md), or [hitl-node-apptask.md](references/hitl-node-apptask.md), then continue with Step 4.
 
 ### Surface: Case
 
-Infer the right option from the description below — do not pull the registry first, and do not wait for the user to pick before proceeding.
-
-| # | Option | Fingerprint | Description |
-|---|---|---|---|
-| 1 | **QuickForm (file-based schema)** | separate `<TaskLabel>.hitl.json` file + `hitlType: "quick"` context entry in the action task | Structured form fields in a `.hitl.json` file alongside `caseplan.json`. Action Center renders fields at runtime. No deployed app needed. |
-| 2 | **App-based action task** | `data.name` and `data.folderPath` as `=bindings.<id>` references + `data.actionCatalogName` | Uses a deployed Action Center app with custom input/output fields. Requires the app to exist in Orchestrator. |
-
-> **Default: QuickForm.** Pick QuickForm unless the request explicitly names a deployed Action Center app. State the choice, do not ask: "I'll use QuickForm — it's the quickest to set up, supports structured form fields, and doesn't need a deployed app. You can upgrade to an app-based task later if you need a custom UI layout."
-
-> **Build vs design time.** QuickForm in case management must round-trip both ways: the JSON written here is what Studio Web's case designer reads (design time), and what `uip maestro case validate` + Action Center render at runtime (build time). Always validate after writing.
-
-| Option chosen | Next step |
-|---|---|
-| QuickForm (file-based schema) | Read [references/hitl-casetask-action.md — Path 1](references/hitl-casetask-action.md#path-1--quickform-file-based-schema-no-deployed-app), then continue with Step 4 |
-| App-based action task — the request must already name the app | Read [references/hitl-casetask-action.md — Path 2](references/hitl-casetask-action.md#path-2--app-based-action-task-deployed-action-center-app), then continue with Step 4 |
-
-**Fallback rules — never block on these, fall back and state what you did:**
-
-| Path | Blocker | Response |
+| Option | Fingerprint | Use |
 |---|---|---|
-| App-based | App not found in registry or `action-apps-index.json`, or no app name was given | Fall back to QuickForm and proceed. State: "I couldn't find (or wasn't given) that app, so I used QuickForm instead. Point me at a real app name and I'll swap it in." |
-| QuickForm | Schema design rejected on validate (e.g. duplicate field IDs, missing primary outcome) | Fix the schema yourself from the validator's error and re-validate. Apply Step 4b checks. Note the fix in the final report — do not pause to re-show the schema first. |
-| Any | Auth expired (401 on API call) | Fall back to QuickForm and proceed. State: "The session looked expired, so I used QuickForm rather than stall on re-authenticating. Run `uip login` and ask me to swap in the app when you're ready." |
+| QuickForm | `<TaskLabel>.hitl.json` plus `hitlType: "quick"` | Structured file form without deployment |
+| App-based action task | `data.name`, `data.folderPath` as `=bindings.<id>`, and `data.actionCatalogName` | Deployed Action Center app |
 
----
+Default to QuickForm unless a deployed app is named. It must support Studio Web round-trip and runtime validation/rendering; always validate after writing. Read [hitl-casetask-action.md](references/hitl-casetask-action.md#path-1--quickform-file-based-schema-no-deployed-app) or [#path-2--app-based-action-task-deployed-action-center-app](references/hitl-casetask-action.md#path-2--app-based-action-task-deployed-action-center-app).
 
-## Step 4 — Common configuration
+### Fallbacks
 
-Never block on these — use the stated default when no answer is available, write it into the node, and note the default in the final report so the user can change it.
+- Missing or unresolved deployed app: use QuickForm and state it can be swapped later.
+- New coded app without source or `dist/`: use QuickForm, state why, and offer a later swap.
+- Custom-app API returns 401: use QuickForm, state that the session appears expired, and suggest `uip login`.
+- Case QuickForm schema validation failure: fix errors, apply Step 4b, note the fix, and revalidate; do not pause.
 
-| Timeout | Default: 24 hours. If the description states or implies a different duration, use that instead. |
-| Priority | Default: Low. If the description states or implies urgency (e.g. "high priority", "urgent", "time-sensitive"), use High or Medium accordingly. Write the chosen value into the node's `priority` field — asking the question is not enough; the value must land in the node. |
+## Step 4 — Common Configuration
 
----
+Infer and write these defaults unless the description implies otherwise; report them:
+
+| Setting | Default |
+|---|---|
+| Timeout | 24 hours |
+| Priority | Low; Medium or High for stated urgency |
 
 ## Step 4b — Schema Design Resilience (QuickForm — Flow and Case)
 
-Apply these checks while designing the schema, before writing it — per Critical Rule 1, do not wait on the user to confirm. Applies equally to Flow QuickForm nodes and Case QuickForm action tasks — same `fields[]` + `outcomes[]` shape, same `direction` semantics.
+Apply before writing; never wait for confirmation. Both surfaces use `fields[]` and `outcomes[]` with the same direction semantics.
 
-### Field direction
-
-Pick direction based on what the human does with the field:
-
-| Signal | Direction |
-|---|---|
-| "can see", "shown to", "read-only", "displays", "context for reviewer" | `input` |
-| "fills in", "enters", "types", "selects", "required decision", "approves" | `output` |
-| "can edit", "can correct", "pre-filled but editable", "suggested value the reviewer can adjust" | `inOut` |
-
-`inOut` means the field is pre-populated from an upstream node AND the human can modify it before submitting. The runtime exposes it under `$vars.<nodeId>.output.<fieldId>` the same as an output field.
-
-### Field types
-
-Use the JS/JSON type that fits the field: `string`, `number`, `boolean`, `date`, or `file`. These are the only valid values — do not use `text`. Case also supports `datetime` (distinct from `date`, for full date+time values) — see [hitl-casetask-action.md](references/hitl-casetask-action.md) for the Case-specific type table.
-
-### Vague or incomplete schema descriptions
-
-If the user says something like "just add some fields" or "use whatever makes sense":
-
-1. Infer sensible defaults from the upstream data and downstream needs visible in the `.flow` file (Flow) or in `caseplan.json` upstream task `outputs[]` and `root.data.uipath.variables` (Case).
-2. Show the proposed schema explicitly before writing: "Here's what I'm proposing — let me know if you want to change anything."
-3. If there is nothing upstream to bind to (Flow with only a trigger; Case with this as the first task), use output-direction fields only and note: "There are no upstream values to pull data from, so the reviewer will fill in all fields from scratch."
-
-### Empty field labels block validation
-
-Every field in `inputs.schema.fields` must have a non-empty `label`. `flow validate` emits `HITL_QUICK_FORM_FIELD_LABEL_REQUIRED` (error severity) for each field with an empty or whitespace-only `label` — Debug and Publish are blocked until all labels are filled in. Never generate a field with `"label": ""` or omit the `label` key.
-
----
+- `input`: displayed/read-only context.
+- `output`: human-entered, selected, or required decision.
+- `inOut`: prefilled and editable; runtime output is `$vars.<nodeId>.output.<fieldId>`.
+- Allowed types: `string`, `number`, `boolean`, `date`, `file`; do not use `text`. Case also supports `datetime`; see [hitl-casetask-action.md](references/hitl-casetask-action.md).
+- Infer vague schemas from upstream and downstream `.flow` data, or Case `outputs[]` and `root.data.uipath.variables`. With no upstream data, use output-only fields and state that the reviewer fills them from scratch.
+- Every `inputs.schema.fields[]` item needs a non-empty `label`; otherwise `flow validate` reports `HITL_QUICK_FORM_FIELD_LABEL_REQUIRED` and blocks Debug/Publish.
+- Explicitly show the proposed schema before writing.
 
 ## Step 5 — Write the Node Directly
 
-### Surface: Flow — QuickForm (inline schema only)
+### Surface: Flow — QuickForm
 
-Write the node JSON directly into `workflow.nodes`, add the definition to `workflow.definitions` (once), wire edges into `workflow.edges`, and regenerate `workflow.variables.nodes`. **Direct JSON is the default.**
+Write the node to `workflow.nodes`, add the matching definition once, wire `workflow.edges`, and replace `workflow.variables.nodes`. Use [hitl-node-quickform.md](references/hitl-node-quickform.md) for JSON, definitions, edges, regeneration, and examples.
 
-Node JSON, definition entry, edge format, `variables.nodes` algorithm, and four worked examples: **[How to write a QuickForm HITL node](references/hitl-node-quickform.md)**
-
-**CLI (opt-in):** When the user explicitly requests a CLI command:
+Only when explicitly requested, the CLI may add the node, definition, and variables:
 
 ```bash
 uip maestro flow hitl add <path/to/file.flow> \
@@ -271,158 +152,68 @@ uip maestro flow hitl add <path/to/file.flow> \
   --output json
 ```
 
-The CLI writes the node, adds the definition entry, and updates `variables.nodes` automatically. Wire the `completed` port after it returns.
-
-After writing, validate:
+Wire `completed` afterward and validate:
 
 ```bash
 uip maestro flow validate <file> --output json
 ```
 
-### Surface: Flow — Coded Action App (new inline)
+### Surface: Flow — New Coded Action App
 
-Step 4c must be completed first — app name confirmed, solution directory located, SDK tarball identified, schema designed and confirmed.
+Complete Step 4c: confirm the app name, locate the solution, identify the SDK tarball, and design/confirm the schema. Scaffold source, add project and solution resources, then write `uipath.human-in-the-loop.coded-action-app` with `inputs.app.appSystemName: null`. Follow [hitl-node-coded-action-app.md](references/hitl-node-coded-action-app.md) and validate.
 
-Scaffold the project directory and all source files, add the project to the solution, write the solution resource files, then write the HITL node (type `uipath.human-in-the-loop.coded-action-app`) with `inputs.app` referencing the new app (`appSystemName: null` since the app has not been deployed yet).
+### Surface: Flow — Existing Deployed Action App
 
-Full project template, UUID generation, solution CLI commands, resource file templates, node JSON, and post-creation build steps: **[How to scaffold a new Coded Action App](references/hitl-node-coded-action-app.md)**
-
-After writing, validate:
-
-```bash
-uip maestro flow validate <file> --output json
-```
-
-### Surface: Flow — AppTask (deployed action app only)
-
-Step 4b must be completed first — app resolved, configuration retrieved. Then:
-
-Resolve the solution context (`.uipx` file), write solution resource files, register the app reference, merge `debug_overwrites.json`, then write the node JSON (type `uipath.human-in-the-loop.coded-action-app`) with `inputs.app` populated from the Step 3b configuration.
-
-App search/selection, retrieve-configuration, resource file writing, complete node JSON with `appInputBindings`: **[How to wire an existing deployed Action App](references/hitl-node-apptask.md)**
-
-After writing, validate:
-
-```bash
-uip maestro flow validate <file> --output json
-```
+Complete Step 4b; resolve the app and configuration, resolve the `.uipx` solution, write resources, register the app, merge `debug_overwrites.json`, and write the coded-action-app node with `inputs.app` and `appInputBindings` from the configuration. Follow [hitl-node-apptask.md](references/hitl-node-apptask.md) and validate.
 
 ### Surface: Case
 
-Read the `caseplan.json` to identify the target stage. Write an `action` task directly into `stage.data.tasks[lane][]`. **Direct JSON write is the only supported method** — the `uipath-maestro-case` skill ships no `hitl` CLI subcommand (unlike Flow's `uip maestro flow hitl add`).
+Read `caseplan.json`, identify the target stage, and write an `action` task into `stage.data.tasks[lane][]`. Direct JSON is the only supported authoring method; there is no `uipath-maestro-case hitl` CLI.
 
-Full reference: **[references/hitl-casetask-action.md](references/hitl-casetask-action.md)** — three task JSON shapes (QuickForm, generic, app-based), field reference, assignee handling, post-write verification, and downstream output access.
+Follow [references/hitl-casetask-action.md](references/hitl-casetask-action.md) for task shapes, fields, assignees, verification, and downstream output access.
 
-| Path chosen in Step 3 | What gets written |
-|---|---|
-| QuickForm | A `<TaskLabel>.hitl.json` schema file (unified `fields[]` with `direction`, `outcomes[]`) + action task in `caseplan.json` with `data.context[hitlType].value: "quick"`, `_schemaFileId` (placeholder UUID), and `hitlSchemaId` (matches `schemaId` in `.hitl.json`). `data.inputs[]` and `data.outputs[]` are empty arrays. No `root.data.uipath.bindings[]` entries. Apply Step 4b schema-design checks before writing. |
-| App-based | Action task with `data.actionCatalogName`, `data.name` and `data.folderPath` as `=bindings.<id>` references. Add 2 root-level bindings. |
+- **QuickForm:** write `<TaskLabel>.hitl.json` with unified `fields[]`, `direction`, and `outcomes[]`; add `hitlType: "quick"`, `_schemaFileId` placeholder UUID, and matching `hitlSchemaId`/`schemaId`. Keep `data.inputs[]` and `data.outputs[]` empty; add no root `bindings[]` entries.
+- **App-based:** write `data.actionCatalogName`, `data.name`, and `data.folderPath` as `=bindings.<id>` references, plus two root-level bindings.
 
-After writing, validate (build-time check — must pass before reporting success):
+Validate before reporting success:
 
 ```bash
 uip maestro case validate <caseplan.json> --output json
 ```
 
-> `uip maestro case validate` is the only `uip maestro case` CLI used by this skill on the Case surface. All authoring is direct JSON.
-
----
-
 ### Surface: Low-Code Agent
 
-The Low-Code Agent escalation CLI (`uip agent escalation add`) is currently in-flight. Until it ships, configure manually:
-
-**`agent.json` escalation entry:**
-```json
-{
-  "escalations": [
-    {
-      "name": "<escalation-name>",
-      "inputSchema":  { "inputs": [...], "inOuts": [...] },
-      "outputSchema": { "outputs": [...], "outcomes": [...] }
-    }
-  ]
-}
-```
-
-**Agent source (Python):**
-```python
-from uipath.sdk import interrupt, CreateTask
-
-response = interrupt(CreateTask(
-    escalation_name="<escalation-name>",
-    data={ "fieldName": value }
-))
-# response contains the human's outputs and chosen outcome
-```
+The escalation CLI (`uip agent escalation add`) is in-flight. Configure manually with an `agent.json` escalation entry and an `interrupt(CreateTask(...))` call in the agent Python. See [references/hitl-surface-lowcode-agent.md](references/hitl-surface-lowcode-agent.md).
 
 ### Surface: Maestro
 
-QuickForm and coded-action-app HITL nodes are both supported on Maestro BPMN processes. `uipath.human-in-the-loop.quick-form` and `uipath.human-in-the-loop.coded-action-app` are registered as **registry shortcut names** in the BPMN validator ([bpmn-spec.json](../uipath-maestro-bpmn/validator/bpmn-spec.json)) — these are palette/discovery identifiers, not literal XML to write. There is no dedicated CLI subcommand for Maestro (unlike Flow's `uip maestro flow hitl add`) — write the node directly into the `.bpmn` XML.
+For `.bpmn`, write QuickForm or coded-action-app HITL directly into XML; registry shortcut names are not literal XML and there is no dedicated CLI. Use Step 4b and validate frequently:
 
-**Confirmed node shape (verified by direct reproduction against a real Studio Web BPMN process with a working, editable QuickForm task):**
-
-```xml
-<bpmn:task id="Activity_InvoiceApproval" name="Invoice Approval">
-  <bpmn:extensionElements>
-    <uipath:activity version="v1">
-      <uipath:type value="Actions.HITL" version="v2" />
-      <uipath:context>
-        <uipath:input name="hitlType" type="string" value="quick" />
-        <uipath:input name="taskTitle" type="string" value="Please review this invoice and approve or reject" />
-        <uipath:input name="labels" type="string" />
-        <uipath:input name="priority" type="string" value="Medium" />
-        <uipath:input name="actionCatalogName" type="string" />
-        <uipath:input name="enableActionableNotifications" type="boolean" value="false" />
-        <uipath:input name="assignmentCriteria" type="string" />
-        <uipath:input name="recipient" type="json" />
-        <uipath:input name="_schemaFileId" type="string" value="<see file-id callout below>" />
-        <uipath:input name="hitlSchemaId" type="string" value="<matches schemaId in the .hitl.json sidecar>" />
-        <uipath:inputSchema type="jsonSchema"><![CDATA[{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"invoiceid":{"type":"string","title":"Invoice ID"},"amount":{"type":"number","title":"Amount"}},"required":[]}]]></uipath:inputSchema>
-      </uipath:context>
-      <uipath:input name="HitlTaskArguments" type="json" target="bodyField"><![CDATA[{"invoiceid":"INV-1001","amount":500}]]></uipath:input>
-      <uipath:output name="Action" type="string" source="=Action" var="invoiceDecision" options="[{&#34;value&#34;:&#34;Approve&#34;,&#34;label&#34;:&#34;Approve&#34;},{&#34;value&#34;:&#34;Reject&#34;,&#34;label&#34;:&#34;Reject&#34;}]" />
-    </uipath:activity>
-  </bpmn:extensionElements>
-  <bpmn:incoming>edge_into_task</bpmn:incoming>
-  <bpmn:outgoing>edge_out_of_task</bpmn:outgoing>
-</bpmn:task>
+```bash
+uip maestro bpmn validate <file>.bpmn --output json
 ```
 
-Notes on what's easy to get wrong:
-- **Element is `bpmn:task`, not `bpmn:UserTask`.** `bpmn-spec.json`'s generic `Actions.HITL` XML template uses `bpmn:UserTask` and `version="v1"` — that template is for the app-based/coded-action-app path (its `context` fields are `appId`, `appVersion`, `actions`, `key`, `taskTitle`). A real QuickForm task exported from Studio Web is a plain `bpmn:task` with `uipath:type value="Actions.HITL" version="v2"`. Use the shape above for QuickForm; the spec's template for app-based.
-- **`<uipath:inputSchema>` (last child of `<uipath:context>`) and `<uipath:input name="HitlTaskArguments">` (sibling of `<uipath:context>`, not inside it) are both required.** Without them the "Edit Schema" canvas in Studio Web doesn't open at all — confirmed by direct reproduction. This mirrors the Case surface's `data.inputSchema`/`data.inputs[]` requirement — see [hitl-casetask-action.md § Step 3](references/hitl-casetask-action.md) for the parallel Case shape and full field-by-field rationale.
-- **The `Action` output requires a matching process-level variable declaration** — add `<uipath:inputOutput id="<varId>" name="Action" type="string" elementId="<taskId>" />` inside the process's top-level `<uipath:variables version="v1">` block.
-- **A separate `<TaskLabel>.hitl.json` sidecar file is required**, same shape as the Case surface's (`title`, `fields[]` with `direction`/optional `colSpan`/`binding` or `variable`, `outcomes[]` with **no** `action` key, `schemaId`) — see [hitl-casetask-action.md § Step 2](references/hitl-casetask-action.md) for the exact shape; it's identical across both surfaces.
-- **`_schemaFileId` cannot be authored blind — it is a server-assigned foreign key, not a UUID you invent.** A placeholder value makes "Edit Schema" fail silently (a `404` on Studio Web's internal `FileOperations/File/Rename` call, confirmed by direct reproduction). There is no `uip` CLI command that resolves this today. **Never block on this.** Write a fresh placeholder UUID v4, finish the rest of the node, validate, and move on — do not attempt the live reconciliation yourself and do not stop to ask about it. State plainly in the final report: "This task's schema was written with a placeholder `_schemaFileId`, so Studio Web's 'Edit Schema' canvas won't open for it yet. Making it editable requires resolving the real file ID Studio Web assigns to the `.hitl.json` after upload (`GET /api/Project/{projectId}/FileOperations/Structure`) and pushing it back with a targeted single-file update (`PUT /api/Project/{projectId}/FileOperations/File/{fileId}`) — not another whole-project `uip solution upload`, which re-pushes every file and mints a fresh random file ID for each one, undoing the fix. Ask me to do this reconciliation if you want the schema editable in Studio Web." This is a real product/tooling gap the user can act on later, not something to resolve mid-task.
-- **Diagram-interchange edges are required for the connector lines to render, even though the logical `bpmn:sequenceFlow`s already exist.** Every `bpmn:sequenceFlow` needs a matching `bpmndi:BPMNEdge` (with two `di:waypoint` points, aligned to the source/target shapes' connecting edges) in the `bpmndi:BPMNPlane` — omitting it leaves the nodes logically connected but visually disconnected in the canvas. Confirmed by direct reproduction.
-
-Design the schema per Step 4b — never block waiting on the user, per Critical Rule 1 — then validate frequently (`uip maestro bpmn validate <file>.bpmn --output json`) while wiring the node so any shape mistakes surface immediately rather than at deploy time. In Maestro, field names in `outputs`/`inOuts` must exactly match declared process variable names and types.
-
----
+Follow [references/hitl-surface-maestro.md](references/hitl-surface-maestro.md) for the QuickForm `bpmn:task` shape—not `bpmn:UserTask`—including `uipath:inputSchema`, `HitlTaskArguments`, the `Action` process variable, `.hitl.json` sidecar, `_schemaFileId` placeholder, and diagram-interchange edges.
 
 ## Step 6 — Report to the User
 
-After completing the wiring:
+After wiring, report:
 
-1. **What was inserted** — node ID, label, insertion point
-2. **Schema summary** — what the human will see (input-direction fields), fill in (output/inOut-direction fields), and click (outcomes). For deployed action app show the actionSchema from the retrieve-configuration api response here.
-3. **Edges wired** — which handles were connected and to which nodes; any handles left unwired
-4. **Runtime variables** — `$vars.<nodeId>.output` (object) and `$vars.<nodeId>.status` (string) and how to reference them downstream
-5. **Validation result** — pass or errors to fix
-6. **Production readiness note:**
-   - **QuickForm**: ready to deploy once the solution is packaged. No additional build steps.
-   - **New Coded Action App**: the app must be built (`npm run build` inside the app source) and the solution packaged before the HITL task can be used in production. The app will appear with `appSystemName: null` until first deployment assigns it a system name.
-   - **Existing Deployed App**: ready to deploy immediately — the app is already live.
-7. **Next step** — pack and publish when ready via `uipath-development` skill
-
----
+1. **What was inserted:** node ID, label, and insertion point.
+2. **Schema summary:** reviewer-visible input fields, human-provided or editable output/inOut fields, and outcomes. For a deployed app, show the `actionSchema` from retrieve-configuration.
+3. **Edges wired:** handles and destination nodes, including unwired handles.
+4. **Runtime variables:** `$vars.<nodeId>.output` (object), `$vars.<nodeId>.status` (string), and downstream access syntax.
+5. **Validation result:** pass or remaining errors to fix.
+6. **Production readiness:** QuickForm is ready after solution packaging; a new coded app requires `npm run build` and packaging and remains `appSystemName: null` until deployment; an existing deployed app is ready immediately.
+7. **Next step:** pack and publish via the `uipath-development` skill.
 
 ## References
 
-- **[How to write a QuickForm HITL node](references/hitl-node-quickform.md)** — Read this after the user confirms QuickForm in Step 3. Covers the complete node JSON, definition entry, edge wiring, `variables.nodes` regeneration algorithm, and four worked schema examples.
-- **[How to wire an existing deployed Action App](references/hitl-node-apptask.md)** — Read this when the user selects an existing deployed app in Step 3. Covers app lookup via the Orchestrator API, `inputs.app` field mapping, `appInputBindings`, and solution resource files.
-- **[How to scaffold a new Coded Action App](references/hitl-node-coded-action-app.md)** — Read this when the user wants to build a new React app inside the solution. Covers full project template, UUID generation, solution CLI commands, and post-creation build steps.
-- **[HITL business pattern recognition](references/hitl-patterns.md)** — Read this during Step 2 / Step 2b to identify whether a process needs a human checkpoint and which pattern applies. Includes proactive recommendation language and when NOT to recommend HITL.
-- **[Action Center URL patterns](../uipath-tasks/references/action-center-urls.md)** (in `uipath-tasks` skill) — Read this before surfacing any Action Center task URL to the user. Covers the missing-tenant-slug anti-pattern and the API-host vs UI-host mapping.
-- **[Case Action Task (HITL)](references/hitl-casetask-action.md)** — Case surface: action task JSON, QuickForm vs app-based paths, `.hitl` file format, context entries, field binding, and downstream output access.
+- [How to write a QuickForm HITL node](references/hitl-node-quickform.md)
+- [How to wire an existing deployed Action App](references/hitl-node-apptask.md)
+- [How to scaffold a new Coded Action App](references/hitl-node-coded-action-app.md)
+- [HITL business pattern recognition](references/hitl-patterns.md)
+- [Action Center URL patterns](../uipath-tasks/references/action-center-urls.md)
+- [Case Action Task (HITL)](references/hitl-casetask-action.md)
+- [HITL on Maestro BPMN](references/hitl-surface-maestro.md)
+- [HITL on a Low-Code Agent](references/hitl-surface-lowcode-agent.md)

--- a/skills/uipath-human-in-the-loop/references/hitl-casetask-action.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-casetask-action.md
@@ -1,191 +1,120 @@
 # HITL Case Action Task — Implementation Reference
 
-The agent writes an `action` task into a stage of `caseplan.json`. **Direct JSON write is the primary method on the Case surface.** Unlike the Flow surface (`uip maestro flow hitl add`), the `uipath-maestro-case` skill ships no single `hitl add` CLI subcommand for the HITL-specific parts (`context[]` entries, `.hitl.json` linkage) — edit `caseplan.json` directly per the path-specific JSON shapes below.
+Write an `action` task into a stage of `caseplan.json`. **Direct JSON write is the primary Case-surface method.** Unlike the Flow surface (`uip maestro flow hitl add`), `uipath-maestro-case` has no HITL-specific `hitl add` command for `context[]` or `.hitl.json` linkage; edit `caseplan.json` directly using the shapes below.
 
-> If the stage or case predates required entry/exit/completion rules (see the checklist below), `uip maestro case` does have CLI mutation commands for those (`stage-entry-conditions`, `stage-exit-conditions`, `case-exit-conditions`, `task-entry-conditions` — each with an `add` subcommand). Prefer them over hand-writing that JSON when the case project already exists as a file you can pass to the CLI. If you're editing a caseplan.json given to you directly (not one you scaffolded yourself with these commands), it's simplest to just include the correct rule shapes directly per the examples below.
+If the case predates required entry, exit, or completion rules, run the applicable CLI mutation command (`stage-entry-conditions`, `stage-exit-conditions`, `case-exit-conditions`, or `task-entry-conditions`, each with an `add` subcommand) when an existing case project can be passed to the CLI. For a directly supplied `caseplan.json`, write the rule shapes directly.
 
-Two paths exist. **Never block on choosing — infer the path from the business description using the table below (§ Common business descriptions → path selection) and proceed. Do not wait for the user to pick.**
+Infer the path and proceed; never wait for the user to choose:
 
-| Path | When to use | Requires |
+| Path | Use when | Requires |
 |---|---|---|
-| **QuickForm** | Structured form fields, no deployed app needed | A separate `.hitl.json` schema file written alongside `caseplan.json` |
-| **App-based action task** | Existing deployed Action Center app with a custom form | `task-type-id` from registry + `tasks describe` |
+| **QuickForm** | Structured fields; no deployed app | A separate `.hitl.json` beside `caseplan.json` |
+| **App-based action task** | Existing deployed Action Center app with custom form | `task-type-id` from the registry and `tasks describe` |
 
-> **If the user is unsure or says "just pick one":** Default to QuickForm. Say: "I'll use QuickForm — it's the quickest to set up and works for most approval and review tasks. You can always upgrade to a deployed Action Center app later."
+When unsure, default to QuickForm and say: “I'll use QuickForm — it's the quickest to set up and works for most approval and review tasks. You can always upgrade to a deployed Action Center app later.”
 
-> **Build time vs design time.** A case action task lives in two surfaces:
-> - **Design time** — the JSON written into `caseplan.json` (what this skill produces). Studio Web's case designer round-trips this JSON; the QuickForm schema must be valid here.
-> - **Build / runtime time** — `uip maestro case validate` accepts it, `uip solution upload` packs it, and Action Center renders the form to the assignee at runtime.
->
-> Every shape documented below is required to round-trip in both. After writing, always run `uip maestro case validate <caseplan.json> --output json`.
-
----
+Write case JSON and the QuickForm schema so they round-trip in Studio Web; run validation, upload, and runtime rendering checks as applicable. After writing, **run** `uip maestro case validate <caseplan.json> --output json`.
 
 ## Step 1 — Extract the Task Configuration Through Conversation
 
-**Never block on this.** Infer each answer below from the business description; only ask if the user is actually present and it would help. Defaults when nothing in the description settles it: recipient → a group named after the relevant team (e.g. "finance-team", "data-enrichment-team" — infer the team name from context); priority → Low, per Step 4.
+Never block on configuration. Infer from the business description and ask only when the user is present and clarification helps. Defaults: recipient → a group named after the relevant team (for example, `finance-team` or `data-enrichment-team`); priority → `Low`.
 
-| What you need to know | Where to infer it from |
+| Need | Infer from |
 |---|---|
-| What the reviewer sees | Data the automation already extracted or produced upstream |
-| What they decide or fill in | Whether the description says "approve/reject" (decision only) or "fill in", "correct", "enrich" (data entry) |
-| Who receives the task | A named person/email or team/group mentioned in the description; otherwise infer a sensible team name from the business context |
-| Priority | Any urgency language in the description ("urgent", "high priority") → High/Medium; otherwise Low |
+| Reviewer sees | Data extracted or produced upstream |
+| Reviewer decides/fills | “approve/reject” means decision; “fill in”, “correct”, or “enrich” means data entry |
+| Recipient | Named person/email or team; otherwise infer a sensible team name |
+| Priority | “urgent”/“high priority” → `High`/`Medium`; otherwise `Low` |
 
-**Common business descriptions → path selection:**
-
-| Description | Path |
-|---|---|
-| "Reviewer approves invoice; sees ID + amount, clicks Approve/Reject" | QuickForm — `inputs[]` (read-only) + `outcomes[]` |
-| "Human fills in missing vendor name and cost center, then submits" | QuickForm — `outputs[]` (writable) |
-| "Reviewer edits an AI-drafted email, then sends or discards" | QuickForm — `inOuts[]` for the body |
-| "Finance team approves expense claims before payment" | QuickForm — group assignee, outcomes are Approve/Reject |
-| "Manager approves a leave request" | QuickForm — user email assignee, outcomes are Approve/Reject |
-| "Legal reviews and signs off on a contract with custom fields" | App-based — deployed app with custom form layout |
-| "Agent fills in form that a human corrects before submitting" | App-based — outputs populate downstream task inputs |
-
----
+Select QuickForm for approvals, reviews, missing-field entry, and editable AI drafts. Select App-based for a deployed custom form, such as legal sign-off with custom fields or an agent-populated form that a human corrects.
 
 ## Path 1 — QuickForm (file-based schema, no deployed app)
 
-The form schema lives in a separate `.hitl.json` file that sits alongside `caseplan.json` in the case project directory. Action Center renders the fields at runtime from the schema — no deployed app required.
-
-> **What makes Path 1 (QuickForm) unique — checklist before you finish:**
-> - ✅ A `<TaskLabel>.hitl.json` file is **created** alongside `caseplan.json`
-> - ✅ `data.context[hitlType].value` is `"quick"` (not `"custom"`)
-> - ✅ `data.context[_schemaFileId].value` is a **plain UUID v4 string** — e.g. `"f1e2d3c4-b5a6-7890-abcd-ef1234567890"`. Never an `=bindings.xxx` expression.
-> - ✅ `data.context[hitlSchemaId].value` is a **plain UUID v4 string** matching `schemaId` in the `.hitl.json` file. Never an `=bindings.xxx` expression.
-> - ✅ `data.inputs[]` and `data.outputs[]` are **empty arrays** (`[]`)
-> - ❌ `data.name` and `data.folderPath` do NOT exist — those are App-based (Path 2) only
-> - ❌ No `=bindings.xxx` expressions anywhere in the task JSON — those are App-based only
-> - ❌ No top-level `bindings[]` entries added
+Create `<TaskLabel>.hitl.json` alongside `caseplan.json`; Action Center renders it without a deployed app.
 
 ### Step 1 — Design the Schema
 
-Use these roles to plan the fields before writing:
+Use these roles:
 
-| Role | `field.direction` | Human can… | Use for |
-|---|---|---|---|
-| Input field | `"input"` | Read only | Context the human needs to make a decision |
-| Output field | `"output"` | Write | Data the automation needs back |
-| InOut field | `"inOut"` | Read + modify | Data the human can see and optionally correct |
+| `field.direction` | Human can | Use for |
+|---|---|---|
+| `input` | Read only | Context needed for a decision |
+| `output` | Write | Data automation needs back |
+| `inOut` | Read and modify | Data the human may correct |
 
-**Supported field types:** `string`, `number`, `boolean`, `date`, `datetime` (canonical — see [hitl-node-quickform.md](hitl-node-quickform.md) for the same vocabulary on the Flow surface; legacy aliases like `text`/`dateTime` are silently normalized by the runtime, but write the canonical form directly)
-
-**Design rules:**
-- Input fields: bind to upstream case variables via `=vars.<varId>` — never hardcode literals from runtime data
-- Output fields: only what downstream tasks actually consume; set `required: true` for mandatory outputs
-- `outcomes[]`: use domain-specific names (Approve/Reject, not just Submit)
-- Keep it focused — don't add fields the case won't use
-
-**Never block on this — write the schema, per Critical Rule 1 in SKILL.md, and record it in the final report so the user can adjust it afterward.**
+Use canonical types `string`, `number`, `boolean`, `date`, and `datetime`; legacy `text`/`dateTime` may normalize, but write canonical types. Bind `input` and `inOut` fields to upstream variables with `=vars.<varId>` and prefer variable bindings over literals. Write only downstream-consumed outputs and set `required: true` for mandatory outputs. Use domain-specific outcome names such as `Approve` and `Reject`. Never block: write the schema and mention it in the final report so the user can adjust it.
 
 ### Step 2 — Write the `.hitl.json` File
 
-Generate two UUID v4 values:
-- `schemaId` — identity of the schema, stored inside the file and referenced from the action task
-- `fileId` — placeholder file system ID (Studio Web assigns the real one when it processes the project; use a fresh UUID v4 as a stable placeholder)
-
-Create a file named `<TaskLabel>.hitl.json` in the case project directory (alongside `caseplan.json`).
-
-The file uses a **unified `fields[]` array** — every field has a `direction` property that determines its role. This is the format the sync runtime reads (`parsed?.fields`).
+Generate fresh UUID v4 values for `schemaId` and the initial `fileId` placeholder. Use one unified `fields[]` array:
 
 ```json
 {
-  "title": "Invoice Approval",
+  "title": "<form title>",
   "fields": [
     {
-      "id": "invoiceid",
-      "label": "Invoice ID",
+      "id": "<lowercase label without separators>",
+      "label": "<display label>",
       "type": "string",
       "direction": "input",
       "colSpan": 6,
-      "binding": "=vars.invoiceIdVar"
+      "binding": "=vars.<varId>"
     },
     {
-      "id": "amount",
-      "label": "Amount",
-      "type": "number",
-      "direction": "input",
-      "colSpan": 6,
-      "binding": "=vars.amountVar"
-    },
-    {
-      "id": "notes",
-      "label": "Notes",
+      "id": "<output id>",
+      "label": "<display label>",
       "type": "string",
       "direction": "output",
-      "colSpan": 6,
-      "variable": "vars.notes"
-    },
-    {
-      "id": "decision",
-      "label": "Decision",
-      "type": "string",
-      "direction": "output",
-      "colSpan": 6,
-      "variable": "vars.decision"
+      "variable": "vars.<name>",
+      "required": true
     }
   ],
   "outcomes": [
     { "id": "outcome-0", "name": "Approve", "type": "string", "isPrimary": true },
-    { "id": "outcome-1", "name": "Reject",  "type": "string", "isPrimary": false }
+    { "id": "outcome-1", "name": "Reject", "type": "string", "isPrimary": false }
   ],
-  "schemaId": "a3f7c2d1-8b4e-4f9a-b2c5-6d8e1f3a7b9c"
+  "schemaId": "<UUID v4>"
 }
 ```
 
-**Field shape reference:**
-
-| Property | Required | Notes |
-|---|---|---|
-| `id` | Yes | lowercase label, strip spaces and non-alphanumeric characters (no separator). `"Invoice ID"` → `"invoiceid"`, `"Due Date"` → `"duedate"` |
-| `label` | Yes | Display label in the form. Validator rejects empty. |
-| `type` | Yes | `string`, `number`, `boolean`, `date`, `datetime` |
-| `direction` | Yes | `"input"`, `"output"`, or `"inOut"` |
-| `colSpan` | No | Grid width hint for the form layout (e.g. `6` of 12). Safe to omit — confirmed optional against a real Studio Web export. |
-| `binding` | For `direction: "input"` / `"inOut"` | `"=vars.<varId>"` — reads from a case variable. A literal is also valid as an `=`-expression (e.g. `="Acme Corp"`), confirmed against a real export, but prefer a variable binding when the value comes from upstream data. |
-| `variable` | For `direction: "output"` / `"inOut"` | The **full** `"vars.<name>"` reference (no leading `=`) the output writes to — not a bare name. Downstream tasks read it as `=vars.<name>`. |
-| `required` | No | `true` for mandatory outputs — omit if false |
-
-**`outcomes[]` shape:** `{ "id": "<slug>", "name": "<OutcomeName>", "type": "string", "isPrimary": <bool> }` — first entry is the primary action. **No `action` key** — confirmed against a real Studio Web export; an earlier draft of this doc invented one, do not reintroduce it.
-
-> **`title` is required, top-level in the `.hitl.json` file** — the form's display title in Action Center, separate from both the task's `displayName` (canvas label) and `data.taskTitle` (the assignee-facing message). All three are independent strings and do not need to match.
+`title` is required and top-level, independent of task `displayName` and `data.taskTitle`. Required field keys are `id`, `label`, `type`, and `direction`. Make `id` the lowercase label with spaces and non-alphanumeric characters removed (`Invoice ID` → `invoiceid`). `colSpan` is optional. Require `binding` for `input`/`inOut`, normally `=vars.<varId>`; an `=` literal such as `="Acme Corp"` is valid. Require `variable` for `output`/`inOut`, using full `vars.<name>` without a leading `=`. `required` is optional. Make `outcomes[]` entries `{ "id": "<slug>", "name": "<OutcomeName>", "type": "string", "isPrimary": <bool> }`; the first is primary and there is no `action` key.
 
 ### Step 3 — Write the Action Task in `caseplan.json`
 
+Write an action node with `id`, `elementId`, `type: "action"`, `displayName`, `isRequired`, `shouldRunOnlyOnce`, `entryConditions[]`, and `data`:
+
 ```json
 {
-  "id": "ta1b2c3d4",
-  "elementId": "Stage_aB3kL9-ta1b2c3d4",
+  "id": "<task id>",
+  "elementId": "<stage id>-<task id>",
   "type": "action",
-  "displayName": "Invoice Approval",
+  "displayName": "<canvas label>",
   "isRequired": true,
   "shouldRunOnlyOnce": false,
   "entryConditions": [
     {
-      "id": "Condition_EnTk1",
+      "id": "<condition id>",
       "displayName": "Entry Rule 1",
-      "rules": [ [ { "id": "Rule_EnTk1", "rule": "current-stage-entered" } ] ]
+      "rules": [[{ "id": "<rule id>", "rule": "current-stage-entered" }]]
     }
   ],
   "data": {
-    "taskTitle": "Please review this invoice and approve or reject",
+    "taskTitle": "<assignee message>",
     "context": [
-      { "name": "hitlType",                    "type": "string",  "value": "quick" },
-      { "name": "taskTitle",                   "type": "string",  "value": "Please review this invoice and approve or reject" },
-      { "name": "labels",                      "type": "string" },
-      { "name": "priority",                    "type": "string",  "value": "Medium" },
-      { "name": "actionCatalogName",           "type": "string" },
-      { "name": "enableActionableNotifications","type": "boolean", "value": "false" },
-      { "name": "assignmentCriteria",          "type": "string",  "value": "user" },
-      { "name": "recipient",                   "type": "json",    "body": { "Type": 2, "Value": "approver@company.com" } },
-      { "name": "_schemaFileId",               "type": "string",  "value": "f1e2d3c4-b5a6-7890-abcd-ef1234567890" },
-      { "name": "hitlSchemaId",                "type": "string",  "value": "a3f7c2d1-8b4e-4f9a-b2c5-6d8e1f3a7b9c" }
+      { "name": "hitlType", "type": "string", "value": "quick" },
+      { "name": "taskTitle", "type": "string", "value": "<same assignee message>" },
+      { "name": "labels", "type": "string" },
+      { "name": "priority", "type": "string", "value": "Low" },
+      { "name": "actionCatalogName", "type": "string" },
+      { "name": "enableActionableNotifications", "type": "boolean", "value": "false" },
+      { "name": "assignmentCriteria", "type": "string", "value": "user" },
+      { "name": "recipient", "type": "json", "body": { "Type": 2, "Value": "<email>" } },
+      { "name": "_schemaFileId", "type": "string", "value": "<placeholder UUID v4>" },
+      { "name": "hitlSchemaId", "type": "string", "value": "<schemaId>" }
     ],
     "inputs": [
       { "name": "invoiceid", "type": "string", "displayName": "Invoice ID", "target": "bodyField", "value": "=vars.invoiceIdVar" },
-      { "name": "amount",    "type": "number", "displayName": "Amount",    "target": "bodyField", "value": "=vars.amountVar" }
+      { "name": "amount", "type": "number", "displayName": "Amount", "target": "bodyField", "value": "=vars.amountVar" }
     ],
     "outputs": [
       { "name": "Action", "type": "string", "displayName": "Action", "source": "=Action", "var": "invoiceDecision",
@@ -204,212 +133,112 @@ The file uses a **unified `fields[]` array** — every field has a `direction` p
 }
 ```
 
-> **`displayName`, `inputs[]`/`outputs[]`, and `inputSchema` are all required — this is the part an earlier draft of this doc got wrong.** It previously claimed `data.inputs[]`/`data.outputs[]` "are always empty arrays for QuickForm — the schema is in the `.hitl.json` file." That is false. Confirmed against a real Studio Web export and by direct reproduction: without `inputSchema` (a JSON-Schema mirror of the input fields) and populated `inputs[]`/`outputs[]` on the task node itself, Studio Web's "Edit Schema" canvas does not open at all — clicking it does nothing, silently. The `.hitl.json` file and the task's own `data.*` fields are **two parallel representations of the same schema** that must both be written; neither one alone is sufficient.
-> - `inputs[]`: one entry per input field, `name` = field `id`, `value` = the same `=`-expression as that field's `binding` in `.hitl.json`.
-> - `outputs[]`: one entry per **output field with a `variable`**, plus one always-present `Action` entry whose `options[]` mirrors `outcomes[]` from `.hitl.json` (`{value, label}` pairs) — this is the decision/outcome the reviewer picks, not a separate field.
-> - `inputSchema`: a `draft-07` JSON Schema, `properties` keyed by the same field ids as `inputs[]`, each `{"type": "<field type>", "title": "<field label>"}`.
+Populate `inputs[]` with one entry per input field: `name` = field `id`, `type`, `displayName`, `target: "bodyField"`, and `value` = the `.hitl.json` `binding`. Populate `outputs[]` with one entry per output field having a `variable`, plus one always-present `Action` entry whose `options[]` mirrors `outcomes[]` as `{ "value": "<name>", "label": "<name>" }` pairs. `Action` represents the selected outcome.
 
-**Context entry notes:**
+Set `inputSchema` to draft-07 JSON Schema with `properties` keyed by input field IDs and values `{ "type": "<field type>", "title": "<field label>" }`. Both task-level representations and `.hitl.json` are required; omitting either prevents Studio Web’s “Edit Schema” canvas from opening.
 
-| `name` | Notes |
-|---|---|
-| `hitlType` | Always `"quick"` for QuickForm |
-| `_schemaFileId` | **Not a value you can invent — see the callout below.** It must be the real, backend-assigned file ID of the uploaded `.hitl.json`, not a fresh UUID. |
-| `hitlSchemaId` | Must match the `schemaId` value inside the `.hitl.json` file exactly. |
-| `taskTitle` | Appears both as `data.taskTitle` (top-level) and in `context[]` — **both are required**. |
-| `labels` | No `value` — leave the entry present but empty. |
-| `priority` | `"Low"` \| `"Medium"` (default) \| `"High"` \| `"Critical"` |
-| `actionCatalogName` | No `value` for QuickForm — leave the entry present but empty. |
-| `enableActionableNotifications` | Leave as `"false"` unless the user explicitly wants email notifications. |
-| `assignmentCriteria` | `"user"` when assigning to a specific email. Omit the `value` (or omit the entry) for group rules. |
-| `recipient` | `{ "Type": 2, "Value": "<email>" }` for email; `{ "Type": 1, "Value": "<group>" }` for group; `{ "Type": 3, "Value": "=vars.<varId>" }` for runtime-resolved assignee. |
+Context rules: `hitlType` is `"quick"`; `hitlSchemaId` exactly matches the file’s `schemaId`; `taskTitle` appears in both locations; `labels` and `actionCatalogName` have no `value`; priority is `"Low" | "Medium" | "High" | "Critical"`; leave `enableActionableNotifications` as string `"false"` unless notifications are requested; `assignmentCriteria` is `"user"` for an email and may omit `value` or the entry for a group. Recipient forms are `{ "Type": 2, "Value": "<email>" }`, `{ "Type": 1, "Value": "<group>" }`, or `{ "Type": 3, "Value": "=vars.<varId>" }` for runtime assignment.
 
-> **`_schemaFileId` cannot be authored blind — it is a server-assigned foreign key, not a UUID you invent.** Confirmed by direct reproduction against Studio Web: a placeholder UUID here makes "Edit Schema" fail with a `404` on `FileOperations/File/Rename` (the fileId in that failed request is whatever placeholder was written) — Studio Web does **not** silently reconcile it on upload, contrary to what an earlier draft of this doc claimed. There is currently no `uip` CLI command that resolves this.
->
-> **Never block on this.** Write a fresh placeholder UUID v4, finish the task, validate, and move on — do not attempt the reconciliation below yourself, and do not stop to ask about it. State plainly in the final report that this task's schema won't be editable in Studio Web until the real file ID is reconciled, and offer to do it if asked:
-> 1. Upload the project once with any placeholder value in `_schemaFileId` (`uip solution upload`).
-> 2. Look up the real ID Studio Web assigned to the `.hitl.json` file via `GET /api/Project/{projectId}/FileOperations/Structure` (find the entry whose `name` matches the `.hitl.json` filename — an internal Studio Web REST endpoint, not a `uip` CLI verb).
-> 3. Patch `_schemaFileId` in `caseplan.json` to that real ID.
-> 4. Push the corrected `caseplan.json` back with a **targeted single-file update** — `PUT /api/Project/{projectId}/FileOperations/File/{fileId}` (same file's own real ID) — **not** another whole-project `uip solution upload`. A second whole-project upload re-pushes every file and mints a **new** random file ID for each one, including `.hitl.json`, immediately invalidating whatever you just patched.
->
-> This is a real gap, not just a documentation gap: today there is no supported CLI path to make a freshly-authored QuickForm task's schema editable in Studio Web without dropping to this undocumented internal API. It's a follow-up the user can request, never a mid-task blocker.
+`_schemaFileId` is a backend-assigned foreign key, not an authored UUID, and no `uip` CLI command resolves it. Never block: use a fresh UUID v4 placeholder, validate, and report that Studio Web editing requires reconciliation. If requested:
+
+1. Run `uip solution upload` once with the placeholder.
+2. Look up the real ID with `GET /api/Project/{projectId}/FileOperations/Structure`, matching the `.hitl.json` filename.
+3. Patch `_schemaFileId` with the real ID.
+4. Push only the corrected file with `PUT /api/Project/{projectId}/FileOperations/File/{fileId}`; do not run another whole-project `uip solution upload`, because it remints file IDs.
 
 ### Step 4 — Discover Upstream Variables
 
-Read available case variables from the top-level `variables` field in `caseplan.json` (current schema is flat — no `root` wrapper; see [case-schema.md](../../uipath-maestro-case/references/case-schema.md#top-level-shape) in the case skill):
+Read the flat top-level `variables` field; it has no `root` wrapper:
 
 ```json
 {
-  "inputs":      [ { "id": "<varId>", "name": "invoiceId", "type": "string" } ],
-  "outputs":     [],
-  "inputOutputs":[]
+  "inputs": [ { "id": "<varId>", "name": "<name>", "type": "string" } ],
+  "outputs": [],
+  "inputOutputs": []
 }
 ```
 
-For cross-task references, source values come from upstream task `outputs[].var` — see [bindings-and-expressions.md](../../uipath-maestro-case/references/bindings-and-expressions.md) in the case skill for the full discovery procedure.
-
-> **No root-level bindings needed for QuickForm.** Unlike App-based (Path 2), QuickForm does **not** add entries to the top-level `bindings[]` array.
-
-### Post-Write Verification (QuickForm)
-
-Run `uip maestro case validate <caseplan.json> --output json`. Confirm:
-
-- `.hitl.json` file exists in the project directory with `schemaId`, `fields[]` (unified array with `direction`), `outcomes[]`
-- Action task `type === "action"`
-- `data.taskTitle` non-empty and matches `data.context[taskTitle].value`
-- `data.context[]` has entries for: `hitlType` (`"quick"`), `_schemaFileId`, `hitlSchemaId`, `taskTitle`, `labels`, `priority`, `actionCatalogName`, `enableActionableNotifications`
-- `data.context[hitlSchemaId].value` matches `schemaId` in the `.hitl.json` file
-- `data.inputs[]`/`data.outputs[]` are populated (mirroring `.hitl.json`'s fields) and `data.inputSchema` is present — see the callout in Step 3
-- top-level `bindings[]` is **not** modified by this path
-
-### Downstream Output Access (QuickForm)
-
-Each field in `outputs[]` and `inOuts[]` exposes its value downstream via the field's `variable` property — the **full** `"vars.<name>"` string, not a bare name:
-
-```json
-{ "id": "decision", "variable": "vars.decision", "type": "string", "label": "Decision" }
-```
-
-Downstream task input value: `"=vars.decision"`. The selected outcome is available via the task's `Action` output (see Step 3).
-
-For the full cross-task wiring procedure, see [bindings-and-expressions.md](../../uipath-maestro-case/references/bindings-and-expressions.md).
-
----
+For cross-task references, source values from upstream task `outputs[].var`. Follow [bindings-and-expressions.md](../../uipath-maestro-case/references/bindings-and-expressions.md). Do not modify top-level `bindings[]` for QuickForm.
 
 ## Path 2 — App-Based Action Task (deployed Action Center app)
 
-The task form is defined by a deployed Action Center app. Inputs are shown to the human; outputs are collected from the form and usable downstream via `=vars.<var>` expressions.
+The deployed app defines the form; inputs are shown to the human and outputs are available downstream.
 
 ### Step 1 — Discover the App
 
+Run:
+
 ```bash
-# Pull the registry first (requires uip login)
 uip maestro case registry pull
-
-# Search for action apps
 uip maestro case registry search --type action-apps --output json
-
-# Get a specific app by name (check action-apps-index.json if CLI search fails)
 uip maestro case registry get "<app-name>" --type action-apps --output json
 ```
 
-> CLI search is known to fail for action-apps — always fall back to direct inspection of `~/.uipcli/case-resources/action-apps-index.json`. Use `id` (not `entityKey`), `deploymentTitle` (not `name`), and `deploymentFolder.fullyQualifiedName` for the folder path.
+If CLI search fails for action apps, inspect `~/.uipcli/case-resources/action-apps-index.json` directly. Use `id` rather than `entityKey`, `deploymentTitle` rather than `name`, and `deploymentFolder.fullyQualifiedName` for the folder path.
 
 ### Step 2 — Get the Input/Output Schema
 
-```bash
-uip maestro case tasks describe --type action --id "<action-app-id>" --output json
-```
-
-Returns `inputs[]` and `outputs[]`. Capture both — they define what the human fills in and what the automation reads back.
+Run `uip maestro case tasks describe --type action --id "<action-app-id>" --output json` and capture both `inputs[]` and `outputs[]`.
 
 ### Step 3 — Write Root-Level Bindings
 
-Add 2 entries to the top-level `bindings[]` array — one for `name` and one for `folderPath`. Deduplicate by `(default + resource + resourceKey)`.
+Add and deduplicate two top-level `bindings[]` entries by `(default + resource + resourceKey)`: one for `name` and one for `folderPath`.
 
 ```json
 {
-  "id": "bG0SraLpg",
+  "id": "b<8 chars>",
   "name": "name",
   "type": "string",
   "resource": "app",
-  "resourceKey": "Shared.Contract Review App",
+  "resourceKey": "<folderPath>.<deploymentTitle>",
   "propertyAttribute": "name",
-  "default": "Contract Review App"
-},
-{
-  "id": "bH1iJK2lm",
-  "name": "folderPath",
-  "type": "string",
-  "resource": "app",
-  "resourceKey": "Shared.Contract Review App",
-  "propertyAttribute": "folderPath",
-  "default": "Shared"
+  "default": "<deploymentTitle>"
 }
 ```
 
-`resourceKey` = `<folderPath>.<deploymentTitle>`. Binding IDs: `b` + 8 chars.
-
-For the full binding procedure, see [bindings/impl-json.md](../../uipath-maestro-case/references/plugins/variables/bindings/impl-json.md) in the case skill.
+The `folderPath` entry has the same shape with `name: "folderPath"`, `propertyAttribute: "folderPath"`, and the folder as `default`. Binding IDs are `b` + 8 chars. Follow [bindings/impl-json.md](../../uipath-maestro-case/references/plugins/variables/bindings/impl-json.md).
 
 ### Step 4 — Write the Task
 
+Write `type: "action"`, `isRequired`, `shouldRunOnlyOnce`, `entryConditions[]`, and:
+
 ```json
 {
-  "id": "ta1b2c3d4",
-  "elementId": "Stage_aB3kL9-ta1b2c3d4",
-  "type": "action",
-  "isRequired": true,
-  "shouldRunOnlyOnce": false,
-  "entryConditions": [
-    {
-      "id": "Condition_EnTk1",
-      "displayName": "Entry Rule 1",
-      "rules": [ [ { "id": "Rule_EnTk1", "rule": "current-stage-entered" } ] ]
-    }
-  ],
   "data": {
-    "taskTitle": "Please review this contract and fill in the required fields",
-    "name": "=bindings.bG0SraLpg",
-    "folderPath": "=bindings.bH1iJK2lm",
-    "actionCatalogName": "Contract Review App",
+    "taskTitle": "<assignee message>",
+    "name": "=bindings.<name-binding-id>",
+    "folderPath": "=bindings.<folder-binding-id>",
+    "actionCatalogName": "<deploymentTitle>",
     "assignmentCriteria": "user",
-    "recipient": { "Type": 2, "Value": "reviewer@company.com" },
-    "context": [
-      { "name": "hitlType", "type": "string", "value": "custom" }
-    ],
+    "recipient": { "Type": 2, "Value": "<email>" },
+    "context": [{ "name": "hitlType", "type": "string", "value": "custom" }],
     "inputs": [],
     "outputs": []
   }
 }
 ```
 
-`data.name` and `data.folderPath` MUST be `=bindings.<id>` references — never string literals.
-`data.inputs[]` and `data.outputs[]` are populated from the `tasks describe` response in Step 2.
+Populate `data.inputs[]` and `data.outputs[]` from `tasks describe`. `data.name` and `data.folderPath` must be `=bindings.<id>` references, never literals. App-based tasks have no schema file: write `hitlType: "custom"` and never write `_schemaFileId` or `hitlSchemaId`. For full `inputs[]`/`outputs[]` variable shapes, see [action/impl-json.md](../../uipath-maestro-case/references/plugins/tasks/action/impl-json.md).
 
-> **`hitlType` is `"custom"` for app-based tasks.** App-based tasks have no schema file at all — the form is defined by the deployed app itself, not by a schema document. **Never write `_schemaFileId` or `hitlSchemaId` for an app-based task** — those two context entries exist only on the QuickForm path (Path 1), where they identify the `.hitl.json` schema file. An app-based task is fully described by `data.name`/`data.folderPath` (the bindings to the deployed app) plus `data.inputs[]`/`data.outputs[]` (from `tasks describe`) — nothing else identifies its "schema."
+## Post-Write Verification
 
-For the full `inputs[]`/`outputs[]` variable shapes, see [action/impl-json.md](../../uipath-maestro-case/references/plugins/tasks/action/impl-json.md).
-
----
-
-## Post-Write Verification (all paths)
+Run:
 
 ```bash
 uip maestro case validate <caseplan.json> --output json
 ```
 
-| Path | Verify |
-|---|---|
-| QuickForm | `.hitl.json` file present with `title`, `fields[]`, `outcomes[]` (no `action` key), `schemaId`; task has `displayName`; `data.context[]` has `hitlType: "quick"`, `_schemaFileId`, `hitlSchemaId` (matches `.hitl.json` `schemaId`), `taskTitle`; `data.inputs[]`/`data.outputs[]` populated (not empty) and `data.inputSchema` present, mirroring `.hitl.json`'s fields; no `actionCatalogName` value; no top-level `bindings[]` entries added |
-| App-based | `type: "action"`, `data.taskTitle` non-empty, `data.name` and `data.folderPath` start with `=bindings.`, `data.context[]` has `hitlType: "custom"` and **no** `_schemaFileId`/`hitlSchemaId` entries (app-based tasks have no schema file), top-level `bindings[]` has 2 entries with `resource: "app"` and `propertyAttribute` = `name` / `folderPath`, `data.actionCatalogName` matches the deployed `deploymentTitle` |
-| Both | The task node has `entryConditions[]` set — e.g. `current-stage-entered` (see the Step 3/4 examples above). Without it, validate fails with `Task has no entry rules`. This is a case-structural requirement, not HITL-specific — it applies to every action task written via direct JSON. |
+For QuickForm, confirm the adjacent `.hitl.json` has `title`, unified `fields[]`, `outcomes[]`, no `action` key, and `schemaId`; the task has `type: "action"`, `displayName`, non-empty matching `data.taskTitle` and context `taskTitle`, `hitlType: "quick"`, `_schemaFileId`, matching `hitlSchemaId`, required context entries, populated task `inputs[]`/`outputs[]`, `inputSchema`, no `actionCatalogName` value, and no new top-level bindings. Confirm schema fields and task representations mirror each other.
 
-If validate reports errors, **never report success**. Diagnose from the JSON output and fix before reporting back. A validate error unrelated to the HITL task itself (e.g. `Case has no completion rules` on a stage/case that predates your edit) is a pre-existing gap in the case plan, not something this skill introduces — surface it to the user rather than reverse-engineering the CLI to silence it.
+For App-based, confirm `type: "action"`, non-empty `data.taskTitle`, `data.name` and `data.folderPath` beginning `=bindings.`, `hitlType: "custom"`, no `_schemaFileId`/`hitlSchemaId`, two app bindings with `propertyAttribute` values `name` and `folderPath`, and matching `actionCatalogName`/`deploymentTitle`.
 
----
+Both paths require task `entryConditions[]`, such as `current-stage-entered`; otherwise validation fails with `Task has no entry rules`. This is a case-structural requirement. If validation reports errors, diagnose and fix them before reporting success. Surface unrelated errors, such as `Case has no completion rules` in a pre-existing case, rather than suppressing them. Report the created files/task, validation result, any placeholder `_schemaFileId` reconciliation requirement, and schema-adjustment guidance.
 
 ## Downstream Output Access
 
-| Path | Outputs available downstream? | How |
-|---|---|---|
-| QuickForm | Yes — every `outputs[]` and `inOuts[]` field in the `.hitl.json` | `field.variable` is already the full `=vars.<name>` reference (minus the leading `=`) |
-| App-based | Yes — every `data.outputs[]` entry | `=vars.<output.var>` |
+| Path | Access |
+|---|---|
+| QuickForm | Every `.hitl.json` `outputs[]`/`inOuts[]` field uses its full `variable` (`vars.<name>`); the selected outcome is the task’s `Action` output. |
+| App-based | Every `data.outputs[]` entry is read with `=vars.<output.var>`. |
 
-**QuickForm example:**
-
-```json
-{ "id": "decision", "variable": "vars.decision", "type": "string", "label": "Decision" }
-```
-
-Downstream task input: `"value": "=vars.decision"`.
-
-**App-based example:**
-
-```json
-{ "name": "decision", "type": "string", "id": "out_decision", "var": "decisionVar" }
-```
-
-Downstream task input: `"value": "=vars.decisionVar"`.
-
-For the full cross-task wiring procedure, see [bindings-and-expressions.md](../../uipath-maestro-case/references/bindings-and-expressions.md).
+For QuickForm, downstream input values use `=vars.<name>`; for App-based, use `=vars.<output.var>`. Follow [bindings-and-expressions.md](../../uipath-maestro-case/references/bindings-and-expressions.md).

--- a/skills/uipath-human-in-the-loop/references/hitl-node-apptask.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-apptask.md
@@ -1,45 +1,22 @@
 # HITL AppTask Node — Direct JSON Reference
 
-The AppTask variant uses a deployed coded app (Studio Web) as the task form. Node type: `uipath.human-in-the-loop.coded-action-app`. Same three handles (`input`, `completed`) as QuickForm. Difference from QuickForm: `inputs.app` points to the deployed app (no inline schema).
-
----
+The AppTask variant uses a deployed coded app (Studio Web) as the task form. Node type: `uipath.human-in-the-loop.coded-action-app`. It has QuickForm's `input` and `completed` handles; `inputs.app` references a deployed app instead of an inline schema.
 
 ## App Lookup and Solution Registration
 
-Before writing the node JSON, resolve the app and register it with the solution. All API calls use auth from the stored login session (`uip login`).
+Before writing node JSON, resolve the app and register it with the solution. Run API calls with auth from the stored login session (`uip login`).
 
-### Step 1 — Resolve solution context and credentials
+### 1. Resolve context and credentials
 
-**Read credentials from the active `uip` session:**
+Run:
 
 ```bash
 source "$HOME/.uipath/.auth"
-# Variables now available:
-# UIPATH_ACCESS_TOKEN       — bearer token
-# UIPATH_URL                — e.g. https://cloud.uipath.com
-# UIPATH_ORGANIZATION_NAME  — org name (slug)
-# UIPATH_ORGANIZATION_ID    — org UUID
-# UIPATH_TENANT_NAME
-# UIPATH_TENANT_ID
-# UIPATH_PROJECT_ID
 ```
 
-Map to working variables:
+Map `UIPATH_ACCESS_TOKEN`, `UIPATH_URL`, `UIPATH_ORGANIZATION_NAME`, `UIPATH_ORGANIZATION_ID`, `UIPATH_TENANT_NAME`, `UIPATH_TENANT_ID`, and `UIPATH_PROJECT_ID` to `ACCESS_TOKEN`, `BASE_URL`, `ORG_NAME`, `ORG_ID`, and `TENANT_ID`. Derive `USER_ID` from the `sub` claim by base64url-decoding the middle `ACCESS_TOKEN` segment, parsing its JSON, and reading `sub`.
 
-| Variable | Source |
-|---|---|
-| `BASE_URL` | `$UIPATH_URL` |
-| `ORG_NAME` | `$UIPATH_ORGANIZATION_NAME` |
-| `ORG_ID` | `$UIPATH_ORGANIZATION_ID` |
-| `TENANT_ID` | `$UIPATH_TENANT_ID` |
-| `ACCESS_TOKEN` | `$UIPATH_ACCESS_TOKEN` |
-| `USER_ID` | `sub` claim — base64url-decode the middle segment of `ACCESS_TOKEN`, parse JSON, read `sub` |
-
-**Resolve solution context:**
-
-Find the `.uipx` file: look in the flow file's directory first, then its parent directory.
-
-Parse it as JSON:
+Find the `.uipx` file in the flow file's directory and parse it as JSON:
 
 ```json
 {
@@ -50,11 +27,11 @@ Parse it as JSON:
 }
 ```
 
-Extract `SolutionId` → `SOLUTION_ID`. Find the entry in `Projects[]` whose directory matches the flow file's directory → its `Id` is `PROJECT_KEY`.
+Set `SOLUTION_ID` from `SolutionId`. Select the `Projects[]` entry whose directory matches the flow file's directory and set `PROJECT_KEY` from `Id`. If none matches, run `uip solution projects add` first because the project is not registered.
 
-> If no project entry matches, the project is not registered. Run `uip solution projects add` first.
+### 2. Search for apps
 
-### Step 2 — Search for apps
+Run:
 
 ```
 GET {BASE_URL}/{ORG_NAME}/studio_/backend/api/resourcebuilder/solutions/{SOLUTION_ID}/resources/search
@@ -69,48 +46,27 @@ GET {BASE_URL}/{ORG_NAME}/studio_/backend/api/resourcebuilder/solutions/{SOLUTIO
   &searchTerm={APP_NAME}
 ```
 
-Headers: `Authorization: Bearer {ACCESS_TOKEN}`, `Accept: application/json`, `x-uipath-tenantid: {TENANT_ID}`
+Send `Authorization: Bearer {ACCESS_TOKEN}`, `Accept: application/json`, and `x-uipath-tenantid: {TENANT_ID}`. Flatten `solutionResources` and `availableResources`; follow `nextPageCursor` when present. For each folder group retain each item's `key`, `name`, `type`, `kind`, and parent `fullyQualifiedName`, `path`, and `folderKey`.
 
-Response:
+If the request returns 401, upload the solution `.uipx` file first by just using the solution-tool cli upload command; do not bundle the solution.
 
-```json
-{
-  "solutionResources": [
-    {
-      "fullyQualifiedName": "Shared",
-      "path": "Shared",
-      "key": "<folderKey>",
-      "resources": [
-        { "key": "<appKey>", "name": "Invoice Approval", "type": "Coded Action", "kind": "app" }
-      ]
-    }
-  ],
-  "availableResources": [...],
-  "nextPageCursor": null
-}
-```
+Apply these selection rules:
 
-If this returns 401, upload the solution uipx file first by just using the solution-tool cli upload command, do not bundle the solution.
+- Exactly one match: use it and continue.
+- Multiple matches: never block. Prefer an exact case-insensitive name match in a `Shared` folder; otherwise use the first result. State the selected app and alternatives so the user can correct it. Fetch more pages when truncated.
+- Zero matches: never block. Fall back to QuickForm per SKILL.md Step 3's fallback rule and continue. State: `No deployed app named <APP_NAME> was found, so I used QuickForm instead. Verify the name and that the app is deployed, then ask me to swap it in.`
 
-Flatten both `solutionResources` and `availableResources` folder groups into a single list. Each item carries: `key`, `name`, `type`, `kind`, and its parent `folder` (`fullyQualifiedName`, `path`, `folderKey`).
+### 3. Retrieve configuration
 
-**Selection rules:**
-
-- **Exactly one match** → use it, proceed to Step 3.
-- **Multiple matches** → never block waiting for a choice. Pick the best match automatically (prefer an exact case-insensitive name match in a `Shared` folder, else the first result), proceed, and state the choice plus the alternatives so the user can correct it:
-
-  > I found multiple apps matching that name and used **Invoice Approval** (Shared / Coded Action). Other matches, if this was the wrong one: **Invoice Approval** (Finance / VB Action). Tell me to swap it if I picked wrong.
-
-  Use `nextPageCursor` to fetch additional pages if the list is truncated.
-
-- **Zero matches** → never block. Fall back to QuickForm (per SKILL.md Step 3's fallback rule) and proceed. State: "No deployed app named `<APP_NAME>` was found, so I used QuickForm instead. Verify the name and that the app is deployed, then ask me to swap it in."
-
-### Step 3 — Retrieve app configuration
+Run:
 
 ```
 POST {BASE_URL}/{ORG_NAME}/studio_/backend/api/resourcebuilder/solutions/{SOLUTION_ID}/resources/retrieve-configuration
-Content-Type: application/json
+```
 
+Send `Content-Type: application/json`, `Authorization: Bearer {ACCESS_TOKEN}`, `Accept: application/json`, and `x-uipath-tenantid: {TENANT_ID}`. Use:
+
+```json
 {
   "key": "<selectedApp.key>",
   "name": "<selectedApp.name>",
@@ -120,26 +76,22 @@ Content-Type: application/json
 }
 ```
 
-Headers: `Authorization: Bearer {ACCESS_TOKEN}`, `Content-Type: application/json`, `Accept: application/json`, `x-uipath-tenantid: {TENANT_ID}`
+From the response set:
 
-The response is a resource object. Key extractions from `spec`:
+- `APP_SYSTEM_NAME` = `spec.appSystemName`
+- `APP_VERSION_REF` = `spec.appVersionRef` (`{ key, name }`)
+- `VERSION` = `spec.version`, default `"1.0.0"`
+- `inputSchema` = parsed JSON-string `spec.actionSchema`, then `.inputs`
+- `inOutSchema` = parsed JSON-string `spec.actionSchema`, then `.inOuts`
+- `folder` = `raw.folder.fullyQualifiedName`, `.path`, and `.folderKey`, falling back to selected-app folder values
 
-| Extract | Field | Notes |
-|---|---|---|
-| `APP_SYSTEM_NAME` | `spec.appSystemName` | |
-| `APP_VERSION_REF` | `spec.appVersionRef` | object `{ key, name }` |
-| `VERSION` | `spec.version` | default `"1.0.0"` if absent |
-| `inputSchema` | parsed from `spec.actionSchema` → `.inputs` | `spec.actionSchema` is a **JSON string** — parse it first |
-| `inOutSchema` | parsed from `spec.actionSchema` → `.inOuts` | |
-| `folder` | `raw.folder.fullyQualifiedName`, `.path`, `.folderKey` | fall back to `selectedApp.folder` values |
+If retrieval fails, warn and continue with empty `inputSchema` and `inOutSchema`. For node `outputSchema`, parse `spec.actionSchema` and read `.outputs`.
 
-> If this call fails, warn and continue with empty `inputSchema`/`inOutSchema`.
+### 4. Write solution resource files
 
-### Step 4 — Write solution resource files
+Create directories as needed. Paths are relative to `<solutionDir>`, the directory containing `.uipx`.
 
-Create directories as needed. All paths are relative to `<solutionDir>` (the directory containing the `.uipx` file).
-
-**File 1: `resources/solution_folder/app/<app.type>/<AppName>.json`**
+Write `resources/solution_folder/app/<app.type>/<AppName>.json`:
 
 ```json
 {
@@ -169,9 +121,7 @@ Create directories as needed. All paths are relative to `<solutionDir>` (the dir
 }
 ```
 
-> Write `spec.actionSchema` verbatim from the API response. Re-serializing it changes unicode escapes vs. plain quotes and will break schema matching.
-
-**File 2: `resources/solution_folder/appVersion/<AppName>.json`** *(skip if `APP_SYSTEM_NAME` or `APP_VERSION_REF` are absent)*
+Write `resources/solution_folder/appVersion/<AppName>.json`; skip it if `APP_SYSTEM_NAME` or `APP_VERSION_REF` is absent:
 
 ```json
 {
@@ -210,14 +160,19 @@ Create directories as needed. All paths are relative to `<solutionDir>` (the dir
 }
 ```
 
-`MAJOR_VERSION` = first segment of `VERSION` (e.g. `"2.0.1"` → `"2"`).
+Set `MAJOR_VERSION` to the first `VERSION` segment (for example, `"2.0.1"` becomes `"2"`). Write `spec.actionSchema` verbatim from the API response; do not re-serialize it because changed unicode escapes or quote representation breaks schema matching.
 
-### Step 5 — Register app reference
+### 5. Register the app reference
+
+Run:
 
 ```
 POST {BASE_URL}/{ORG_NAME}/studio_/backend/api/resourcebuilder/solutions/{SOLUTION_ID}/resources/reference?api-version=2&forceUpdate=true
-Content-Type: application/json
+```
 
+Send `Content-Type: application/json`, `Authorization: Bearer {ACCESS_TOKEN}`, `Accept: application/json`, and `x-uipath-tenantid: {TENANT_ID}`. Use:
+
+```json
 {
   "kind": "app",
   "type": "<app.type>",
@@ -230,13 +185,11 @@ Content-Type: application/json
 }
 ```
 
-> If this call fails, warn and continue.
+If registration fails, warn and continue.
 
-### Step 6 — Write debug overwrites
+### 6. Write debug overwrites
 
-Read `<solutionDir>/userProfile/<USER_ID>/debug_overwrites.json` if it exists. Merge in the new entry — do not overwrite unrelated entries.
-
-Structure:
+Read `<solutionDir>/userProfile/<USER_ID>/debug_overwrites.json` if it exists and merge the app entry without overwriting unrelated entries:
 
 ```json
 {
@@ -264,22 +217,16 @@ Structure:
 }
 ```
 
-Merge rules:
-- Tenant entry for `TENANT_ID` exists → find resource by `solutionResourceKey` and replace, or append if not found.
-- No tenant entry → add a new tenant object.
-
-> If this write fails, warn and continue.
-
----
+If the tenant exists, replace the resource matching `solutionResourceKey` or append it; otherwise add a tenant object. If writing fails, warn and continue.
 
 ## Full Node JSON
 
 ```json
 {
-  "id": "invoiceReview1",
+  "id": "<nodeId>",
   "type": "uipath.human-in-the-loop.coded-action-app",
   "typeVersion": "1.0",
-  "display": { "label": "Invoice Review" },
+  "display": { "label": "<label>" },
   "inputs": {
     "recipient": {
       "channels": ["ActionCenter"],
@@ -287,27 +234,21 @@ Merge rules:
       "assignee": { "type": "group" }
     },
     "app": {
-      "displayName": "Invoice Approval",
-      "name": "Invoice Approval",
-      "key": "c0ba97df-8a30-4fe0-b4b4-4611a631d77b",
-      "folderPath": "Shared",
+      "displayName": "<app.name>",
+      "name": "<app.name>",
+      "key": "<app.key>",
+      "folderPath": "<folder.fullyQualifiedName>",
       "inputSchema": {
         "type": "object",
-        "properties": {
-          "AI Agent Decision": { "type": "string" },
-          "Invoice Amount":    { "type": "integer" }
-        }
+        "properties": { "<param>": { "type": "string" } }
       },
       "outputSchema": {
         "type": "object",
-        "properties": {
-          "Human Agent Decision": { "type": "string" }
-        }
+        "properties": { "<param>": { "type": "string" } }
       }
     },
     "appInputBindings": {
-      "AI Agent Decision": "=vars.<nodeId>.output.<field>",
-      "Invoice Amount":    "=metadata.InstanceId"
+      "<parameter>": "=vars.<nodeId>.output.<field>"
     },
     "schema": {
       "fields": [],
@@ -336,48 +277,42 @@ Merge rules:
 }
 ```
 
-### `inputs.app` field mapping
+### `inputs.app` mapping
 
-| Field | Source | Example |
-|---|---|---|
-| `displayName` | `selectedApp.name` from search | `"Invoice Approval"` |
-| `name` | `selectedApp.name` from search | `"Invoice Approval"` |
-| `key` | `selectedApp.key` from search | `"c0ba97df-8a30-4fe0-b4b4-4611a631d77b"` |
-| `folderPath` | `selectedApp.folder.fullyQualifiedName` from search | `"Shared"` |
-| `inputSchema` | JSON Schema object built from `config.actionSchema.inputs` — `{ "type": "object", "properties": { "<param>": { "type": "string" }, ... } }` | See note |
-| `outputSchema` | JSON Schema object built from `config.actionSchema.outputs` — `{ "type": "object", "properties": { "<param>": { "type": "string" }, ... } }` | See note |
+- `displayName`, `name`: `selectedApp.name`
+- `key`: `selectedApp.key`
+- `folderPath`: `selectedApp.folder.fullyQualifiedName`
+- `inputSchema`: JSON Schema object from parsed `config.actionSchema.inputs`
+- `outputSchema`: JSON Schema object from parsed `config.actionSchema.outputs`
 
-> `inputSchema` and `outputSchema` are JSON Schema objects (`{ "type": "object", "properties": { ... } }`), **not arrays**. Parse `spec.actionSchema` (a JSON string) from the retrieve-configuration response and extract `inputs`/`outputs` to build the property maps.
+Both schemas must be `{ "type": "object", "properties": { ... } }`, not arrays. Parse `spec.actionSchema`, which is a JSON string, before extracting `inputs` and `outputs`.
 
-### `inputs.appInputBindings` format
+### `inputs.appInputBindings`
 
-Maps app parameter names to binding expressions. Format: `"=vars.<path>"` (with `=` prefix, no `js:`):
+Map app parameter names to expressions with an `=` prefix and no `js:`:
 
 ```json
 "appInputBindings": {
-  "AI Agent Decision": "=vars.<nodeId>.output.<field>",
-  "Invoice Amount":    "=metadata.InstanceId"
+  "<parameter>": "=vars.<path>"
 }
 ```
 
-### `inputs.recipient` options
+### `inputs.recipient`
 
 ```json
-// Action Center (default — no specific assignee)
+// Action Center, default; no specific assignee
 "recipient": { "channels": ["ActionCenter"], "connections": {}, "assignee": { "type": "group" } }
 
 // Specific user by email
-"recipient": { "channels": ["Email"], "assignee": { "type": "user", "value": "user@company.com" } }
+"recipient": { "channels": ["Email"], "assignee": { "type": "user", "value": "<user@company.com>" } }
 
 // Everyone in a group
-"recipient": { "channels": ["ActionCenter"], "assignee": { "type": "group", "value": "Finance Team" } }
+"recipient": { "channels": ["ActionCenter"], "assignee": { "type": "group", "value": "<group>" } }
 ```
-
----
 
 ## Definition Entry
 
-AppTask uses a **separate** definition entry — `nodeType` is `"uipath.human-in-the-loop.coded-action-app"`, not `"uipath.human-in-the-loop.quick-form"`. Add it once to `workflow.definitions`, deduplicated by `nodeType`.
+Add exactly one definition entry to `workflow.definitions`, deduplicated by `nodeType`, using `nodeType` `"uipath.human-in-the-loop.coded-action-app"`, not `"uipath.human-in-the-loop.quick-form"`:
 
 ```json
 {
@@ -387,11 +322,7 @@ AppTask uses a **separate** definition entry — `nodeType` is `"uipath.human-in
   "description": "App-based human task using a deployed coded action app",
   "tags": ["human-task", "hitl", "human-in-the-loop", "coded-action-app", "approval"],
   "sortOrder": 28,
-  "display": {
-    "label": "App Task",
-    "icon": "users",
-    "shape": "square"
-  },
+  "display": { "label": "App Task", "icon": "users", "shape": "square" },
   "handleConfiguration": [
     {
       "position": "left",
@@ -400,9 +331,7 @@ AppTask uses a **separate** definition entry — `nodeType` is `"uipath.human-in
     },
     {
       "position": "right",
-      "handles": [
-        { "id": "completed", "type": "source", "handleType": "output", "showButton": true, "constraints": { "forbiddenTargetCategories": ["trigger"] } }
-      ],
+      "handles": [{ "id": "completed", "type": "source", "handleType": "output", "showButton": true, "constraints": { "forbiddenTargetCategories": ["trigger"] } }],
       "visible": true
     }
   ],
@@ -414,29 +343,21 @@ AppTask uses a **separate** definition entry — `nodeType` is `"uipath.human-in
 }
 ```
 
----
-
 ## Edge Wiring
 
-Identical to QuickForm. Only the `completed` handle is available — there are no `cancelled` or `timeout` handles in v1.0:
+Wire only `completed`; v1.0 has no `cancelled` or `timeout` handles:
 
 ```json
-{ "id": "invoiceReview1-completed-nextNode1-input", "sourceNodeId": "invoiceReview1", "sourcePort": "completed", "targetNodeId": "nextNode1", "targetPort": "input" }
+{ "id": "<nodeId>-completed-<targetNodeId>-input", "sourceNodeId": "<nodeId>", "sourcePort": "completed", "targetNodeId": "<targetNodeId>", "targetPort": "input" }
 ```
-
----
 
 ## `variables.nodes` — Regenerate After Adding
 
-Same rule as QuickForm — add `output` and `status` entries for the new node, then replace the entire `variables.nodes` array. See [hitl-node-quickform.md](hitl-node-quickform.md) for the regeneration algorithm.
-
----
+Use the same rule as QuickForm: add `output` and `status` entries for the new node, then replace the entire `variables.nodes` array. See [hitl-node-quickform.md](hitl-node-quickform.md) for the regeneration algorithm.
 
 ## Runtime Variables
 
-Same as QuickForm:
-
-| Variable | What it contains |
+| Variable | Contents |
 |---|---|
 | `$vars.<nodeId>.output` | Outputs the human filled in via the app |
 | `$vars.<nodeId>.status` | Selected outcome's action value (`"Continue"` or `"End"`) |

--- a/skills/uipath-human-in-the-loop/references/hitl-node-coded-action-app.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-coded-action-app.md
@@ -1,26 +1,18 @@
 # HITL Coded Action App (Inline) — Project Scaffold and Node Reference
 
-Create a new coded action app project inside the solution using the user's own source code, then wire the HITL node to reference it.
-
-Use this path when the user selects **New Coded Action App** in Step 3.
-
----
+Create a coded action app project inside the solution from the user's source code and wire the HITL node to reference it. Use this path when the user selects **New Coded Action App** in Step 3.
 
 ## Overview
 
-| Step | Action |
-|---|---|
-| 1 | Generate keys |
-| 2 | Create project folder and copy source code (excluding `node_modules`) |
-| 3 | Add project to solution via CLI |
-| 4 | Write solution resource files |
-| 5 | Write HITL node into the `.flow` file |
-
----
+1. Generate keys.
+2. Create `<APP_NAME>` and copy source code, excluding `node_modules`.
+3. Add the project to the solution via CLI.
+4. Write solution resources.
+5. Write the HITL node in the `.flow` file.
 
 ## Step 1 — Generate Keys
 
-Generate three UUIDs before writing any files. All three are used across multiple files — generate them once and reuse.
+Generate three UUIDs before writing files and reuse them everywhere:
 
 ```bash
 node -e "
@@ -37,95 +29,78 @@ console.log('PROJECT_KEY=' + r());
 | `PACKAGE_KEY` | Package resource key, app resource `spec.package.key` |
 | `PROJECT_KEY` | `projectKey` in both resource files |
 
----
-
 ## Step 2 — Create Project Folder and Copy Source Code
 
-Create this structure relative to `<SOLUTION_DIR>` (the directory containing the `.uipx` file):
+Create this structure relative to `<SOLUTION_DIR>`, the directory containing the `.uipx` file:
 
 ```
 <SOLUTION_DIR>/
 └── <APP_NAME>/
     ├── project.uiproj
     ├── webAppManifest.json
-    └── source/          ← contents copied from <SOURCE_PATH> provided by the user
+    └── source/          ← contents copied from <SOURCE_PATH>
 ```
 
-### `<APP_NAME>/project.uiproj`
+Write `<APP_NAME>/project.uiproj`:
 
 ```json
 {
   "ProjectType": "AppV2",
-  "WebAppSettings": {
-    "AppId": null,
-    "IsCoreProject": false
-  },
+  "WebAppSettings": { "AppId": null, "IsCoreProject": false },
   "Name": "<APP_NAME>",
   "Description": null,
   "MainFile": null
 }
 ```
 
-### `<APP_NAME>/webAppManifest.json`
+Write `<APP_NAME>/webAppManifest.json`:
 
 ```json
 {
   "type": "Coded",
   "solutionResourceSubType": "CodedAction",
-  "config": {
-    "isCompiled": true,
-    "isActionApp": true,
-    "bundlePath": "source/dist"
-  }
+  "config": { "isCompiled": true, "isActionApp": true, "bundlePath": "source/dist" }
 }
 ```
 
-### Copy source code
-
-The source path provided by the user must already contain the built `dist/` folder. Copy its contents into `<APP_NAME>/source/`, skipping `node_modules`:
+Run:
 
 ```bash
 rsync -a --exclude='node_modules' "<SOURCE_PATH>/" "<SOLUTION_DIR>/<APP_NAME>/source/"
 ```
 
-> The `dist/` folder must exist inside `<SOURCE_PATH>` before copying — it is the compiled output that the solution packages. If it is missing, never block waiting for a build: fall back to QuickForm instead (per SKILL.md Step 3's fallback rule), proceed, and state that you did so — the user can ask you to swap in the Coded Action App once it's built.
-
----
+Require `<SOURCE_PATH>/dist/`, the compiled output packaged by the solution. If it is missing, never wait for a build: fall back to QuickForm per SKILL.md Step 3's fallback rule, proceed, and state that you did so; the user can request a Coded Action App after it is built.
 
 ## Step 3 — Add Project to Solution
+
+Run:
 
 ```bash
 uip solution projects add --project-path "<APP_NAME>/project.uiproj" --solution-path "<SOLUTION_DIR>"
 ```
 
-This updates `<SOLUTION_DIR>/SolutionStorage.json` with a new `Projects` entry for the app.
-
-> If the command reports the project is already registered, read `SolutionStorage.json` to confirm and skip this step.
-
----
+If the command reports that the project is already registered, read `SolutionStorage.json` to confirm and skip the command.
 
 ## Step 4 — Write Solution Resource Files
 
-Create directories as needed. All paths are relative to `<SOLUTION_DIR>`.
+Create directories as needed. Paths are relative to `<SOLUTION_DIR>`.
 
-### 4a — Read and transform `action-schema.json`
+### 4a — Transform `action-schema.json`
 
-Read `<SOURCE_PATH>/action-schema.json`. The file has this top-level shape:
+Read `<SOURCE_PATH>/action-schema.json`, shaped as:
 
 ```json
 {
-  "inputs":   { "type": "object", "properties": { ... } },
-  "outputs":  { "type": "object", "properties": { ... } },
-  "inOuts":   { "type": "object", "properties": { ... } },
+  "inputs": { "type": "object", "properties": { ... } },
+  "outputs": { "type": "object", "properties": { ... } },
+  "inOuts": { "type": "object", "properties": { ... } },
   "outcomes": { "type": "object", "properties": { ... } }
 }
 ```
 
-Transform it into a `ParsedActionSchema` object using the algorithm below. This object is used in two places: JSON-stringified into `spec.actionSchema` in the resource file, and directly as `inputSchema`/`inOutSchema` arrays in the HITL node.
+Build one `ParsedActionSchema` and reuse it in `spec.actionSchema` and directly for the HITL node's `inputSchema`/`inOutSchema`.
 
-**Transform each property in `inputs.properties`, `outputs.properties`, and `inOuts.properties`:**
-
-For each `{ propertyKey: propDef }` entry:
+For every property in `inputs.properties`, `outputs.properties`, and `inOuts.properties`, recursively create:
 
 ```json
 {
@@ -141,10 +116,7 @@ For each `{ propertyKey: propDef }` entry:
 }
 ```
 
-For arrays (`propDef.type === "array"`): use `propDef.items.type` and `propDef.items.format` to determine the .NET type; recurse on `propDef.items.properties` if the item type is `"object"`.
-For objects (`propDef.type === "object"`): recurse on `propDef.properties`.
-
-**Type mapping** (`itemType` = `propDef.type` for scalars, `propDef.items.type` for arrays; `itemFormat` = `propDef.format` or `propDef.items.format`):
+For arrays, use `propDef.items.type` and `propDef.items.format`; recurse through `propDef.items.properties` for item type `object`. For objects, recurse through `propDef.properties`. Use `itemType = propDef.type` for scalars or `propDef.items.type` for arrays, and `itemFormat = propDef.format` or `propDef.items.format`:
 
 | Condition | .NET type |
 |---|---|
@@ -157,7 +129,7 @@ For objects (`propDef.type === "object"`): recurse on `propDef.properties`.
 | `itemType === "object"` | `System.Object` |
 | `itemType === "file"` | `UiPath.Platform.ResourceHandling.IResource` |
 
-**Transform each property in `outcomes.properties`:**
+Transform each `outcomes.properties` entry to:
 
 ```json
 {
@@ -173,7 +145,7 @@ For objects (`propDef.type === "object"`): recurse on `propDef.properties`.
 }
 ```
 
-**Assemble the final `ParsedActionSchema`:**
+Assemble:
 
 ```json
 {
@@ -182,20 +154,18 @@ For objects (`propDef.type === "object"`): recurse on `propDef.properties`.
   "description": "Action Schema",
   "id": "ID<new UUID with dashes removed>",
   "name": "ActionSchema",
-  "inputs":   [ /* transformed inputs */ ],
-  "outputs":  [ /* transformed outputs */ ],
-  "inOuts":   [ /* transformed inOuts */ ],
+  "inputs": [ /* transformed inputs */ ],
+  "outputs": [ /* transformed outputs */ ],
+  "inOuts": [ /* transformed inOuts */ ],
   "outcomes": [ /* transformed outcomes */ ]
 }
 ```
 
 Set `ACTION_SCHEMA_JSON_STRING = JSON.stringify(parsedSchema)`.
 
-### 4b — Read `externalClientId` from `uipath.json`
+### 4b — Read `externalClientId` and write resources
 
-Read `<SOURCE_PATH>/uipath.json`. Use its `clientId` field as `externalClientId` in the resource file below.
-
-### File: `resources/solution_folder/app/codedAction/<APP_NAME>.json`
+Read `<SOURCE_PATH>/uipath.json` and use its `clientId` as `externalClientId`. Create `resources/solution_folder/app/codedAction/<APP_NAME>.json`:
 
 ```json
 {
@@ -207,9 +177,7 @@ Read `<SOURCE_PATH>/uipath.json`. Use its `clientId` field as `externalClientId`
     "apiVersion": "apps.uipath.com/v1",
     "projectKey": "<PROJECT_KEY>",
     "isOverridable": true,
-    "dependencies": [
-      { "name": "<APP_NAME>", "kind": "package" }
-    ],
+    "dependencies": [{ "name": "<APP_NAME>", "kind": "package" }],
     "runtimeDependencies": [],
     "files": [],
     "folders": [{ "fullyQualifiedName": "solution_folder" }],
@@ -229,9 +197,9 @@ Read `<SOURCE_PATH>/uipath.json`. Use its `clientId` field as `externalClientId`
 }
 ```
 
-> `appSystemName` is `null` for a new app; the platform populates it on first deployment.
+`appSystemName` is `null` for a new app; the platform populates it on first deployment.
 
-### File: `resources/solution_folder/package/<APP_NAME>.json`
+Create `resources/solution_folder/package/<APP_NAME>.json`:
 
 ```json
 {
@@ -258,17 +226,13 @@ Read `<SOURCE_PATH>/uipath.json`. Use its `clientId` field as `externalClientId`
 }
 ```
 
----
-
 ## Step 5 — Write the HITL Node
 
-All values below come directly from the `ParsedActionSchema` assembled in Step 4a — reuse the same objects and UUIDs, do not regenerate them.
+Reuse the same `ParsedActionSchema` objects and UUIDs; do not regenerate them:
 
-- `inputs.app.inputSchema` = the `inputs` array from `ParsedActionSchema`
-- `inputs.app.inOutSchema` = the `inOuts` array from `ParsedActionSchema`
-- `schema.outcomes` = for each entry in `ParsedActionSchema.outcomes`: `{ "name": outcome.name, "type": "string" }`
-
-### Full Node JSON
+- `inputs.app.inputSchema` = `ParsedActionSchema.inputs`
+- `inputs.app.inOutSchema` = `ParsedActionSchema.inOuts`
+- `schema.outcomes` = `{ "name": outcome.name, "type": "string" }` for each parsed outcome
 
 ```json
 {
@@ -304,7 +268,7 @@ All values below come directly from the `ParsedActionSchema` assembled in Step 4
 }
 ```
 
-**`inputs.recipient` options** — same as AppTask:
+Use one of these `inputs.recipient` forms:
 
 ```json
 // Action Center, unassigned (default)
@@ -317,13 +281,11 @@ All values below come directly from the `ParsedActionSchema` assembled in Step 4
 "recipient": { "channels": ["ActionCenter"], "assignee": { "type": "group", "value": "Finance Team" } }
 ```
 
-**Definition entry** — uses `nodeType: "uipath.human-in-the-loop.coded-action-app"` (NOT the QuickForm nodeType). See [hitl-node-apptask.md](hitl-node-apptask.md#definition-entry) for the full definition block. Add once to `workflow.definitions`, deduplicated by `nodeType`.
+Add one definition entry to `workflow.definitions`, deduplicated by `nodeType`, using `nodeType: "uipath.human-in-the-loop.coded-action-app"`—not the QuickForm nodeType. See [hitl-node-apptask.md](hitl-node-apptask.md#definition-entry) for the full definition block.
 
-**Edge wiring** — wire `completed` (only handle available in v1.0). See [hitl-node-quickform.md](hitl-node-quickform.md) for edge format.
+Wire the `completed` handle only; it is the only handle available in v1.0. See [hitl-node-quickform.md](hitl-node-quickform.md) for edge format.
 
-**`variables.nodes` regeneration** — add `output` and `status` entries for the new node, then replace the entire array. See [hitl-node-quickform.md](hitl-node-quickform.md) for the regeneration algorithm.
-
----
+Add `output` and `status` entries for the new node to `variables.nodes`, then replace the entire array. See [hitl-node-quickform.md](hitl-node-quickform.md) for the regeneration algorithm.
 
 ## Runtime Variables
 

--- a/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
@@ -1,101 +1,73 @@
 # HITL QuickForm Node — Direct JSON Reference
 
-The agent writes the `uipath.human-in-the-loop.quick-form` node directly into the `.flow` file as JSON. **Direct JSON is the default.** A CLI opt-in is available when the user explicitly requests it, or as a fallback if direct JSON writing fails — see [CLI reference: uip maestro flow hitl add](../../uipath-maestro-flow/references/shared/cli-commands.md#uip-maestro-flow-hitl-add).
-
----
+Write `uipath.human-in-the-loop.quick-form` directly into the `.flow` file as JSON. **Direct JSON is the default.** Use the CLI only when the user explicitly requests it or direct JSON writing fails: [CLI reference: uip maestro flow hitl add](../../uipath-maestro-flow/references/shared/cli-commands.md#uip-maestro-flow-hitl-add).
 
 ## Step 1 — Extract the Schema Through Conversation
 
-**Never block on this.** Infer the answers to the questions below from the prompt and any upstream `.flow` data, and proceed straight to schema design — do not wait for a reply. If the user is present and volunteers this information unprompted, use it. Only stop and report the open decision if the request is genuinely too ambiguous to pick a sensible default.
+**Never block.** Infer answers from the prompt and upstream `.flow` data, use volunteered information, design and write the node immediately, and report the chosen schema prominently so the user can adjust it. Stop and report an open decision only when the request is genuinely too ambiguous for a sensible default; a prompt specifying fields, outcomes, and output shape is never too ambiguous.
 
-| What you need to know | Question to ask |
-|---|---|
-| What the reviewer sees | "What information does the reviewer need to make their decision?" |
-| What they fill in | "Does the reviewer need to enter any data, or just click Approve/Reject?" |
-| What actions they take | "What are the named actions — e.g. Approve/Reject, or something domain-specific like Accept/Negotiate/Decline?" |
+Determine what the reviewer sees, whether they only choose an outcome or also enter data, and the named actions. Translate business requirements into `inputs`, `outputs`, `inOuts`, and `outcomes`:
 
-**Common business descriptions → schema translations:**
-
-| Business description | Schema shape |
-|---|---|
-| "Human reviews and approves/rejects an invoice" | `inputs: [invoiceId, amount]`, `outcomes: [Approve, Reject]` |
-| "Reviewer checks agent-drafted email before sending" | `inputs: [draftEmail, recipientName]`, `inOuts: [emailBody]`, `outcomes: [Approve, Reject]` |
-| "Escalate to human when confidence < 0.7" | `inputs: [agentReasoning, confidenceScore]`, `outputs: [action, notes]`, `outcomes: [Retry, Skip, Escalate]` |
-| "Human fills in missing vendor data" | `inputs: [rawExtract]`, `outputs: [vendorName, costCenter]`, `outcomes: [Submit]` |
-| "Approve before writing to ServiceNow" | `inputs: [proposedChange, targetSystem]`, `inOuts: [finalValue]`, `outcomes: [Approve, Reject]` |
-
----
+- Approval/rejection: read-only context such as `invoiceId`, `amount`; outcomes such as `Approve`, `Reject`.
+- Editable review: read-only context plus editable `inOut` data such as `emailBody`.
+- Escalation: inputs such as reasoning and confidence; outputs such as action and notes; outcomes such as `Retry`, `Skip`, `Escalate`.
+- Data completion: raw input plus output fields; outcome such as `Submit`.
+- Proposed change: read-only proposal and target plus editable final value; outcomes such as `Approve`, `Reject`.
 
 ## Step 1b — Discover Upstream Variables
 
-Before designing input field bindings, read **both** `workflow.variables.nodes` and `workflow.variables.globals` from the `.flow` file.
+Before designing bindings, read both `workflow.variables.nodes` and `workflow.variables.globals`.
 
-### Node outputs (`variables.nodes`)
-
-Each entry exposes exactly what `$vars` paths are available:
+Each `variables.nodes` entry exposes a `$vars` path:
 
 ```json
 { "id": "fetchInvoice.output", "type": "object", "binding": { "nodeId": "fetchInvoice", "outputId": "output" } }
 ```
 
-The `id` field is the `$vars` path — `fetchInvoice.output` → `$vars.fetchInvoice.output`. Nested field access appends `.fieldName` (e.g., `$vars.fetchInvoice.output.invoiceId`).
+`fetchInvoice.output` maps to `$vars.fetchInvoice.output`; append nested fields such as `$vars.fetchInvoice.output.invoiceId`.
 
-> **Binding path key = upstream script output key, not the HITL field `id`.** The HITL field `id` identifies the form field (lowercase, used for rendering). The binding path key is the property name in the upstream script's `return` statement. These are different things. If the script returns `{ supplierName: "Acme" }` and you give the HITL field `"id": "suppliername"`, the correct binding is `vars.fetchSupplier.output.supplierName` — NOT `vars.fetchSupplier.output.suppliername`. The field `id` is irrelevant to the binding path. Always look at the upstream script source to derive the key, never at the HITL field schema you are writing.
+**Binding path key = upstream script output key, not the HITL field `id`.** Inspect upstream script source and use the property name in its `return`: if it returns `{ supplierName: "Acme" }`, bind with `vars.fetchSupplier.output.supplierName`, even if the HITL field id is `suppliername`.
 
-**outputId by node type:**
-
-| Node type | outputId | Access pattern |
+| Node type | `outputId` | Access pattern |
 |---|---|---|
-| HTTP node | `output` | `$vars.{nodeId}.output.body.{field}` |
-| Script node | `output` | `$vars.{nodeId}.output.{field}` |
-| Prior HITL node | `output`, `status` | `$vars.{nodeId}.output.{field}` |
-| Agent node | `output` | `$vars.{nodeId}.output.content` |
-| Trigger (manual) | `output` | `$vars.start.output.{field}` |
+| HTTP | `output` | `$vars.{nodeId}.output.body.{field}` |
+| Script | `output` | `$vars.{nodeId}.output.{field}` |
+| Prior HITL | `output`, `status` | `$vars.{nodeId}.output.{field}` |
+| Agent | `output` | `$vars.{nodeId}.output.content` |
+| Manual trigger | `output` | `$vars.start.output.{field}` |
 
-### Flow-level globals (`variables.globals`)
-
-Also read `workflow.variables.globals`. Each entry has an `id` that maps directly to a `$vars` reference — no node prefix, no `.output` segment:
+Read `workflow.variables.globals`. A global such as:
 
 ```json
 { "id": "customerName", "direction": "in", "type": "string" }
 ```
 
-→ HITL binding: `"vars.customerName"` (no `=js:$` prefix — HITL binding is a raw path)
+maps directly to `vars.customerName`. Use `direction: "in"` globals for flow-level trigger inputs via `triggerNodeId`.
 
-**When to use globals instead of node outputs:** When data was declared as a flow-level input variable (e.g. the trigger passes it as a named parameter via `triggerNodeId`), it lives in `globals` with `direction: "in"`. Bind directly to `vars.<globalId>` — do not add `.output` or a node prefix.
-
-| Source | HITL `binding` format | Expression format (other nodes) |
+| Source | HITL `binding` | Other-node expression |
 |---|---|---|
 | Node output | `vars.<nodeId>.output.<field>` | `=js:$vars.<nodeId>.output.<field>` |
 | Flow global (`direction: "in"`) | `vars.<globalId>` | `=js:$vars.<globalId>` |
 
-> **`binding` vs `variable` prefix rule:** `binding` (input/inOut fields) uses the full path starting with `vars.` because it references an existing variable path. `variable` (output/inOut fields) uses `vars.<name>` — the `vars.` prefix is required; it declares the global variable name.
-
-For the full variable system, see → [How $vars paths are constructed in Flow](../../uipath-maestro-flow/references/shared/variables-and-expressions.md)
-
----
+`binding` uses the full existing path beginning with `vars.`; never add `=js:$`. `variable` declares an output/inOut global name and also requires `vars.`. See [How $vars paths are constructed in Flow](../../uipath-maestro-flow/references/shared/variables-and-expressions.md).
 
 ## Step 2 — Design the Schema
 
-The node schema uses `fields[]` entries inside `inputs.schema`. Use these conceptual roles to plan the fields before writing the node JSON:
+Plan `inputs.schema.fields[]` with these roles:
 
-| Role | `direction` value | Human can… | Use for |
+| Role | `direction` | Human can… | Use for |
 |---|---|---|---|
-| Input field | `"input"` | Read only | Context the human needs to make a decision |
-| Output field | `"output"` | Write | Data the automation needs back |
-| InOut field | `"inOut"` | Read + modify | Data the human can see and optionally correct |
+| Input | `"input"` | Read only | Decision context |
+| Output | `"output"` | Write | Data automation needs back |
+| InOut | `"inOut"` | Read + modify | Data the human may correct |
 
-**Supported field types:** `string`, `number`, `boolean`, `date`, `file`
+Supported types are `string`, `number`, `boolean`, `date`, and `file`.
 
-**Design rules:**
-- Input fields: everything the human needs to decide — IDs, amounts, context; bind to upstream node output via `binding`
-- Output fields: only what downstream nodes actually use; set `required: true` for mandatory outputs
-- `outcomes`: use domain-specific names (Approve/Reject, not just Submit)
-- Keep it focused — don't add fields the automation won't use
-
-**Never block on this — write the node, don't wait to show the schema first.** Design the schema from the prompt and any upstream `.flow` data, write the node, and record the chosen schema prominently in the final report so the user can adjust it afterward. Only stop and report the open decision if the request is genuinely too ambiguous to pick a sensible default. (A prompt that already specifies the fields, outcomes, and output shape is never too ambiguous.)
-
----
+- Bind input fields to upstream data; use globals when appropriate.
+- Include only output fields used downstream; set `required: true` for mandatory outputs.
+- Use domain-specific outcomes, not generic `Submit` unless appropriate.
+- Keep the schema focused.
+- Write the node immediately and record the selected schema prominently in the final report.
 
 ## Full Node JSON
 
@@ -116,40 +88,14 @@ The node schema uses `fields[]` entries inside `inputs.schema`. Use these concep
     "schema": {
       "schemaId": "a3f7c2d1-8b4e-4f9a-b2c5-6d8e1f3a7b9c",
       "fields": [
-        {
-          "id": "invoiceid",
-          "label": "Invoice ID",
-          "type": "string",
-          "direction": "input",
-          "binding": "vars.fetchInvoice.output.invoiceId"
-        },
-        {
-          "id": "amount",
-          "label": "Amount",
-          "type": "number",
-          "direction": "input",
-          "binding": "vars.fetchInvoice.output.amount"
-        },
-        {
-          "id": "notes",
-          "label": "Notes",
-          "type": "string",
-          "direction": "output",
-          "variable": "vars.notes",
-          "required": false
-        },
-        {
-          "id": "decision",
-          "label": "Decision",
-          "type": "string",
-          "direction": "output",
-          "variable": "vars.decision",
-          "required": true
-        }
+        { "id": "invoiceid", "label": "Invoice ID", "type": "string", "direction": "input", "binding": "vars.fetchInvoice.output.invoiceId" },
+        { "id": "amount", "label": "Amount", "type": "number", "direction": "input", "binding": "vars.fetchInvoice.output.amount" },
+        { "id": "notes", "label": "Notes", "type": "string", "direction": "output", "variable": "vars.notes", "required": false },
+        { "id": "decision", "label": "Decision", "type": "string", "direction": "output", "variable": "vars.decision", "required": true }
       ],
       "outcomes": [
-        { "id": "approve", "name": "Approve", "type": "string", "isPrimary": true,  "action": "Continue" },
-        { "id": "reject",  "name": "Reject",  "type": "string", "isPrimary": false, "action": "End" }
+        { "id": "approve", "name": "Approve", "type": "string", "isPrimary": true, "action": "Continue" },
+        { "id": "reject", "name": "Reject", "type": "string", "isPrimary": false, "action": "End" }
       ]
     }
   },
@@ -160,9 +106,9 @@ The node schema uses `fields[]` entries inside `inputs.schema`. Use these concep
       "source": "=result",
       "var": "output",
       "properties": {
-        "notes":    { "type": "string" },
+        "notes": { "type": "string" },
         "decision": { "type": "string" },
-        "Action":   { "type": "string", "enum": ["Approve", "Reject"], "default": "Approve" }
+        "Action": { "type": "string", "enum": ["Approve", "Reject"], "default": "Approve" }
       }
     },
     "status": {
@@ -177,15 +123,11 @@ The node schema uses `fields[]` entries inside `inputs.schema`. Use these concep
 }
 ```
 
-**Required fields:** `id`, `type`, `typeVersion`. Position goes in the top-level `layout.nodes` object (keyed by node id), not on the node itself.
-
-**Node ID rule:** camelCase from the label, strip non-alphanumeric, append `1` (increment to `2`, `3`... until unique among existing node IDs). Example: `"Invoice Review"` → `invoiceReview1`.
-
----
+Required top-level fields are `id`, `type`, and `typeVersion`. Put position in top-level `layout.nodes`, keyed by node id, never on the node. Derive the id as camelCase from the label, strip non-alphanumeric characters, append `1`, and increment until unique: `Invoice Review` → `invoiceReview1`.
 
 ## Definition Entry
 
-Every `.flow` file must have one definition entry for `uipath.human-in-the-loop.quick-form` in `workflow.definitions`. Add it exactly once — deduplicate by `nodeType`.
+Every `.flow` must contain exactly one `workflow.definitions` entry for this node type; deduplicate by `nodeType`:
 
 ```json
 {
@@ -195,28 +137,16 @@ Every `.flow` file must have one definition entry for `uipath.human-in-the-loop.
   "description": "Fast inline approvals with inline debug",
   "tags": ["human-task", "hitl", "human-in-the-loop", "quick-form", "approval"],
   "sortOrder": 27,
-  "display": {
-    "label": "Quick Form",
-    "icon": "users",
-    "shape": "square"
-  },
+  "display": { "label": "Quick Form", "icon": "users", "shape": "square" },
   "handleConfiguration": [
     {
       "position": "left",
-      "handles": [
-        {
-          "id": "input",
-          "type": "target",
-          "handleType": "input"
-        }
-      ],
+      "handles": [{ "id": "input", "type": "target", "handleType": "input" }],
       "visible": true
     },
     {
       "position": "right",
-      "handles": [
-        { "id": "completed", "label": "Completed", "type": "source", "handleType": "output", "showButton": true, "constraints": { "forbiddenTargetCategories": ["trigger"] } }
-      ],
+      "handles": [{ "id": "completed", "label": "Completed", "type": "source", "handleType": "output", "showButton": true, "constraints": { "forbiddenTargetCategories": ["trigger"] } }],
       "visible": true
     }
   ],
@@ -226,11 +156,7 @@ Every `.flow` file must have one definition entry for `uipath.human-in-the-loop.
       "fields": [],
       "outcomes": [{ "id": "submit", "name": "Submit", "type": "string", "isPrimary": true, "action": "Continue" }]
     },
-    "recipient": {
-      "channels": ["Email", "ActionCenter"],
-      "connections": {},
-      "assignee": { "type": "group" }
-    }
+    "recipient": { "channels": ["Email", "ActionCenter"], "connections": {}, "assignee": { "type": "group" } }
   },
   "outputDefinition": {
     "output": { "type": "object", "description": "Task result data", "source": "=result", "var": "output" },
@@ -239,23 +165,19 @@ Every `.flow` file must have one definition entry for `uipath.human-in-the-loop.
 }
 ```
 
----
-
 ## Edge Wiring
 
-Wire the `completed` output handle to the downstream node. Edge ID format: `{sourceNodeId}-{sourcePort}-{targetNodeId}-{targetPort}` (append `-2`, `-3` on collision).
+Wire the `completed` output handle to the downstream node. Use edge ids `{sourceNodeId}-{sourcePort}-{targetNodeId}-{targetPort}`; append `-2`, `-3`, and so on for collisions:
 
 ```json
 { "id": "invoiceReview1-completed-processApproval1-input", "sourceNodeId": "invoiceReview1", "sourcePort": "completed", "targetNodeId": "processApproval1", "targetPort": "input" }
 ```
 
-**Always wire `completed`.** A HITL node with no edge on `completed` blocks the flow forever.
-
----
+**Always wire `completed`.** Without this edge the flow blocks forever.
 
 ## `variables.nodes` — Regenerate After Every Node Add/Remove
 
-The HITL node exposes two outputs (`output`, `status`). After adding it, **completely replace** `workflow.variables.nodes` by iterating all nodes and collecting their outputs:
+After adding or removing a node, completely replace `workflow.variables.nodes` by iterating every node and collecting its outputs. Include all nodes, not only HITL nodes; never append. Each HITL contributes exactly one `output` and one `status` entry, with no per-field entries:
 
 ```json
 "variables": {
@@ -276,175 +198,77 @@ The HITL node exposes two outputs (`output`, `status`). After adding it, **compl
 }
 ```
 
-Include entries for **all** nodes in the flow, not just the HITL node. Replace the entire array — do not append. Add one `output` entry and one `status` entry per HITL node — no per-field entries. Output and inOut field values from the task are accessible via `$vars.<nodeId>.output.<fieldId>` at runtime (fields are embedded in the output object, not exposed as separate node variables).
+Output and inOut values are embedded in the output object and accessed as `$vars.<nodeId>.output.<fieldId>`. **Scripts must always use `$vars.<nodeId>.output.<fieldId>`.** Do not use the global alias from `field.variable` directly in scripts. `$vars.decision` and `$vars.<nodeId>.output.decision` are different paths; the field-id path is reliable in script nodes. See Critical Rule 10 in SKILL.md.
 
-> **Scripts must always use `$vars.<nodeId>.output.<fieldId>`.** The `field.variable` property declares a name for the global alias — do NOT use that name directly in scripts. `$vars.decision` (global alias) and `$vars.<nodeId>.output.decision` (field ID access) are different paths and only the field ID path is reliable in script nodes. See Critical Rule 10 in SKILL.md.
-
----
-
-## Canonical Field Shape (reference)
-
-This is the exact JSON a correctly authored QuickForm `fields[]` entry looks like for each direction. Use this as ground truth when writing or reviewing HITL nodes.
+## Canonical Field Shape
 
 ```json
 {
   "fields": [
-    {
-      "id": "invoiceid",
-      "type": "number",
-      "label": "Invoice ID",
-      "direction": "input",
-      "binding": "vars.fetchInvoice1.output.invoiceId"
-    },
-    {
-      "id": "vendorname",
-      "type": "string",
-      "label": "Vendor Name",
-      "direction": "input",
-      "binding": "vars.fetchInvoice1.output.vendorName"
-    },
-    {
-      "id": "approveddate",
-      "type": "date",
-      "label": "Approved Date",
-      "direction": "output",
-      "variable": "vars.approvedDate"
-    },
-    {
-      "id": "approved",
-      "type": "boolean",
-      "label": "Approved",
-      "direction": "output",
-      "variable": "vars.approved"
-    }
+    { "id": "invoiceid", "type": "number", "label": "Invoice ID", "direction": "input", "binding": "vars.fetchInvoice1.output.invoiceId" },
+    { "id": "vendorname", "type": "string", "label": "Vendor Name", "direction": "input", "binding": "vars.fetchInvoice1.output.vendorName" },
+    { "id": "approveddate", "type": "date", "label": "Approved Date", "direction": "output", "variable": "vars.approvedDate" },
+    { "id": "approved", "type": "boolean", "label": "Approved", "direction": "output", "variable": "vars.approved" }
   ],
   "outcomes": [
-    {
-      "id": "submit",
-      "name": "Submit",
-      "type": "string",
-      "action": "Continue",
-      "isPrimary": true
-    }
+    { "id": "submit", "name": "Submit", "type": "string", "action": "Continue", "isPrimary": true }
   ]
 }
 ```
 
-**Key rules this sample encodes:**
-- `type`: always a JS/JSON type — `string`, `number`, `boolean`, `date`, or `file`. Never `"text"`.
-- `variable`: always `"vars.<name>"` — the `vars.` prefix is required.
-- `binding`: input/inOut fields only; raw path (`vars.<nodeId>.output.<field>`), no `=js:$` prefix.
-- Output/inOut fields have `variable`; input fields do not.
+Field rules:
 
----
+- `id` is the lowercase label with spaces changed to `-` and non-alphanumeric characters stripped: `Invoice ID` → `invoiceid`, `Due Date` → `due-date`.
+- `type` is exactly `string`, `number`, `boolean`, `date`, or `file`; never `text`.
+- `binding` is only for input/inOut fields and is a raw `vars...` path with no `=js:$` prefix.
+- `variable` is only for output/inOut fields and always has the form `vars.<name>`; default to `vars.<camelCase id>` when unspecified.
+- Omit `required` when false; set it to `true` for mandatory outputs.
+- Input fields have no `variable`; output fields have no `binding`; inOut fields have both.
+- Generate a fresh UUID v4 for `schema.schemaId`, using `crypto.randomUUID()` or equivalent.
+- `outcomes[0]` has `isPrimary: true` and `action: "Continue"`; later outcomes have `isPrimary: false` and `action: "End"`.
+- Use `outcomeType: "Neutral"` for middle outcomes that are neither clearly positive nor negative, such as Skip, Defer, or Hold.
 
-## Schema Conversion — Examples
-
-The agent translates the user's business description into the `fields[]` and `outcomes[]` arrays. No CLI needed — apply these rules directly.
-
-### Rules
-
-| What | Rule |
-|---|---|
-| field `id` | lowercase label, spaces→`-`, strip non-alphanumeric. `"Invoice ID"` → `"invoiceid"`, `"Due Date"` → `"due-date"` |
-| `direction` | `inputs[]` items → `"input"`, `outputs[]` → `"output"`, `inOuts[]` → `"inOut"` |
-| field `type` | Use the JS/JSON type: `string`, `number`, `boolean`, `date`, or `file` |
-| `binding` | **Input / inOut fields only.** Format: `"vars.<nodeId>.output.<field>"` for node outputs; `"vars.<globalId>"` for flow globals. **No `=js:$` prefix** — HITL binding is a raw path, not an expression. |
-| `variable` | **Output / inOut fields only** — absent on input fields. Format: `"vars.<name>"` (always include the `vars.` prefix). Defaults to `"vars.<camelCase id>"` if not specified. |
-| `required` | omit if false; set `true` for mandatory outputs |
-| `outcomes[0]` | `isPrimary: true`, `action: "Continue"` |
-| `outcomes[1+]` | `isPrimary: false`, `action: "End"` |
-| `schema.schemaId` | Generate a fresh UUID (e.g. `crypto.randomUUID()` or any UUID v4) |
-
-### Example 1 — Simple approval (inputs only + outcomes)
-
-Business description: *"Reviewer sees invoice ID and amount, clicks Approve or Reject"*
+Compact patterns:
 
 ```json
+// Input-only approval
 "fields": [
-  { "id": "invoiceid", "label": "Invoice ID", "type": "string",   "direction": "input", "binding": "vars.fetchData1.output.invoiceId" },
-  { "id": "amount",    "label": "Amount",     "type": "number", "direction": "input", "binding": "vars.fetchData1.output.amount" }
+  { "id": "invoiceid", "label": "Invoice ID", "type": "string", "direction": "input", "binding": "vars.fetchData1.output.invoiceId" },
+  { "id": "amount", "label": "Amount", "type": "number", "direction": "input", "binding": "vars.fetchData1.output.amount" }
 ],
 "outcomes": [
-  { "id": "approve", "name": "Approve", "type": "string", "isPrimary": true,  "action": "Continue" },
-  { "id": "reject",  "name": "Reject",  "type": "string", "isPrimary": false, "action": "End" }
+  { "id": "approve", "name": "Approve", "type": "string", "isPrimary": true, "action": "Continue" },
+  { "id": "reject", "name": "Reject", "type": "string", "isPrimary": false, "action": "End" }
+]
+
+// Editable input
+{ "id": "emailbody", "label": "Email Body", "type": "string", "direction": "inOut", "binding": "vars.draft1.output.body", "variable": "vars.emailBody" }
+
+// Human-entered outputs
+[
+  { "id": "vendorname", "label": "Vendor Name", "type": "string", "direction": "output", "variable": "vars.vendorName", "required": true },
+  { "id": "costcenter", "label": "Cost Center", "type": "string", "direction": "output", "variable": "vars.costCenter", "required": true }
 ]
 ```
-
-### Example 2 — Write-back validation (inOut — human can edit before confirming)
-
-Business description: *"Human sees the AI-drafted email, can edit it, then clicks Send or Discard"*
-
-```json
-"fields": [
-  { "id": "recipient",  "label": "Recipient",  "type": "string", "direction": "input", "binding": "vars.draft1.output.recipient" },
-  { "id": "emailbody",  "label": "Email Body", "type": "string", "direction": "inOut", "binding": "vars.draft1.output.body", "variable": "vars.emailBody" }
-],
-"outcomes": [
-  { "id": "send",    "name": "Send",    "type": "string", "isPrimary": true,  "action": "Continue" },
-  { "id": "discard", "name": "Discard", "type": "string", "isPrimary": false, "action": "End" }
-]
-```
-
-### Example 3 — Data enrichment (output — human fills in missing fields)
-
-Business description: *"Agent couldn't extract vendor name or cost center. Human fills them in and clicks Submit."*
-
-```json
-"fields": [
-  { "id": "rawextract",  "label": "Raw Extract",  "type": "string", "direction": "input",  "binding": "vars.extract1.output.rawText" },
-  { "id": "vendorname",  "label": "Vendor Name",  "type": "string", "direction": "output", "variable": "vars.vendorName",  "required": true },
-  { "id": "costcenter",  "label": "Cost Center",  "type": "string", "direction": "output", "variable": "vars.costCenter", "required": true }
-],
-"outcomes": [
-  { "id": "submit", "name": "Submit", "type": "string", "isPrimary": true, "action": "Continue" }
-]
-```
-
-### Example 4 — Exception escalation (multiple outcomes + notes output)
-
-Business description: *"If agent confidence is low, escalate. Human sees reasoning and score, can Retry, Skip, or Escalate further."*
-
-```json
-"fields": [
-  { "id": "reasoning",       "label": "Agent Reasoning",  "type": "string",   "direction": "input",  "binding": "vars.classify1.output.reasoning" },
-  { "id": "confidencescore", "label": "Confidence Score", "type": "number", "direction": "input",  "binding": "vars.classify1.output.score" },
-  { "id": "notes",           "label": "Notes",            "type": "string",   "direction": "output", "variable": "vars.notes" }
-],
-"outcomes": [
-  { "id": "retry",    "name": "Retry",    "type": "string", "isPrimary": true,  "action": "Continue" },
-  { "id": "skip",     "name": "Skip",     "type": "string", "isPrimary": false, "action": "End" },
-  { "id": "escalate", "name": "Escalate", "type": "string", "isPrimary": false, "action": "End" }
-]
-```
-
-> **`outcomeType` for middle outcomes:** Use `"Neutral"` when the outcome is neither clearly positive nor negative (e.g., Skip, Defer, Hold).
-
----
 
 ## Runtime Variables
 
-After the HITL node, downstream nodes can reference:
-
-| Variable | Type | What it contains |
+| Variable | Type | Contents |
 |---|---|---|
-| `$vars.<nodeId>.output` | object | All `output` and `inOut` field values keyed by **field `id`** |
-| `$vars.<nodeId>.output.<fieldId>` | varies | Individual field value using the field's `id` (e.g. `$vars.invoiceReview1.output.decision`) |
-| `$vars.<nodeId>.status` | string | Selected outcome name (e.g. `"Approve"`, `"Reject"`) |
-| `$vars.<globalId>` | varies | Workflow-global variable for output/inOut fields. `globalId` is `field.variable` with `vars.` stripped (e.g. `variable: "vars.notes"` → `$vars.notes`). **Do not use this path in scripts — use `$vars.<nodeId>.output.<fieldId>` instead.** |
+| `$vars.<nodeId>.output` | object | All output and inOut values keyed by field `id` |
+| `$vars.<nodeId>.output.<fieldId>` | varies | Individual field value keyed by field `id` |
+| `$vars.<nodeId>.status` | string | Selected outcome name, such as `"Approve"` or `"Reject"` |
+| `$vars.<globalId>` | varies | Workflow global created by output/inOut `field.variable`; strip `vars.` from the variable path |
 
-> **`fieldId` not `variable`**: The output object properties are keyed by the field's `id` (e.g. `"decision"`), not by the `variable` property. The `variable` property (`"approvalResult"`) creates a separate workflow-global variable (`$vars.approvalResult`) — it does not change the key used in the output object. If a field has `"id": "dec1"` and `"variable": "vars.approvalResult"`, access it via the object as `$vars.nodeId.output.dec1`, or directly as `$vars.approvalResult`.
->
-> **Common mistake:** A field with `"id": "approved"` and `"variable": "vars.legalApproval"` must be read as `$vars.<nodeId>.output.approved` — **not** `$vars.<nodeId>.output.legalApproval`. Using the `variable` name as the key produces `undefined` at runtime; `flow validate` does not catch it.
+The output object uses the field `id`, not the `variable` name. If `id` is `dec1` and `variable` is `vars.approvalResult`, use `$vars.<nodeId>.output.dec1` or `$vars.approvalResult`; in scripts, use only the node output path. Using the variable name as the output-object key produces `undefined`, and `flow validate` does not catch it.
 
-**In a downstream script node** — always access inline using `$vars.<nodeId>.output.<fieldId>`, not by destructuring:
+In downstream scripts, access fields inline and do not destructure first:
+
 ```javascript
-// Correct — field ID inline access
 const vendorName = $vars.invoiceReview1.output.vendorName;
 const costCenter = $vars.invoiceReview1.output.costCenter;
 if ($vars.invoiceReview1.status === "approve") {
   await updateSystem(vendorName, costCenter);
 }
-// Wrong — do NOT destructure first:
-// const output = $vars.invoiceReview1.output;  // then output.vendorName misses the node path
+// Wrong: const output = $vars.invoiceReview1.output; then output.vendorName
 ```

--- a/skills/uipath-human-in-the-loop/references/hitl-patterns.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-patterns.md
@@ -1,152 +1,34 @@
 # HITL Business Pattern Recognition Guide
 
-Use this guide to decide whether a business process needs a Human-in-the-Loop node, and where to place it — even when the user has not explicitly asked for one.
-
----
+Decide whether a business process needs a Human-in-the-Loop (HITL) node, and where to place it, even when the user has not explicitly requested one.
 
 ## When to Recommend HITL
 
-Look for these signals in the business description or process context:
+Recommend HITL when any of these signals appears:
 
-### Approval gate
-The automation produces something that requires sign-off before it can proceed.
-
-| Signal phrases | Examples |
-|---|---|
-| "approve", "sign off", "authorize", "get approval" | Invoice approval, PO sign-off, budget authorization |
-| "four-eyes check", "dual control", "maker-checker" | Financial transactions, compliance workflows |
-| "review before posting", "validate before sending" | CRM updates, email campaigns, database writes |
-
-**Insertion point:** After the automation generates the artifact to review, before it takes the action requiring approval.
-
----
-
-### Exception escalation
-The automation hits a case it cannot resolve autonomously and needs a human decision.
-
-| Signal phrases | Examples |
-|---|---|
-| "if uncertain / low confidence, escalate" | AI agent confidence threshold |
-| "edge case", "anomaly", "exception handling" | Fraud alerts, out-of-policy transactions |
-| "escalate to manager / supervisor" | Customer service workflows |
-
-**Insertion point:** Inside a conditional branch where the automation detects it cannot proceed alone.
-
----
-
-### Data enrichment
-The automation extracted or generated data that is incomplete — a human must fill in the gaps.
-
-| Signal phrases | Examples |
-|---|---|
-| "fill in missing fields", "enrich", "complete the record" | Partially extracted invoice data |
-| "human validates / corrects" | OCR output verification |
-| "needs human input before continuing" | Missing vendor code, unknown cost center |
-
-**Insertion point:** After extraction/generation, before the downstream step that requires complete data.
-
----
-
-### Compliance and audit checkpoint
-A regulation or internal policy requires documented human sign-off.
-
-| Signal phrases | Examples |
-|---|---|
-| "compliance", "audit trail", "regulatory sign-off" | SOX controls, GDPR consent flows |
-| "must be reviewed by", "requires attestation" | Legal review gates, privacy impact assessments |
-
-**Insertion point:** At the mandated checkpoint defined by the regulation or policy.
-
----
-
-### Write-back validation
-An agent or automation is about to write to an external system — a human must confirm the proposed change.
-
-| Signal phrases | Examples |
-|---|---|
-| "before writing to", "before posting to", "agent writes to ServiceNow / SAP / CRM" | Any write to a system of record |
-| "human confirms before agent acts" | Autonomous agent guard rails |
-
-**Insertion point:** Immediately before the write/post action.
-
----
-
-### Agentic output review
-An AI agent produced a document, draft, classification, or recommendation — a human must verify it before the result is used or published.
-
-| Signal phrases | Examples |
-|---|---|
-| "review AI-generated content", "human verifies before sending" | Agent-drafted emails, RCA reports, meeting summaries |
-| "check before publishing", "validate AI output" | AI-written case notes, support ticket responses |
-| "human in the loop for AI decisions" | Any LLM output going to a system of record or customer |
-
-**Insertion point:** After the agent node, before the downstream action that consumes the output.
-
----
-
-### IT / change management approval
-A change request or access request needs human authorization before the automation executes it.
-
-| Signal phrases | Examples |
-|---|---|
-| "CAB approval", "change request", "change window" | IT change management (ServiceNow, Jira Service Management) |
-| "access request", "provision access", "grant permission" | Identity and access management workflows |
-| "runbook approval", "deployment sign-off" | DevOps release gates |
-
-**Insertion point:** After the automation prepares the change record, before it applies the change.
-
----
-
-### HR and offer / contract workflows
-A document or decision with legal or HR significance must be reviewed before it is sent to a third party.
-
-| Signal phrases | Examples |
-|---|---|
-| "offer letter", "employment contract", "onboarding approval" | HR hiring workflows |
-| "termination review", "performance decision" | HR case management |
-| "contract terms", "counter-sign", "legal review gate" | Procurement, vendor onboarding |
-
-**Insertion point:** After document generation, before the document is dispatched.
-
----
-
-### Customer communication approval
-An automation is about to send a message on behalf of a person or brand — a human must review tone, accuracy, or content before it goes out.
-
-| Signal phrases | Examples |
-|---|---|
-| "approve before sending", "review draft email", "check before posting" | Customer support responses, marketing emails |
-| "agent-written reply", "draft response" | Helpdesk, CRM follow-ups |
-
-**Insertion point:** After the draft is generated, before the send/post action.
-
----
-
-### Financial transaction approval
-A monetary action above a threshold or of a certain type requires human sign-off.
-
-| Signal phrases | Examples |
-|---|---|
-| "above threshold", "over limit", "exceeds budget" | PO approval, expense reimbursement over limit |
-| "wire transfer", "payment release", "credit note" | AP/AR workflows |
-| "price override", "discount approval" | Sales quote approval |
-
-**Insertion point:** After the automation determines the transaction details, before it submits the payment or posts the entry.
-
----
+| Signal | Indicators | Insertion point |
+|---|---|---|
+| **Approval gate** | Approval, sign-off, authorization, four-eyes/dual control/maker-checker, or review before posting or sending; includes invoices, orders, budgets, CRM updates, campaigns, and database writes. | After generating the artifact and before the action requiring approval. |
+| **Exception escalation** | Uncertainty, low confidence, edge cases, anomalies, exception handling, or escalation to a manager/supervisor; includes fraud, out-of-policy transactions, and customer cases. | In the branch where automation cannot proceed autonomously. |
+| **Data enrichment** | Missing fields, enrichment, record completion, or human validation/correction; includes incomplete extraction, missing vendor codes, and unknown cost centers. | After extraction or generation and before the step requiring complete data. |
+| **Compliance and audit checkpoint** | Compliance, audit trail, regulatory sign-off, required review, or attestation; includes financial controls, consent, legal review, and privacy assessments. | At the checkpoint required by regulation or policy. |
+| **Write-back validation** | Human confirmation before writing or posting to an external system. | Immediately before the write or post action. |
+| **Agentic output review** | Review or validation of AI-generated documents, drafts, classifications, recommendations, case notes, decisions, or responses before sending, publishing, consuming, or recording them. | After the agent node and before the downstream action. |
+| **IT/change-management approval** | CAB approval, change requests/windows, access requests, provisioning, permission grants, runbook approval, or deployment sign-off. | After preparing the change or access record and before applying it. |
+| **HR, offer, or contract workflow** | Offer letters, employment contracts, onboarding approval, termination or performance decisions, contract terms, counter-signature, or legal review. | After document generation or decision preparation and before dispatch or execution. |
+| **Customer communication approval** | Review or approval of an email, post, or agent-written reply before sending or posting. | After draft generation and before the send or post action. |
+| **Financial transaction approval** | Threshold or budget overruns, wire transfers, payment release, credit notes, price overrides, or discount approval. | After determining transaction details and before submitting payment or posting the entry. |
 
 ## When NOT to Recommend HITL
 
-- The process description is fully automated with no decision point (e.g. "process all invoices automatically")
-- The human interaction is asynchronous notification only (use email/Slack activity instead)
-- The user explicitly says no human review is needed
-- The decision can be made by a rule or AI model with sufficient confidence
-- The user is asking about **runtime task management** — reassigning, monitoring, cancelling, or checking the status of existing Action Center tasks. These are operational questions answered by `uip tasks` commands or the Orchestrator UI, not by adding a HITL node. A question like "how do I reassign a task sitting for 3 days?" is task administration, not automation authoring — do not recommend adding a HITL checkpoint in response.
-
----
+- The process is fully automated with no decision point, such as processing all invoices automatically.
+- The interaction is asynchronous notification only; use an email or Slack activity instead.
+- The user explicitly says no human review is needed.
+- A rule or AI model can make the decision with sufficient confidence.
+- The user asks about **runtime task management**—reassigning, monitoring, cancelling, or checking the status of existing Action Center tasks. Answer with `uip tasks` commands or the Orchestrator UI, not by adding a HITL node. Reassigning a task sitting for days is task administration, not automation authoring.
 
 ## Proactive HITL Recommendation
 
-**Never block on this.** If a business description contains any of the above signals but the user has not asked for a HITL, state it and proceed straight to Step 3 (schema design) — do not wait for a reply:
+**Never block on this.** If any signal is present and the user has not asked for HITL, state the recommendation and proceed straight to Step 3 (schema design); do not wait for a reply:
 
-> "This process includes [signal]. Before the automation [action], a human should review [data]. I'm inserting a HITL node here — remove it if you don't want it."
+> “This process includes [signal]. Before the automation [action], a human should review [data]. I'm inserting a HITL node here — remove it if you don't want it.”

--- a/skills/uipath-human-in-the-loop/references/hitl-surface-lowcode-agent.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-surface-lowcode-agent.md
@@ -1,0 +1,28 @@
+<!-- when: adding a HITL escalation to a Low-Code Agent (agent.json) project -->
+# HITL on a Low-Code Agent — Escalation Reference
+
+The Low-Code Agent escalation CLI (`uip agent escalation add`) is currently in-flight. Until it ships, configure manually.
+
+**`agent.json` escalation entry:**
+```json
+{
+  "escalations": [
+    {
+      "name": "<escalation-name>",
+      "inputSchema":  { "inputs": [...], "inOuts": [...] },
+      "outputSchema": { "outputs": [...], "outcomes": [...] }
+    }
+  ]
+}
+```
+
+**Agent source (Python):**
+```python
+from uipath.sdk import interrupt, CreateTask
+
+response = interrupt(CreateTask(
+    escalation_name="<escalation-name>",
+    data={ "fieldName": value }
+))
+# response contains the human's outputs and chosen outcome
+```

--- a/skills/uipath-human-in-the-loop/references/hitl-surface-maestro.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-surface-maestro.md
@@ -1,7 +1,7 @@
 <!-- when: adding a HITL node to a Maestro BPMN (.bpmn) process -->
 # HITL on Maestro BPMN — Node Reference
 
-QuickForm and coded-action-app HITL nodes are both supported on Maestro BPMN processes. `uipath.human-in-the-loop.quick-form` and `uipath.human-in-the-loop.coded-action-app` are registered as **registry shortcut names** in the BPMN validator ([bpmn-spec.json](../uipath-maestro-bpmn/validator/bpmn-spec.json)) — these are palette/discovery identifiers, not literal XML to write. There is no dedicated CLI subcommand for Maestro (unlike Flow's `uip maestro flow hitl add`) — write the node directly into the `.bpmn` XML.
+QuickForm and coded-action-app HITL nodes are both supported on Maestro BPMN processes. `uipath.human-in-the-loop.quick-form` and `uipath.human-in-the-loop.coded-action-app` are registered as **registry shortcut names** in the BPMN validator ([bpmn-spec.json](../../uipath-maestro-bpmn/validator/bpmn-spec.json)) — these are palette/discovery identifiers, not literal XML to write. There is no dedicated CLI subcommand for Maestro (unlike Flow's `uip maestro flow hitl add`) — write the node directly into the `.bpmn` XML.
 
 Design the schema per Step 4b — never block waiting on the user, per Critical Rule 1 — then validate frequently (`uip maestro bpmn validate <file>.bpmn --output json`) while wiring the node so any shape mistakes surface immediately rather than at deploy time. In Maestro, field names in `outputs`/`inOuts` must exactly match declared process variable names and types.
 

--- a/skills/uipath-human-in-the-loop/references/hitl-surface-maestro.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-surface-maestro.md
@@ -1,0 +1,43 @@
+<!-- when: adding a HITL node to a Maestro BPMN (.bpmn) process -->
+# HITL on Maestro BPMN — Node Reference
+
+QuickForm and coded-action-app HITL nodes are both supported on Maestro BPMN processes. `uipath.human-in-the-loop.quick-form` and `uipath.human-in-the-loop.coded-action-app` are registered as **registry shortcut names** in the BPMN validator ([bpmn-spec.json](../uipath-maestro-bpmn/validator/bpmn-spec.json)) — these are palette/discovery identifiers, not literal XML to write. There is no dedicated CLI subcommand for Maestro (unlike Flow's `uip maestro flow hitl add`) — write the node directly into the `.bpmn` XML.
+
+Design the schema per Step 4b — never block waiting on the user, per Critical Rule 1 — then validate frequently (`uip maestro bpmn validate <file>.bpmn --output json`) while wiring the node so any shape mistakes surface immediately rather than at deploy time. In Maestro, field names in `outputs`/`inOuts` must exactly match declared process variable names and types.
+
+**Confirmed node shape (verified by direct reproduction against a real Studio Web BPMN process with a working, editable QuickForm task):**
+
+```xml
+<bpmn:task id="Activity_InvoiceApproval" name="Invoice Approval">
+  <bpmn:extensionElements>
+    <uipath:activity version="v1">
+      <uipath:type value="Actions.HITL" version="v2" />
+      <uipath:context>
+        <uipath:input name="hitlType" type="string" value="quick" />
+        <uipath:input name="taskTitle" type="string" value="Please review this invoice and approve or reject" />
+        <uipath:input name="labels" type="string" />
+        <uipath:input name="priority" type="string" value="Medium" />
+        <uipath:input name="actionCatalogName" type="string" />
+        <uipath:input name="enableActionableNotifications" type="boolean" value="false" />
+        <uipath:input name="assignmentCriteria" type="string" />
+        <uipath:input name="recipient" type="json" />
+        <uipath:input name="_schemaFileId" type="string" value="<see file-id callout below>" />
+        <uipath:input name="hitlSchemaId" type="string" value="<matches schemaId in the .hitl.json sidecar>" />
+        <uipath:inputSchema type="jsonSchema"><![CDATA[{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"invoiceid":{"type":"string","title":"Invoice ID"},"amount":{"type":"number","title":"Amount"}},"required":[]}]]></uipath:inputSchema>
+      </uipath:context>
+      <uipath:input name="HitlTaskArguments" type="json" target="bodyField"><![CDATA[{"invoiceid":"INV-1001","amount":500}]]></uipath:input>
+      <uipath:output name="Action" type="string" source="=Action" var="invoiceDecision" options="[{&#34;value&#34;:&#34;Approve&#34;,&#34;label&#34;:&#34;Approve&#34;},{&#34;value&#34;:&#34;Reject&#34;,&#34;label&#34;:&#34;Reject&#34;}]" />
+    </uipath:activity>
+  </bpmn:extensionElements>
+  <bpmn:incoming>edge_into_task</bpmn:incoming>
+  <bpmn:outgoing>edge_out_of_task</bpmn:outgoing>
+</bpmn:task>
+```
+
+Notes on what's easy to get wrong:
+- **Element is `bpmn:task`, not `bpmn:UserTask`.** `bpmn-spec.json`'s generic `Actions.HITL` XML template uses `bpmn:UserTask` and `version="v1"` — that template is for the app-based/coded-action-app path (its `context` fields are `appId`, `appVersion`, `actions`, `key`, `taskTitle`). A real QuickForm task exported from Studio Web is a plain `bpmn:task` with `uipath:type value="Actions.HITL" version="v2"`. Use the shape above for QuickForm; the spec's template for app-based.
+- **`<uipath:inputSchema>` (last child of `<uipath:context>`) and `<uipath:input name="HitlTaskArguments">` (sibling of `<uipath:context>`, not inside it) are both required.** Without them the "Edit Schema" canvas in Studio Web doesn't open at all — confirmed by direct reproduction. This mirrors the Case surface's `data.inputSchema`/`data.inputs[]` requirement — see [hitl-casetask-action.md § Step 3](hitl-casetask-action.md) for the parallel Case shape and full field-by-field rationale.
+- **The `Action` output requires a matching process-level variable declaration** — add `<uipath:inputOutput id="<varId>" name="Action" type="string" elementId="<taskId>" />` inside the process's top-level `<uipath:variables version="v1">` block.
+- **A separate `<TaskLabel>.hitl.json` sidecar file is required**, same shape as the Case surface's (`title`, `fields[]` with `direction`/optional `colSpan`/`binding` or `variable`, `outcomes[]` with **no** `action` key, `schemaId`) — see [hitl-casetask-action.md § Step 2](hitl-casetask-action.md) for the exact shape; it's identical across both surfaces.
+- **`_schemaFileId` cannot be authored blind — it is a server-assigned foreign key, not a UUID you invent.** A placeholder value makes "Edit Schema" fail silently (a `404` on Studio Web's internal `FileOperations/File/Rename` call, confirmed by direct reproduction). There is no `uip` CLI command that resolves this today. **Never block on this.** Write a fresh placeholder UUID v4, finish the rest of the node, validate, and move on — do not attempt the live reconciliation yourself and do not stop to ask about it. State plainly in the final report: "This task's schema was written with a placeholder `_schemaFileId`, so Studio Web's 'Edit Schema' canvas won't open for it yet. Making it editable requires resolving the real file ID Studio Web assigns to the `.hitl.json` after upload (`GET /api/Project/{projectId}/FileOperations/Structure`) and pushing it back with a targeted single-file update (`PUT /api/Project/{projectId}/FileOperations/File/{fileId}`) — not another whole-project `uip solution upload`, which re-pushes every file and mints a fresh random file ID for each one, undoing the fix. Ask me to do this reconciliation if you want the schema editable in Studio Web." This is a real product/tooling gap the user can act on later, not something to resolve mid-task.
+- **Diagram-interchange edges are required for the connector lines to render, even though the logical `bpmn:sequenceFlow`s already exist.** Every `bpmn:sequenceFlow` needs a matching `bpmndi:BPMNEdge` (with two `di:waypoint` points, aligned to the source/target shapes' connecting edges) in the `bpmndi:BPMNPlane` — omitting it leaves the nodes logically connected but visually disconnected in the canvas. Confirmed by direct reproduction.


### PR DESCRIPTION
## Whole-bundle token reduction — `uipath-human-in-the-loop` (SkillReducer pipeline)

Reduces the whole-bundle token cost of `uipath-human-in-the-loop` while holding task performance. Sibling of `/optimize-skill` (body-only); this is the whole-bundle method (body + every reference).

| metric | v000 | final | Δ |
|---|---|---|---|
| body (always loaded) | 8,541 | 3,506 | **−59.0%** |
| references (Σ) | 20,391 | 15,567 | **−23.7%** |
| **raw bundle** | 29,030 | 19,171 | **−34.0%** |
| expected cost E[Cost'] | 12,372 | 6,013 | **−51.4%** |
| description | 66 | 66 | ddmin no-op |
| redundancy | 4.4% | 3.1% | −53% redundant tok |

### What changed
- **Description** — unchanged; ddmin found all four routing units load-bearing.
- **Body** — relocated the Maestro BPMN node XML and the Low-Code Agent escalation snippet into two on-demand references (`hitl-surface-maestro.md`, `hitl-surface-lowcode-agent.md`), then the gated compaction loop densified the core to its floor. `flow-project-creation` flavor markers preserved.
- **References** — iteratively trimmed and gated **per-reference on the full task suite** (each ref gated only on the tasks that load it): casetask −48%, quickform −35%, patterns −46%, apptask −16%, coded-action-app −10%. The 2 relocated refs are exercised by no task (no Maestro/agent task in the suite) and left at full content under the no-task guardrail.

### Validation — 0 real regressions across all three models
| row | model | seeds | result |
|---|---|---|---|
| control (v000) | gpt-5.6-luna | 2 | 23/23 PASS |
| candidate (b*) | gpt-5.6-luna | 2 | 23/23 PASS → **0 real regressions** |
| candidate (b*) | gpt-5.6-terra | 1 | 23/23 PASS → cross-model clean |
| candidate | claude-sonnet-5 (Azure live tenant) | 1 | matched re-verify vs v000 control → **0 real regressions** |

**Sonnet Azure matched re-verify (RESOLVED).** The first single-seed run passed 19/23; the 4 non-passes were suspected live-tenant timeout / fragile-grader flags. A matched-config re-verify re-ran those 4 tasks for **both** control `main` (build 13305964) and candidate branch (build 13305966) under identical adhoc settings on the static tenant:

| task | control (v000) | candidate (b*) | verdict |
|---|---|---|---|
| gdpr-compliance-greenfield | 1.0 PASS | 1.0 PASS | clean (first-run cand timeout was variance) |
| invoice-approval-greenfield | 0.0 FAIL | 0.0 FAIL | **not a regression** — control fails it too (live-tenant/task limit) |
| smoke-approval-gate | 1.0 PASS | 1.0 PASS | clean (first-run 0.667 was a fragile grader regex) |
| smoke-case-quickform | 0.0 FAIL | 1.0 PASS | candidate *beats* control |

Real regression = a task control passes that candidate does not → **zero**, now confirmed on the production model (Sonnet) on the live tenant too.

- **Gate 1 (faithfulness):** presence + instruction-mood clean.
- **Gate 2.5 (adversarial, Opus + deterministic anchor/presence):** 1 MEDIUM found & fixed — a Case action-task example had been compacted to empty `inputs[]`/`outputs[]` arrays (the known-broken shape v000's callout warns against); restored the populated example verbatim. Post-push CI link check caught one relocated cross-skill link needing `../../` (fixed); CI now green.

Per-task (Luna, median): tokens −10.2%, USD −11.6%, wall −2.3%.

Report: https://uipath.atlassian.net/wiki/spaces/~712020d31167b517534d16bb24e15816bfb234/pages/91106148435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
