### PR TITLE
fix(uipath-maestro-flow): answer the three doc gaps that ran three evals out of budget

### DIFF
--- a/skills/uipath-maestro-flow/references/author/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/author/editing-operations-json.md
@@ -211,7 +211,7 @@ On every reachable End node, map every `out` variable:
 {
   "id": "doneSuccess",
   "type": "core.control.end",
-  "typeVersion": "1.0.0",
+  "typeVersion": "<DEFINITION_VERSION>",
   "display": { "label": "Done" },
   "inputs": {},
   "outputs": { "<VARIABLE_ID>": { "source": "=js:<EXPRESSION>" } }
@@ -292,13 +292,13 @@ Only `inout` variables can be updated; `in` variables are read-only. `expression
 
 **Tool:** `Edit` (or `Write` when scaffolding from a template).
 
-1. Add a `core.subflow` parent with `display`, inputs, and error output (the JSON below pins `typeVersion`):
+1. Add a `core.subflow` parent with `display`, inputs, and error output:
 
 ```json
 {
   "id": "<SUBFLOW_NODE_ID>",
   "type": "core.subflow",
-  "typeVersion": "1.0.0",
+  "typeVersion": "<DEFINITION_VERSION>",
   "display": { "label": "<LABEL>" },
   "inputs": { "<IN_VAR>": "=js:<EXPRESSION>" },
   "outputs": {
@@ -313,9 +313,10 @@ Only `inout` variables can be updated; `in` variables are read-only. `expression
 ```
 
 2. Add `subflows.<SUBFLOW_NODE_ID>` with independent `nodes`, `edges`, `variables`, and `layout`; its variables include `in` variables with `triggerNodeId`, `out` variables, and `variables.nodes`.
-3. Match subflow `in` variable IDs to parent input keys; map every `out` variable on its End node.
-4. Parent `$vars` are not visible inside; pass values through inputs.
-5. Put subflow positions in its own `layout.nodes`, never top-level layout. See [subflow/impl.md](plugins/subflow/impl.md).
+3. Add a top-level `definitions[]` entry for `core.subflow` and for every node type used **inside** the subflow that the flow does not already carry. A subflow section has no `definitions` array of its own — see [subflow/impl.md](plugins/subflow/impl.md#subflow-rules).
+4. Match subflow `in` variable IDs to parent input keys; map every `out` variable on its End node.
+5. Parent `$vars` are not visible inside; pass values through inputs.
+6. Put subflow positions in its own `layout.nodes`, never top-level layout. See [subflow/impl.md](plugins/subflow/impl.md).
 
 ## Connector Node Configuration (Edit / Write fallback)
 

--- a/skills/uipath-maestro-flow/references/author/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/hitl/impl.md
@@ -62,6 +62,7 @@ Rules:
 - Output fields use `variable: "vars.<globalName>"` (`vars.` required) and no `binding`.
 - InOut fields use both properties in those formats.
 - Use `schemaId` (not `id`) at schema level and generate a fresh UUID.
+- `priority` is `"Low"` | `"Medium"` | `"High"` — the three options this node's manifest declares; there is no `Critical` here, unlike an Action Center case task. It defaults to `Low` and comes from the request, not from the literal in either option's example. Urgency stated or implied ("urgent", "high priority", "time-sensitive", an SLA) means `High` or `Medium`. The value must land in the node; acknowledging the urgency in conversation is not enough.
 - `typeVersion` — always `"1.0"` for this node. **Do not run `registry get` to derive this value; do not use `"1.1"` or any other version.** The OOTB HITL node version is stable at `1.0`.
 - Do not include a `model` block on node instances; only the definition carries it.
 - `outputs` contains only `output` (with `properties` for output/inOut fields plus `Action`) and `status` (with outcome `enum`/`default`). Do not add per-field `custom: true` entries.
@@ -154,6 +155,7 @@ Rules:
 - Fill `typeVersion` with the version returned by `uip maestro flow registry get <appKey>` for the specific deployed app. Unlike QuickForm, AppTask versions vary by app definition.
 - `inputs.app.inputSchema` and `outputSchema` are JSON Schema objects (`{ "type": "object", "properties": { ... } }`), not arrays.
 - `inputs.appInputBindings` maps names from `inputSchema.properties` to `"=vars.<path>"` expressions (with `=` and no `js:`). Without these bindings, input fields are blank.
+- `priority` follows Option 1's rule above — derived from the request, not the `"Medium"` literal in the example.
 
 ### If the app does not exist
 

--- a/skills/uipath-maestro-flow/references/author/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/hitl/impl.md
@@ -62,7 +62,7 @@ Rules:
 - Output fields use `variable: "vars.<globalName>"` (`vars.` required) and no `binding`.
 - InOut fields use both properties in those formats.
 - Use `schemaId` (not `id`) at schema level and generate a fresh UUID.
-- `priority` is `"Low"` | `"Medium"` | `"High"` — the three options this node's manifest declares; there is no `Critical` here, unlike an Action Center case task. It defaults to `Low` and comes from the request, not from the literal in either option's example. Urgency stated or implied ("urgent", "high priority", "time-sensitive", an SLA) means `High` or `Medium`. The value must land in the node; acknowledging the urgency in conversation is not enough.
+- `priority` is `"Low"` | `"Medium"` | `"High"` — the three options this node's manifest declares; there is no `Critical` here, unlike an Action Center case task. It defaults to `Low` and comes from the request, not from the literal in either option's example. Explicit high-urgency language — "urgent", "high priority", "critical", "ASAP", a named or breached SLA — selects `High`. Reserve `Medium` for a request that signals only mild or unquantified urgency, and `Low` when none is expressed. The value must land in the node; acknowledging the urgency in conversation is not enough.
 - `typeVersion` — always `"1.0"` for this node. **Do not run `registry get` to derive this value; do not use `"1.1"` or any other version.** The OOTB HITL node version is stable at `1.0`.
 - Do not include a `model` block on node instances; only the definition carries it.
 - `outputs` contains only `output` (with `properties` for output/inOut fields plus `Action`) and `status` (with outcome `enum`/`default`). Do not add per-field `custom: true` entries.

--- a/skills/uipath-maestro-flow/references/author/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/hitl/impl.md
@@ -62,7 +62,7 @@ Rules:
 - Output fields use `variable: "vars.<globalName>"` (`vars.` required) and no `binding`.
 - InOut fields use both properties in those formats.
 - Use `schemaId` (not `id`) at schema level and generate a fresh UUID.
-- `priority` is `"Low"` | `"Medium"` | `"High"` — the three options this node's manifest declares; there is no `Critical` here, unlike an Action Center case task. It defaults to `Low` and comes from the request, not from the literal in either option's example. Explicit high-urgency language — "urgent", "high priority", "critical", "ASAP", a named or breached SLA — selects `High`. Reserve `Medium` for a request that signals only mild or unquantified urgency, and `Low` when none is expressed. The value must land in the node; acknowledging the urgency in conversation is not enough.
+- `priority` is `"Low"` | `"Medium"` | `"High"`, default `Low`. No `Critical` on this node, unlike an Action Center case task. Take the value from the request, not from the literal in either option's example: explicit high-urgency language — "urgent", "high priority", "critical", "ASAP", a named or breached SLA — selects `High`; reserve `Medium` for mild or unquantified urgency, `Low` when none is expressed. The value must land in the node; acknowledging the urgency in conversation is not enough.
 - `typeVersion` — always `"1.0"` for this node. **Do not run `registry get` to derive this value; do not use `"1.1"` or any other version.** The OOTB HITL node version is stable at `1.0`.
 - Do not include a `model` block on node instances; only the definition carries it.
 - `outputs` contains only `output` (with `properties` for output/inOut fields plus `Action`) and `status` (with outcome `enum`/`default`). Do not add per-field `custom: true` entries.

--- a/skills/uipath-maestro-flow/references/author/plugins/subflow/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/subflow/impl.md
@@ -143,7 +143,7 @@ Value flow is: caller input `text` → parent `start` through the parent's `trig
 5. Parent-scope `$vars` are not visible inside the subflow; pass values explicitly through inputs.
 6. Define inline `outputs` on every subflow node: Start needs `outputs.output`; Script nodes need `outputs.output` and `outputs.error`.
 7. Subflows may be nested up to 3 levels.
-8. Each subflow has its own `nodes`, `edges`, `variables`, and `layout` sections.
+8. Each subflow has its own `nodes`, `edges`, `variables`, and `layout` sections — and only those four. There is no per-subflow `definitions` array: `core.subflow` itself and every node type used inside a subflow take their entry in the flow's single top-level `definitions[]`, exactly like a main-flow node. A `definitions` array added under `subflows.<id>` is ignored. `flow validate` catches the omission at ``[subflows[<id>].nodes[<nodeId>].type] Node type `<type>:<version>` has no matching definition``.
 9. Put subflow node positions in that subflow's `layout.nodes`, not the top-level `layout.nodes`; scopes are independent.
 10. When the parent forwards an external input, its `in` variable must also set `triggerNodeId` to the parent trigger node ID. `uip maestro flow validate` does not detect this omission; the value silently arrives `null`. See [Passing a Flow Input Into the Subflow](#passing-a-flow-input-into-the-subflow).
 

--- a/skills/uipath-maestro-flow/references/author/plugins/subflow/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/subflow/impl.md
@@ -143,7 +143,7 @@ Value flow is: caller input `text` → parent `start` through the parent's `trig
 5. Parent-scope `$vars` are not visible inside the subflow; pass values explicitly through inputs.
 6. Define inline `outputs` on every subflow node: Start needs `outputs.output`; Script nodes need `outputs.output` and `outputs.error`.
 7. Subflows may be nested up to 3 levels.
-8. Each subflow has its own `nodes`, `edges`, `variables`, and `layout` sections — and only those four. There is no per-subflow `definitions` array: `core.subflow` itself and every node type used inside a subflow take their entry in the flow's single top-level `definitions[]`, exactly like a main-flow node. A `definitions` array added under `subflows.<id>` is ignored. `flow validate` catches the omission at ``[subflows[<id>].nodes[<nodeId>].type] Node type `<type>:<version>` has no matching definition``.
+8. Each subflow has its own `nodes`, `edges`, `variables`, and `layout` sections — and only those four. There is no per-subflow `definitions` array: `core.subflow` and every node type used inside a subflow take their entry in the flow's single top-level `definitions[]`. A `definitions` array under `subflows.<id>` is ignored. `flow validate` reports the omission at ``[subflows[<id>].nodes[<nodeId>].type] Node type `<type>:<version>` has no matching definition``.
 9. Put subflow node positions in that subflow's `layout.nodes`, not the top-level `layout.nodes`; scopes are independent.
 10. When the parent forwards an external input, its `in` variable must also set `triggerNodeId` to the parent trigger node ID. `uip maestro flow validate` does not detect this omission; the value silently arrives `null`. See [Passing a Flow Input Into the Subflow](#passing-a-flow-input-into-the-subflow).
 

--- a/skills/uipath-maestro-flow/references/author/plugins/transform/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/transform/impl.md
@@ -229,6 +229,16 @@ Aggregation operations:
 | `first` | First item's field value | Yes |
 | `last` | Last item's field value | Yes |
 
+**One figure over the whole collection.** Aggregations are computed per group, so a grand total needs a single group: set `groupByField: ""`. The node then returns a one-element array and the aggregate is at `output[0].<alias>`.
+
+```json
+{ "id": "op1", "type": "groupBy", "config": {
+    "groupByField": "",
+    "aggregations": [{ "id": "a1", "field": "views", "operation": "sum", "alias": "totalViews" }] } }
+```
+
+Verified on `core.action.transform.group-by:1.1` — summing `10, 20, 30` returns `[{ "value": { … }, "total": 60 }]`. The group object still carries a `value` key holding the first row; read the alias, not `value`. Reach for a [Script](../script/impl.md) node only when the figure needs logic the aggregation list cannot express.
+
 ## Debug
 
 | Error | Cause | Fix |
@@ -238,4 +248,5 @@ Aggregation operations:
 | Collection is null/empty | `collection` uses `=js:` or an inline array literal | Use a plain path such as `"$vars.loadCatalog.output.catalog"` or `"$vars.catalog"`; store static arrays in a variable default or upstream node |
 | Map output missing fields | `keepOriginalFields: false` and the field is unmapped | Add the field to mappings or set `keepOriginalFields: true` |
 | GroupBy produces empty groups | No items match `groupByField` | Check that `groupByField` matches the actual data fields |
+| Need one total across every row, not per group | Aggregations are group-scoped | Set `groupByField: ""` for a single group; read `output[0].<alias>` |
 | Chained transform gets empty input although upstream had rows | Used `$vars.<transform>.output.items`; transform output is a bare array | Use `$vars.<transform>.output`; see [Output Shape](#collection-input-and-output-shape) |

--- a/skills/uipath-maestro-flow/references/author/plugins/transform/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/transform/impl.md
@@ -229,7 +229,7 @@ Aggregation operations:
 | `first` | First item's field value | Yes |
 | `last` | Last item's field value | Yes |
 
-**One figure over the whole collection.** Aggregations are computed per group, so a grand total needs a single group: set `groupByField: ""`. The node then returns a one-element array and the aggregate is at `output[0].<alias>`.
+**One figure over the whole collection.** Aggregations are group-scoped, so a grand total needs a single group: set `groupByField: ""`. The node returns a one-element array; read the aggregate at `output[0].<alias>`.
 
 ```json
 { "id": "op1", "type": "groupBy", "config": {
@@ -237,7 +237,7 @@ Aggregation operations:
     "aggregations": [{ "id": "a1", "field": "views", "operation": "sum", "alias": "total" }] } }
 ```
 
-Verified on `core.action.transform.group-by:1.1` — summing `10, 20, 30` returns `[{ "value": { … }, "total": 60 }]`. The group object still carries a `value` key holding the first row; read the alias, not `value`. Reach for a [Script](../script/impl.md) node only when the figure needs logic the aggregation list cannot express.
+The group object also carries a `value` key holding the first row — read the alias, not `value`.
 
 ## Debug
 

--- a/skills/uipath-maestro-flow/references/author/plugins/transform/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/transform/impl.md
@@ -234,7 +234,7 @@ Aggregation operations:
 ```json
 { "id": "op1", "type": "groupBy", "config": {
     "groupByField": "",
-    "aggregations": [{ "id": "a1", "field": "views", "operation": "sum", "alias": "totalViews" }] } }
+    "aggregations": [{ "id": "a1", "field": "views", "operation": "sum", "alias": "total" }] } }
 ```
 
 Verified on `core.action.transform.group-by:1.1` — summing `10, 20, 30` returns `[{ "value": { … }, "total": 60 }]`. The group object still carries a `value` key holding the first row; read the alias, not `value`. Reach for a [Script](../script/impl.md) node only when the figure needs logic the aggregation list cannot express.


### PR DESCRIPTION
Three 2026-09-08 nightly failures each spent most of their budget searching the references for something that was not written down. It shows up as **generation time, not tool time**:

| task | generation | tool | outcome |
|---|---|---|---|
| `skill-flow-group-to-subflow` | 1129s | 25s | 0.000 — produced **no edit at all** |
| `skill-flow-wiki-pageviews` | 1093s | 43s | 0.000 — 2 nodes written |
| `skill-flow-hitl-schema-design-simulated` | — | — | 0.737 — wrong `priority` value |

Every claim here is verified against `uip 1.203.0` and the live registry. Two were settled by running flows, not by reading docs.

## 1. Subflow — where the `definitions[]` entry goes

Eight of group-to-subflow's 45 tool calls ask whether a node type used *inside* a subflow needs a top-level `definitions[]` entry. `grep -i "subflow" file-format.md | grep -i defin` is empty, and "definitions" in `subflow/impl.md` already means the subflow **body**, which collides with the array being asked about.

Settled by a three-case experiment — one flow, inner `core.action.script` node, definition moved around:

| case | `core.action.script` definition | `flow validate` |
|---|---|---|
| A | omitted | **Failure** — `[subflows[sf1].nodes[sfScript].type] … has no matching definition` |
| B | top-level `definitions[]` | **Valid** |
| C | under `subflows.sf1.definitions` | **Failure** — identical; a per-subflow array is ignored |

Rule 8 now closes the section enumeration, says where the entry goes, notes that a per-subflow array is ignored, and quotes the scoped error path validate actually emits.

## 2. Transform — one figure over the whole collection

wiki-pageviews needs a sum over every row. Its **last five tool calls before the timeout** all ask for it, all empty:

```
groupByField ""  ·  aggregate  ·  no group  ·  overall  ·  single group  ·  entire collection
```

**`groupByField: ""` works.** Debugged on `core.action.transform.group-by:1.1` — summing `10, 20, 30`:

```json
"gb.output": [ { "value": { "v": 10 }, "total": 60 } ]
```

A single group, correct grand total, read at `output[0].<alias>`. The pre-existing `$vars.groupByNode.output[0].totalViews` line was pointing straight at this. Documented, including the stray `value` key the group object carries.

## 3. HITL — `priority`

The agent shipped `"priority": "Medium"` for a user who opened with *"it's time-sensitive so please treat it as urgent, high priority."*

The node's own manifest:

```json
{"name": "inputs.priority", "type": "select",
 "options": [{"value": "Low"}, {"value": "Medium"}, {"value": "High"}]}
```

Three options, no `Critical` — that belongs to Action Center case tasks, a different surface. `maestro-flow/hitl/impl.md` carried `priority` only as inert literals (`"Low"` in Option 1, `"Medium"` in Option 2), and that file is what an agent building a quickform reads. The produced node was a `quick-form` carrying Option 2's `Medium`, so the rule goes in Option 1's Rules with a pointer from Option 2.

## Also: two hardcoded `typeVersion` values

`editing-operations-json.md` pinned `"1.0.0"` in the End-node output-mapping example and the Create-a-subflow parent, and said so in prose. The registry returns **`1.0`** for `core.subflow`, `core.trigger.manual` and `core.control.end`, so a hardcoded `1.0.0` produces exactly the ``has no matching definition`` failure — the same one case A above triggers.

It contradicted three things at once: line 27 of its own file (*"do not normalize"*), line 91's existing `<DEFINITION_VERSION>` placeholder, and the do-not-hardcode rule in both `subflow/impl.md` and `end/impl.md`. Create-a-subflow also never told the agent to add a definitions entry, unlike the four sibling procedures that touch them.

## Verification

- `flow validate` and `flow debug` runs above, on a scratch solution scaffolded for the purpose and **deleted afterwards**
- `check-skill-links.mjs` — 6712 links resolve; both new anchors confirmed present (the checker skips fragments)
- Fences balanced and every JSON example parses in all four files; the new group-by snippet parses standalone
- `check-cli-verbs.py` — identical to the `main` baseline (0 High, 0 Medium, 4 Info)
- `tests/tasks/uipath-maestro-flow` — **1159 passed**

## Separate discrepancy, not touched here

`hitl/impl.md` states *"`typeVersion` — always `"1.0"` for this node. Do not run `registry get` … do not use `"1.1"`."* The live registry reports `uipath.human-in-the-loop.quick-form` at version **1.1**. Given `file-format.md:96` requires instance `typeVersion` to match `definitions[].version`, those cannot both be right. The doc is emphatic enough that someone likely had a runtime reason, so I have left it alone — but it wants an owner's eye.

Third of the maestro-flow nightly triage. Filed tags were `infra` on two and `validation-error` on the third; all three were missing documentation. Follows #3138 and #3139.
