### PR TITLE
fix(uipath-maestro-flow): child simulations need the parent agent node in the flow

### DIFF
--- a/skills/uipath-maestro-flow/references/evaluate/commands-reference.md
+++ b/skills/uipath-maestro-flow/references/evaluate/commands-reference.md
@@ -145,7 +145,7 @@ Add or replace a simulation on a data point. If a simulation for `<component-id>
 | `--component-description <text>` | No | Human-readable label for the component |
 | `--simulation-instructions <text>` | No | LLM prompt describing what the component should return (for `Llm` strategy) |
 | `--mock-value <json>` | No | Static JSON output (for `Static` strategy) |
-| `--parent <component-id>` | No | Parent agent node component ID. When set, the simulation is added as a child tool simulation nested inside the parent agent node's simulation. If no parent simulation exists yet, one is auto-created (type `agent`, strategy `Llm`). `--component-type` defaults to `Node`. |
+| `--parent <component-id>` | No | Parent agent node component ID. When set, the simulation is added as a child tool simulation nested inside the parent agent node's simulation. If no parent *simulation* exists yet, one is auto-created (type `agent`, strategy `Llm`) — but the parent agent *node* must already exist in the `.flow`; see [Add the parent agent node first](#add-the-parent-agent-node-first). `--component-type` defaults to `Node`. |
 | `--path <path>` | No | (see Common Options) |
 
 **Strategy guide:**
@@ -163,6 +163,22 @@ Add or replace a simulation on a data point. If a simulation for `<component-id>
 - **Child simulations (published agents):** calls the platform API (`simulatableComponents`) using the current login session to fetch the tool's schema. Requires `uip login`.
 
 Fails with an actionable error if the node/tool is not found or has no outputs.
+
+**Add the parent agent node first.** `--parent` with `--strategy Llm` requires the parent agent node to already be in `nodes[]`, wired to each child tool node by an edge on its `tool` port. Without it the call fails with `Parent agent "<component-id>" not found in the flow.` — an eval set and data point are not enough. `--strategy Static` does not read the flow and succeeds against a parent that does not exist, so a sequence mixing both strategies fails on the `Llm` call alone.
+
+The `--parent` value is the agent node's `id`; each `<component-id>` is a tool node's `id`:
+
+```json
+{ "nodes": [
+    { "id": "agent-1", "type": "uipath.agent.autonomous", "inputs": { "agentInputVariables": {}, "agentOutputVariables": {} } },
+    { "id": "Web_Search", "type": "core.logic.mock" },
+    { "id": "Send_Email", "type": "core.logic.mock" } ],
+  "edges": [
+    { "sourceNodeId": "agent-1", "sourcePort": "tool", "targetNodeId": "Web_Search", "targetPort": "input" },
+    { "sourceNodeId": "agent-1", "sourcePort": "tool", "targetNodeId": "Send_Email", "targetPort": "input" } ] }
+```
+
+`core.logic.mock` tool nodes resolve schemas. See [plugins/inline-agent/impl.md](../author/plugins/inline-agent/impl.md) for a production agent node.
 
 **Static mock value validation:** For `Static` child simulations, the CLI validates that `--mock-value` keys match the auto-resolved schema properties, catching shape mismatches early.
 
