### PR TITLE
fix(tests): cap the activation smokes so a routing verdict gets graded

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_activation_negative.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_activation_negative.yaml
@@ -4,6 +4,9 @@ description: >
   NOT route to uipath-maestro-flow — it should reach uipath-rpa instead.
 tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:discover, negative, connector, uipath-uipath-dataservice]
 
+run_limits:
+  max_turns: 15
+
 initial_prompt: |
   In my RPA Studio (.xaml) workflow, add a Data Fabric activity to read
   customer records from the CustomerDirectory entity.
@@ -21,8 +24,15 @@ initial_prompt: |
   the task take precedence over this paragraph.
 success_criteria:
   - type: skill_triggered
-    description: "Advisory: uipath-rpa handles the RPA-Studio Data Fabric prompt"
+    description: "Advisory: uipath-maestro-flow does NOT take the RPA-Studio Data Fabric prompt"
     skill_name: uipath-maestro-flow
     expected_skill: ""
+    weight: 3.0
+    pass_threshold: 0.0
+
+  - type: skill_triggered
+    description: "Advisory: uipath-rpa handles the RPA-Studio Data Fabric prompt"
+    skill_name: uipath-rpa
+    expected_skill: uipath-rpa
     weight: 3.0
     pass_threshold: 0.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_activation_positive.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_activation_positive.yaml
@@ -4,6 +4,9 @@ description: >
   uipath-maestro-flow skill.
 tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:discover, connector, uipath-uipath-dataservice]
 
+run_limits:
+  max_turns: 25
+
 initial_prompt: |
   I need to create a record in my DataFabric entity from a UiPath Flow.
   The entity is called ProductCatalog — build the Flow that does it.
@@ -26,3 +29,5 @@ success_criteria:
     expected_skill: uipath-maestro-flow
     weight: 3.0
     pass_threshold: 0.0
+    stop_early:
+      on_pass: stop


### PR DESCRIPTION
`skill-flow-datafabric-smoke-activation-negative` routed correctly to `uipath-rpa` at API turn **7** — the only thing it grades — then kept going: `uip rpa init`, package install, XAML edits, build, a 120s `uip rpa run` at turn **54**, and blocking `TaskOutput` polls for 180s + 240s. It hit the inherited 900s turn timeout, which lands as `ERROR` with every criterion reported *"Not evaluated after terminal agent failure"*.

**A correct routing verdict scored 0.000.** Neither activation smoke set any `run_limits`.

## The fix

Cap `max_turns` on both. That converts the failure mode from a turn timeout (`ERROR`, ungraded) to natural completion, which grades — and SUCCESS stays reachable because `orchestrator.py:587` checks `if success:` **before** `elif max_turns_exhausted`.

| | cap | `stop_early` |
|---|---|---|
| negative | 15 | none — deliberately |
| positive | 25 | `{on_pass: stop}` |

## Why the negative gets no `stop_early`

This is the part worth reviewing. My first cut armed a `uipath-rpa` pass-stop here, and that was wrong.

On an early-stopped run the gate is `armed_criteria_passed` over the **armed subset only**, with everything else logged *"advisory, not gated"* (`orchestrator.py:1997`). Arming an rpa pass-stop would therefore:

1. drop the maestro-flow negative criterion — the entire point of a negative smoke — out of the gate on precisely the runs that pass; and
2. stop at turn 7, so a maestro-flow misfire on any later tool call is never observed.

That trades *"always ERRORs at 0.000"* for *"always passes, and can no longer detect what it tests."* Unarmed, the run completes naturally and gates on the **full set** (`orchestrator.py:2011`) with all 15 turns observed. It also means no armed criterion at all, so `validate_early_stop` stops applying and the agent-capability coupling disappears.

Worth noting `on_pass: stop` would have been **inert** on that criterion anyway:

```python
# SkillTriggeredCriterion.live_decidable_polarities
expected_yes = self.expected_skill == self.skill_name
return frozenset({"pass"}) if expected_yes else frozenset({"fail"})
```

A negative's success state is "never engaged", which is not knowable mid-run.

## Why the positive keeps it

Engaging maestro-flow **is** its success condition, and it has exactly one criterion — so the armed subset equals the full set and pass-stop drops nothing. Verified: `armed=1, advisory=0`.

`25` rather than 15 because that task has never failed, so there are no transcripts to size its routing latency from. The cap only bounds a miss.

## Coverage hole this also closes

The task description asserts *"it should reach uipath-rpa instead"*, but `uipath-rpa` appeared **only in prose**. The sole criterion checked `skill_name: uipath-maestro-flow` with `expected_skill: ""` — nothing verified the positive half of the routing claim. Its description also read "uipath-rpa handles the RPA-Studio Data Fabric prompt" while checking maestro-flow; it now says what it checks.

## Verification

Against **coder_eval 0.11.6** (the installed `tests/.venv` is 0.7.1, which predates `stop_early`):

- Both files load through `SkillTriggeredCriterion` / `RunLimits`.
- Negative resolves to **0 armed** criteria → no watcher → full-set gating, both criteria decisive.
- Positive resolves to **1 armed, 0 advisory** → armed-subset gating is identical to full-set.
- `resolve_root("run_limits", …)` confirms the per-field merge: `{max_turns: 15, task_timeout: 900, turn_timeout: 900}` — the override does not drop inherited timeouts.
- `tests/tasks/uipath-maestro-flow/_shared` — **985 passed**.

## Note for maintainers

`tasks/activation/README.md` tells authors to add `stop_when: auto` to new criteria. That key does not exist — `StopEarlyPolicy` is `extra="forbid"` with only `on_pass` and `decide_within`. Worth a follow-up; not touched here to keep this scoped.

Second of the maestro-flow nightly triage (2026-09-08). Filed tag was `infra`/`turn-timeout-too-short`; the timeout was a symptom of a test that never stopped. Follows #3138.
