### PR TITLE
fix(tests): retry a SIGKILLed flow debug instead of failing the criterion

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -102,6 +102,13 @@ _DEBUG_POLL_TIMEOUT_MARKER = "debug polling timed out"
 # the `retries` default.
 _POLL_TIMEOUT_ATTEMPTS = 2
 
+# A SIGKILLed attempt returns no envelope at all, so it cannot be classified as
+# transient or terminal — and it is observed to be flaky (skill-flow-cli-dice-
+# roller-simulated 2026-09-08 polled to 492s of a 540s CLI budget, then went
+# silent until the 600s cap). Its own allowance, like the poll-timeout and
+# unreadable-outputs paths; the deadline still bounds every attempt.
+_SUBPROCESS_TIMEOUT_ATTEMPTS = 2
+
 # Named so `debug_budget` and the criterion guard cannot drift from the
 # function they price. `_DEFAULT_RETRIES` was 3 until the budget started funding
 # every attempt it promises; 2 is a deliberate narrowing (one retry for a fast
@@ -349,7 +356,8 @@ def run_debug(
     Transient server-side errors (5xx / ``RetryLater``, or the CLI's own
     poll-budget expiry — see :func:`_is_transient_debug_error`) are retried up
     to ``retries`` times with ``backoff_seconds`` between attempts; poll
-    timeouts get :data:`_POLL_TIMEOUT_ATTEMPTS`, and any retry is skipped once
+    timeouts get :data:`_POLL_TIMEOUT_ATTEMPTS` and a SIGKILLed attempt gets
+    :data:`_SUBPROCESS_TIMEOUT_ATTEMPTS`, and any retry is skipped once
     the remainder drops below :data:`_MIN_RETRY_BUDGET_SECONDS`. A real flow
     fault fails immediately without burning retries.
 
@@ -420,6 +428,7 @@ def run_debug(
 
     unreadable: str | None = None
     unreadable_attempts = 0
+    subprocess_timeouts = 0
     overwrite_rotations = 0
     rotated_solution_ids: list[str] = []
     # `max_attempts` starts at the transient allowance and is extended by one
@@ -442,15 +451,28 @@ def run_debug(
                 env=env,
             )
         except subprocess.TimeoutExpired as exc:
-            # The CLI's own --timeout never fired, so the stall is upstream of
-            # polling. Keep the partial output rather than dying on a traceback.
+            # Keep the partial output rather than dying on a traceback: its tail
+            # is the only record of how far the run got.
             _LAST_DEBUG_RAW = _as_text(exc.stdout)
             _LAST_DEBUG_STDERR = _as_text(exc.stderr)
+            subprocess_timeouts += 1
+            fundable = (
+                deadline - time.monotonic() - backoff_seconds >= _MIN_RETRY_BUDGET_SECONDS
+            )
+            if subprocess_timeouts < _SUBPROCESS_TIMEOUT_ATTEMPTS and fundable:
+                time.sleep(backoff_seconds)
+                attempt += 1
+                # Extend rather than assign: a retries=1 caller has no attempt
+                # left to spend here, and falling out of the loop would reach
+                # the `r.returncode` read with `r` unbound.
+                max_attempts = max(max_attempts, attempt + 1)
+                continue
             _fail_with_capture(
                 f"flow debug exceeded the {attempt_cap}s subprocess cap without returning "
-                f"(CLI --timeout was {cli_timeout}s, so the stall is upstream of "
-                "polling: solution upload, Studio Web debug provisioning, "
-                "begin-session, or create-instance).\n"
+                f"on {subprocess_timeouts} attempt(s); the CLI's own --timeout of "
+                f"{cli_timeout}s produced no envelope"
+                + ("" if fundable else " and the remaining budget could not fund another")
+                + ". The captured tail ends at the last phase the run reported.\n"
                 f"stdout: {_as_text(exc.stdout)}\nstderr: {_as_text(exc.stderr)}"
             )
         _LAST_DEBUG_RAW = r.stdout

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -429,6 +429,11 @@ def run_debug(
     unreadable: str | None = None
     unreadable_attempts = 0
     subprocess_timeouts = 0
+    # Carried across this call's timeouts only. The module globals persist
+    # between run_debug calls, so reading them back would resurrect a previous
+    # call's capture, and _LAST_DEBUG_STDERR starts as None.
+    timeout_stdout = ""
+    timeout_stderr = ""
     overwrite_rotations = 0
     rotated_solution_ids: list[str] = []
     # `max_attempts` starts at the transient allowance and is extended by one
@@ -451,10 +456,14 @@ def run_debug(
                 env=env,
             )
         except subprocess.TimeoutExpired as exc:
-            # Keep the partial output rather than dying on a traceback: its tail
-            # is the only record of how far the run got.
-            _LAST_DEBUG_RAW = _as_text(exc.stdout)
-            _LAST_DEBUG_STDERR = _as_text(exc.stderr)
+            # Keep the richest partial output across timeouts, not the newest:
+            # a later attempt can die before printing anything, and the earlier
+            # one may hold the only instanceId the remote run can be inspected
+            # or cleaned up by.
+            timeout_stdout = _as_text(exc.stdout) or timeout_stdout
+            timeout_stderr = _as_text(exc.stderr) or timeout_stderr
+            _LAST_DEBUG_RAW = timeout_stdout
+            _LAST_DEBUG_STDERR = timeout_stderr
             subprocess_timeouts += 1
             fundable = (
                 deadline - time.monotonic() - backoff_seconds >= _MIN_RETRY_BUDGET_SECONDS
@@ -469,15 +478,15 @@ def run_debug(
                 continue
             _fail_with_capture(
                 f"flow debug exceeded the {attempt_cap}s subprocess cap without returning "
-                f"on {subprocess_timeouts} attempt(s); the CLI's own --timeout of "
-                f"{cli_timeout}s produced no envelope"
+                f"on {subprocess_timeouts} subprocess timeout(s) across {attempt + 1} "
+                f"attempt(s); the CLI's own --timeout of {cli_timeout}s produced no envelope"
                 + ("" if fundable else " and the remaining budget could not fund another")
-                + ". The stderr tail below is the last phase the run reported.\n"
-                f"stdout: {_as_text(exc.stdout)}\n"
+                + ". The stderr tail below is the last phase any attempt reported.\n"
+                f"stdout: {timeout_stdout}\n"
                 # Tail, not the whole stream: the grader truncates `details` from
                 # the front, and a polling run fills it, so inlining everything
                 # is what drops the phase this message points at.
-                f"stderr: {_as_text(exc.stderr)[-_STDERR_CAPTURE_TAIL_CHARS:]}"
+                f"stderr: {timeout_stderr[-_STDERR_CAPTURE_TAIL_CHARS:]}"
             )
         _LAST_DEBUG_RAW = r.stdout
         # Keep the CLI's stderr too: it is where `flow debug` reports what it

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -472,8 +472,12 @@ def run_debug(
                 f"on {subprocess_timeouts} attempt(s); the CLI's own --timeout of "
                 f"{cli_timeout}s produced no envelope"
                 + ("" if fundable else " and the remaining budget could not fund another")
-                + ". The captured tail ends at the last phase the run reported.\n"
-                f"stdout: {_as_text(exc.stdout)}\nstderr: {_as_text(exc.stderr)}"
+                + ". The stderr tail below is the last phase the run reported.\n"
+                f"stdout: {_as_text(exc.stdout)}\n"
+                # Tail, not the whole stream: the grader truncates `details` from
+                # the front, and a polling run fills it, so inlining everything
+                # is what drops the phase this message points at.
+                f"stderr: {_as_text(exc.stderr)[-_STDERR_CAPTURE_TAIL_CHARS:]}"
             )
         _LAST_DEBUG_RAW = r.stdout
         # Keep the CLI's stderr too: it is where `flow debug` reports what it

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -102,11 +102,10 @@ _DEBUG_POLL_TIMEOUT_MARKER = "debug polling timed out"
 # the `retries` default.
 _POLL_TIMEOUT_ATTEMPTS = 2
 
-# A SIGKILLed attempt returns no envelope at all, so it cannot be classified as
-# transient or terminal — and it is observed to be flaky (skill-flow-cli-dice-
-# roller-simulated 2026-09-08 polled to 492s of a 540s CLI budget, then went
-# silent until the 600s cap). Its own allowance, like the poll-timeout and
-# unreadable-outputs paths; the deadline still bounds every attempt.
+# A SIGKILLed attempt returns no envelope, so `_is_transient_debug_error` can
+# neither classify nor reach it. Its own allowance, like the poll-timeout path;
+# the deadline still bounds every attempt. Flaky in practice: dice-roller
+# 2026-09-08 polled to 492s of a 540s CLI budget, then went silent to the cap.
 _SUBPROCESS_TIMEOUT_ATTEMPTS = 2
 
 # Named so `debug_budget` and the criterion guard cannot drift from the
@@ -429,9 +428,8 @@ def run_debug(
     unreadable: str | None = None
     unreadable_attempts = 0
     subprocess_timeouts = 0
-    # Carried across this call's timeouts only. The module globals persist
-    # between run_debug calls, so reading them back would resurrect a previous
-    # call's capture, and _LAST_DEBUG_STDERR starts as None.
+    # Call-scoped: the globals persist across run_debug calls, and
+    # _LAST_DEBUG_STDERR starts as None, so reading them back resurrects or crashes.
     timeout_stdout = ""
     timeout_stderr = ""
     overwrite_rotations = 0
@@ -456,10 +454,8 @@ def run_debug(
                 env=env,
             )
         except subprocess.TimeoutExpired as exc:
-            # Keep the richest partial output across timeouts, not the newest:
-            # a later attempt can die before printing anything, and the earlier
-            # one may hold the only instanceId the remote run can be inspected
-            # or cleaned up by.
+            # Richest, not newest: a later attempt can die before printing, and
+            # the earlier one may hold the only instanceId for the remote run.
             timeout_stdout = _as_text(exc.stdout) or timeout_stdout
             timeout_stderr = _as_text(exc.stderr) or timeout_stderr
             _LAST_DEBUG_RAW = timeout_stdout
@@ -471,9 +467,8 @@ def run_debug(
             if subprocess_timeouts < _SUBPROCESS_TIMEOUT_ATTEMPTS and fundable:
                 time.sleep(backoff_seconds)
                 attempt += 1
-                # Extend rather than assign: a retries=1 caller has no attempt
-                # left to spend here, and falling out of the loop would reach
-                # the `r.returncode` read with `r` unbound.
+                # Extend, not assign: a retries=1 caller has no attempt left
+                # here, and exiting the loop reads `r.returncode` with `r` unbound.
                 max_attempts = max(max_attempts, attempt + 1)
                 continue
             _fail_with_capture(
@@ -483,9 +478,8 @@ def run_debug(
                 + ("" if fundable else " and the remaining budget could not fund another")
                 + ". The stderr tail below is the last phase any attempt reported.\n"
                 f"stdout: {timeout_stdout}\n"
-                # Tail, not the whole stream: the grader truncates `details` from
-                # the front, and a polling run fills it, so inlining everything
-                # is what drops the phase this message points at.
+                # Tail only: the grader truncates `details` from the front and a
+                # polling run fills it, so the whole stream drops what this names.
                 f"stderr: {timeout_stderr[-_STDERR_CAPTURE_TAIL_CHARS:]}"
             )
         _LAST_DEBUG_RAW = r.stdout

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -1396,22 +1396,47 @@ def test_run_debug_retry_floor_matches_the_cli_minimum():
     )
 
 
-def test_run_debug_subprocess_timeout_fails_cleanly(monkeypatch):
-    """A stall upstream of polling exits as a graded FAIL carrying the partial
-    output, not as an uncaught TimeoutExpired traceback."""
-    exc = subprocess.TimeoutExpired(
+def _subprocess_timeout(instance_id="abc-123"):
+    return subprocess.TimeoutExpired(
         cmd=["uip", "maestro", "flow", "debug"],
         timeout=240,
         output=b'{"partial": true}',
-        stderr=b"Debug instance created - instanceId: abc-123\n",
+        stderr=f"Debug instance created - instanceId: {instance_id}\n".encode(),
     )
-    calls = _stub_debug(monkeypatch, [exc])
+
+
+def test_run_debug_retries_subprocess_timeout_then_completes(monkeypatch):
+    """A SIGKILLed first attempt is flaky, not terminal: the second one grades."""
+    calls = _stub_debug(monkeypatch, [_subprocess_timeout(), _cp(0, _COMPLETED)])
+    payload = run_debug(timeout=240)
+    assert calls["n"] == 2
+    assert flow_check._get_ci(payload, "finalStatus") == "Completed"
+
+
+def test_run_debug_refuses_a_subprocess_timeout_retry_it_cannot_fund(monkeypatch):
+    """The allowance never outruns the deadline. Asserting the allowance has
+    room first is what makes the budget the thing under test."""
+    assert flow_check._SUBPROCESS_TIMEOUT_ATTEMPTS > 1
+    calls = _stub_debug(monkeypatch, [_subprocess_timeout()] * 2, attempt_seconds=180)
+    with pytest.raises(SystemExit) as excinfo:
+        run_debug(timeout=180, budget=240, backoff_seconds=5)
+    assert calls["n"] == 1  # 240 - 180 - 5 = 55, under the 90s retry floor
+    assert "could not fund another" in str(excinfo.value)
+
+
+def test_run_debug_subprocess_timeout_fails_cleanly(monkeypatch):
+    """A SIGKILLed run exits as a graded FAIL carrying the partial output, not
+    as an uncaught TimeoutExpired traceback — after its own allowance."""
+    calls = _stub_debug(monkeypatch, [_subprocess_timeout(), _subprocess_timeout()])
     with pytest.raises(SystemExit) as excinfo:
         run_debug(timeout=240)
-    assert calls["n"] == 1
+    assert calls["n"] == flow_check._SUBPROCESS_TIMEOUT_ATTEMPTS
     message = str(excinfo.value)
     assert "240s subprocess cap" in message
+    assert "on 2 attempt(s)" in message
     assert "abc-123" in message  # without the instanceId the run is unrecoverable
+    # The stall phase is not knowable from a SIGKILL; the tail is the evidence.
+    assert "upstream of" not in message
     assert flow_check._LAST_DEBUG_RAW == '{"partial": true}'
 
 

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -1413,6 +1413,33 @@ def test_run_debug_retries_subprocess_timeout_then_completes(monkeypatch):
     assert flow_check._get_ci(payload, "finalStatus") == "Completed"
 
 
+def test_run_debug_keeps_the_richest_timeout_capture(monkeypatch):
+    """A later timeout that printed nothing must not erase the instanceId an
+    earlier one exposed — it is the only handle on the remote run."""
+    first = _subprocess_timeout("inst-from-attempt-1")
+    second = subprocess.TimeoutExpired(
+        cmd=["uip", "maestro", "flow", "debug"], timeout=240, output=b"", stderr=b""
+    )
+    _stub_debug(monkeypatch, [first, second])
+    with pytest.raises(SystemExit) as excinfo:
+        run_debug(timeout=240)
+    assert "inst-from-attempt-1" in str(excinfo.value)
+    assert flow_check._LAST_DEBUG_RAW == '{"partial": true}'
+
+
+def test_run_debug_timeout_message_counts_all_attempts(monkeypatch):
+    """The two counters are distinct: a transient failure ahead of the timeouts
+    raises the attempt total without spending the timeout allowance."""
+    calls = _stub_debug(
+        monkeypatch,
+        [_cp(1, _TRANSIENT_504), _subprocess_timeout(), _subprocess_timeout()],
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        run_debug(timeout=240)
+    assert calls["n"] == 3
+    assert "2 subprocess timeout(s) across 3 attempt(s)" in str(excinfo.value)
+
+
 def test_run_debug_refuses_a_subprocess_timeout_retry_it_cannot_fund(monkeypatch):
     """The allowance never outruns the deadline. Asserting the allowance has
     room first is what makes the budget the thing under test."""
@@ -1433,7 +1460,7 @@ def test_run_debug_subprocess_timeout_fails_cleanly(monkeypatch):
     assert calls["n"] == flow_check._SUBPROCESS_TIMEOUT_ATTEMPTS
     message = str(excinfo.value)
     assert "240s subprocess cap" in message
-    assert "on 2 attempt(s)" in message
+    assert "on 2 subprocess timeout(s) across 2 attempt(s)" in message
     assert "abc-123" in message  # without the instanceId the run is unrecoverable
     # The stall phase is not knowable from a SIGKILL; the tail is the evidence.
     assert "upstream of" not in message


### PR DESCRIPTION
`skill-flow-cli-dice-roller-simulated` scored **0.714** on a flow that validated (1.0) and was named correctly (1.0). The only failing criterion was the checker's own `uip maestro flow debug`, SIGKILLed at the 600s subprocess cap.

Its YAML funds two attempts and says so:

```yaml
# 1320 funds debug_budget(600) + margin: two 600s attempts plus backoff.
timeout: 1320
```

`debug_budget(600, retries=2)` is 1205s. The second attempt was funded and **never taken** — the `TimeoutExpired` path called `_fail_with_capture` immediately.

## The allowance

A SIGKILLed attempt returns no envelope, so `_is_transient_debug_error` can neither classify nor reach it. It gets its own allowance, `_SUBPROCESS_TIMEOUT_ATTEMPTS`, alongside the existing poll-timeout and unreadable-outputs paths. The deadline still bounds every attempt, and `debug_budget` is untouched — **no criterion ceiling moves**.

Worth retrying because it is flaky rather than deterministic: the same YAML notes *"measured: 2 of 3 codex runs raised subprocess.TimeoutExpired"*.

## The diagnostic was wrong

It asserted:

> the stall is upstream of polling: solution upload, Studio Web debug provisioning, begin-session, or create-instance

The captured output ends at `Still polling... status: Running (492s elapsed)`. The run **was** in the poll loop, and the CLI's own `--timeout 540` produced no envelope before the 600s kill. A SIGKILL cannot tell you which phase stalled, so the message now reports the counts and points at the tail instead of naming a phase.

## Review rounds changed three more things

**The message was destroying the evidence it pointed at.** It inlined the whole stderr; the grader truncates `details` from the front and a polling run fills it — which is why the dice failure shows `492s` in `error_log_tail` but only `282s` in `details`. Now inlines `stderr[-_STDERR_CAPTURE_TAIL_CHARS:]`, matching what `_dump_debug_capture` already keeps.

**Retrying made the capture lossy.** Each timeout overwrote `_LAST_DEBUG_RAW` / `_LAST_DEBUG_STDERR`, so an attempt that died before printing erased the `instanceId` an earlier one exposed — the only handle for inspecting or cleaning up the remote run. Now carries the last non-empty value. Deliberately in **call-scoped locals**, not by reading the globals back: those persist between `run_debug` calls (several checkers call it twice), and `_LAST_DEBUG_STDERR` starts as `None`, which the tail slice would raise `TypeError` on.

**The counts were conflated.** `on N attempt(s)` counted timeout exceptions, so a transient failure ahead of a timeout reported one attempt where two ran. It now reports both: `on 2 subprocess timeout(s) across 3 attempt(s)`.

## An interaction worth knowing

`[transient, timeout, timeout]` produces **three** attempts — the transient spends a `retries` attempt without touching the timeout allowance. That is not a budget violation: `debug_budget` prices wall clock, every attempt is capped at `min(timeout, deadline - now)`, and a retry is refused below `_MIN_RETRY_BUDGET_SECONDS`. It matches the existing design, where the poll-timeout and unreadable-outputs allowances are likewise independent of `retries`. `test_run_debug_timeout_message_counts_all_attempts` pins it.

On a genuinely stuck flow this does double time-to-failure — 600s becomes the full 1205s — in exchange for recovering the flaky case the YAML already funded.

## Tests

Five cases on the pattern of the existing poll-timeout pair: retry-then-completes, richest-capture-wins, both counters distinct, budget-too-small-to-retry, and the updated fails-cleanly.

**Mutation-checked, each against the mutation it is meant to catch:** setting `_SUBPROCESS_TIMEOUT_ATTEMPTS` back to `1`, reverting the carry-forward to a plain assignment, and reporting the timeout count as the attempt total. The budget case asserts the allowance has room first — without that it passed under mutation, for the wrong reason.

`tests/tasks/uipath-maestro-flow` — **1163 passed**.

## Notes

Comments were cut from 18 lines to 12 on a final pass — one warning per wrong edit that is actually reachable.

Separately worth an owner's eye, not addressed here: polling reached 492s and then emitted nothing for 108s while the CLI's own 540s `--timeout` never fired. That reads like a poll request blocking with no per-request timeout, which would mean `--timeout` cannot bound the phase it most needs to.

Touches only `_shared/*.py`, so `Detect changed skills` finds no skill change and the smoke job is skipped — this PR is unaffected by the Data Fabric connection currently breaking #3141.

Sixth of the maestro-flow nightly triage. Filed tag was `validation-error`; the flow was fine and the grader gave up early. Follows #3138, #3139, #3140 (merged) and #3141.