@@ -194,7 +210,7 @@ Example — Child simulation (tool inside an agent node):
 
 ```bash
 # Add a child tool simulation (Static). No separate parent simulation step
-# needed — --parent auto-creates the parent if it does not exist.
+# needed — --parent auto-creates the parent simulation.
 # Output schema is auto-resolved from the agent's tool definitions.
 uip maestro flow eval simulation add Web_Search \
   --parent agent-lookup \

--- a/tests/tasks/uipath-maestro-flow/evaluate/child_simulation/child_simulation_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/child_simulation/child_simulation_crud.yaml
@@ -12,8 +12,8 @@ description: >
 tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, feature:eval, feature:child-simulation]
 
 run_limits:
-  expected_turns: 20
-  max_turns: 60
+  expected_turns: 25
+  max_turns: 90
 
 initial_prompt: |
   Use the `uipath-maestro-flow` skill's evaluate capability to scaffold a Flow
@@ -36,20 +36,26 @@ initial_prompt: |
      `{"query":"weather in NYC"}` and expected
      `{"answer":"Sunny, 72°F in New York City."}`.
 
-  5. Add a `Static` child simulation on the `search-test` data point targeting
+  5. Put the simulation targets in the flow: an autonomous agent node with id
+     `agent-1`, plus two child tool nodes with ids `Web_Search` and
+     `Send_Email`, each wired to `agent-1` by an edge on its `tool` port.
+     Mock tool nodes are fine. The flow does not have to pass
+     `uip maestro flow validate`.
+
+  6. Add a `Static` child simulation on the `search-test` data point targeting
      child tool `Web_Search` on parent agent node `agent-1`. Use
      `--mock-value '{"results":[{"title":"NYC Weather","snippet":"Sunny, 72°F"}]}'`.
      Do NOT add a separate parent simulation first.
 
-  6. Add an `Llm` child simulation on the `search-test` data point targeting
+  7. Add an `Llm` child simulation on the `search-test` data point targeting
      child tool `Send_Email` on the same parent `agent-1`. Supply
-     `--simulation-instructions "Return a success status with a message ID."`,
-     and pass `--output-schema '{"type":"object","properties":{"status":{"type":"string"},"messageId":{"type":"string"}}}'`
-     explicitly.
+     `--simulation-instructions "Return a success status with a message ID."`.
+     The output schema is auto-resolved from the parent agent node — do not
+     pass an output-schema flag.
 
-  7. List the child simulations on `agent-1` to confirm both are present.
+  8. List the child simulations on `agent-1` to confirm both are present.
 
-  8. Remove the `Send_Email` child simulation from `agent-1`.
+  9. Remove the `Send_Email` child simulation from `agent-1`.
 
   Important:
   - Use `--output json` on every `uip maestro flow eval ...` command.
@@ -118,7 +124,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added an Llm child simulation with --parent, --strategy Llm, and --output-schema"
+    description: "Agent added an Llm child simulation with --parent and --strategy Llm"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+.*--parent\s+.*--strategy\s+Llm|--strategy\s+Llm.*--parent'
     min_count: 1


### PR DESCRIPTION
`--parent` with `--strategy Llm` resolves the child tool's output schema out of the `.flow`, so the parent agent node has to already be in `nodes[]`, wired to each tool node on its `tool` port. The doc never said so — and said something adjacent and louder:

> `--parent` auto-creates the parent if it does not exist.

True of the parent *simulation*, false of the parent *node*. The auto-resolution bullets underneath do mention reading the `.flow`, but they read as mechanism, not as a precondition you have to satisfy first.

## What it cost

`skill-flow-eval-child-simulation-crud`, nightly 2026-09-08, scored **0.744** and exhausted `max_turns` before the final step. Roughly 110 of its 170 recorded turns went here:

```
[15] --output-schema  → ValidationError: unknown option '--output-schema'
[17] (retry)          → Parent agent "agent-1" not found in the flow.
[27] (retry)          → Parent agent "agent-1" not found in the flow.
[31] (retry)          → Parent agent "agent-1" not found in the flow.
     then: uip agent init --inline-in-flow, the uipath-agents skill,
     an Agent subagent, and grepping the CLI's minified bundle for
     `childSimulationSchema` / `parentFound`.
```

Two criteria failed, both on the never-reached remove step. The agent did eventually converge on the right shape by hand — that shape is now what the doc shows.

## Skill change

`references/evaluate/commands-reference.md`:

- The `--parent` row separates the auto-created parent *simulation* from the parent *node*.
- A new **Add the parent agent node first** block: the precondition, the verbatim error, and the node/edge shape.
- Notes that `--strategy Static` carries its own `--mock-value` and never reads the flow, so it succeeds against a parent that does not exist. That asymmetry is why this presented as a flag problem rather than a missing node — step 5 passed, step 6 failed.
- Fixes the misleading comment on the child-simulation example.

## Task change

`tests/tasks/uipath-maestro-flow/evaluate/child_simulation/child_simulation_crud.yaml`:

- **Drops `--output-schema`.** Not a phantom flag — it exists, and the contract lives in `maestro-tool`, not the CLI shell. On an older plugin build it is documented as *required* with `--parent`. `tests/docker/Dockerfile:18` is `ARG CLI_VERSION=dev` and tool plugins ride the derived dist-tag, so the eval got a build where it is gone and auto-resolution replaced it — which is what `commands-reference.md` already described. The task was stale against its own runner. The criterion description named the flag too.
- **Adds the step that creates the nodes.** Every prior step built eval-set state; nothing built what the simulations resolve against.
- **`max_turns` 60 → 90.** The old ceiling cut the run off before the last step.

Not seeded as a `template_dir` fixture on purpose: the nodes are part of what the skill is being tested on, and `core.logic.mock` tools plus two `tool`-port edges are cheap to author.

## Verification

- Both yaml invariants hold: the headless preamble is byte-identical (`test_headless_preamble.py`), and the criterion-budget guard is N/A here — `check_child_simulation_crud.py` never calls `run_debug`.
- `yaml.safe_load` clean, 11 criteria intact, no `--output-schema` invocation left.
- **Not executed end-to-end.** `pytest` is not installed locally, and my toolchain has drifted — CLI `1.202.0` against `maestro-tool@1.203.0`, so maestro verbs fail outright with a line-mismatch error. Step 5's shape is taken from the failing run's own final artifact rather than a fresh run, so it wants a CI run to confirm.

Found while root-causing ten maestro-flow failures from that nightly. Filed tag was `max-turns-too-low`; the turn ceiling was a symptom.
