### PR TITLE
test(uipath-maestro-flow): make simulation criteria order-insensitive

### DIFF
--- a/tests/tasks/uipath-maestro-flow/evaluate/child_simulation/child_simulation_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/child_simulation/child_simulation_crud.yaml
@@ -118,7 +118,7 @@ success_criteria:
   - type: command_executed
     description: "Agent added a Static child simulation with --parent and --mock-value"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+.*--parent\s+.*--strategy\s+Static\b.*--mock-value|--parent\s+.*--mock-value.*--strategy\s+Static|--strategy\s+Static.*--parent\s+.*--mock-value|--mock-value.*--parent\s+.*--strategy\s+Static'
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+(?=.*--parent\b)(?=.*--strategy\s+Static\b)(?=.*--mock-value\b)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
@@ -126,7 +126,7 @@ success_criteria:
   - type: command_executed
     description: "Agent added an Llm child simulation with --parent and --strategy Llm"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+.*--parent\s+.*--strategy\s+Llm|--strategy\s+Llm.*--parent'
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+(?=.*--parent\b)(?=.*--strategy\s+Llm\b)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
@@ -142,7 +142,7 @@ success_criteria:
   - type: command_executed
     description: "Agent removed a child simulation with --parent"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+remove\s+.*--parent|--parent.*simulation\s+remove'
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+remove\s+(?=.*--parent\b)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml
@@ -102,7 +102,7 @@ success_criteria:
   - type: command_executed
     description: "Static-simulation creation telemetry (report only; its requested removal leaves no durable witness)"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+.*--strategy\s+Static\b.*--mock-value'
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+(?=.*--strategy\s+Static\b)(?=.*--mock-value\b)'
     min_count: 1
     weight: 3.0
     pass_threshold: 0.0


### PR DESCRIPTION
## Why

`skill-flow-eval-child-simulation-crud` failed its highest-weighted authoring criterion (weight 3.0) on a run that **did the work correctly**. The outcome check on the eval-set JSON passed in that same run:

```
OK: parent simulation agent-1 auto-created (type=agent, strategy=Llm)
OK: parent 'agent-1' keeps child 'Web_Search' and dropped child 'Send_Email'
```

The only thing that failed was the regex reading the command line.

## The bug

The Static criterion was a four-way alternation enumerating flag **orderings**:

```
…simulation\s+add\s+.*--parent\s+.*--strategy\s+Static\b.*--mock-value
|--parent\s+.*--mock-value.*--strategy\s+Static
|--strategy\s+Static.*--parent\s+.*--mock-value
|--mock-value.*--parent\s+.*--strategy\s+Static
```

Three flags have six orderings; those four branches cover four. The agent used the fifth — `--strategy Static … --mock-value … --parent` — which every branch rejects (each requires `--parent` before `--mock-value`, or `Static` last). An enumeration of orderings will always have this failure mode.

Two more patterns had the same shape, plus a second defect: the `(uip|\$UIP)…` prefix binds only to the **first** alternative because the alternation is ungrouped. So `--strategy\s+Llm.*--parent` and `--parent.*simulation\s+remove` matched those flags in *any* command — a bare `echo --strategy Llm --parent agent-1` passed.

## The fix

Replaced all four with the lookahead idiom this repo already uses in `uipath-test`, `uipath-platform/traces` and `uipath-admin`:

```
…simulation\s+add\s+(?=.*--parent\b)(?=.*--strategy\s+Static\b)(?=.*--mock-value\b)
```

The verb stays anchored for every required flag, and flag order stops mattering.

`simulation_crud.yaml`'s Static pattern carried the same latent ordering requirement and is converted with it.

## Verification

Replayed against the recorded Bash commands of the failing run:

- the Static criterion now matches (was 0/1);
- all **six** flag orderings match;
- negatives still reject — an Llm add, a Static add without `--parent` (the parent simulation the task forbids), a non-`simulation add` verb, and the bare-flag `echo` the old ungrouped alternations let through;
- every pattern in both files compiles under `re`.

## Not included

Two other findings from the same failure triage are deliberately out of scope:

- **`check_e2e_contract_intake_pipeline.py` reading `recordId` from `pathParameters`** — this was a real grader bug (it failed the **v1 and v2 arms identically**, because `recordId` is declared `type: "query"` in the connector descriptor and both authoring paths emit it under `queryParameters`). #3128 already fixed it hours ago via `record_id_expr()`. Verified: that helper reads `=js:$vars.queryContracts.output[0].Id` correctly from both arms' real update nodes. No change needed.
- Order-sensitive patterns outside `uipath-maestro-flow` (`uipath-tasks`, `uipath-admin`, `uipath-process-mining`) — same bug class, separate suites, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)