### PR TITLE
fix(tests): give grading room in group_to_subflow, and the build a turn in customer_escalation

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -171,6 +171,15 @@ Experiment files define shared agent defaults per test type. Tasks inherit these
 
 Run-time caps live under `defaults.run_limits` (see coder_eval `RunLimits`).
 
+`turn_timeout` bounds one agent turn; `task_timeout` bounds the turns **and**
+grading under a single watchdog. Raising `task_timeout` therefore does not give
+a turn more room — the orchestrator logs `A larger task_timeout cannot extend
+the agent's single iteration` when a task tries. Raise `turn_timeout` for an
+agent that runs out of time mid-build, and `task_timeout` when the criteria
+need room after it: a task whose `task_timeout` equals its `turn_timeout`
+leaves grading nothing, and firing that watchdog reports the whole task
+`TIMEOUT`, losing even the criteria that passed.
+
 | Experiment | Driver | Used by | max_turns | task_timeout | turn_timeout |
 |------------|--------|---------|-----------|--------------|--------------|
 | `default.yaml` | tempdir | Devs locally, ad-hoc runs | 200 | 1200s | 900s |

--- a/tests/README.md
+++ b/tests/README.md
@@ -176,9 +176,12 @@ grading under a single watchdog. Raising `task_timeout` therefore does not give
 a turn more room — the orchestrator logs `A larger task_timeout cannot extend
 the agent's single iteration` when a task tries. Raise `turn_timeout` for an
 agent that runs out of time mid-build, and `task_timeout` when the criteria
-need room after it: a task whose `task_timeout` equals its `turn_timeout`
-leaves grading nothing, and firing that watchdog reports the whole task
-`TIMEOUT`, losing even the criteria that passed.
+need room after it: grading only gets what the turn did not spend. A task whose
+`task_timeout` equals its `turn_timeout` therefore grades only if the agent
+finishes early. That is fine where turns reliably come in short (`smoke.yaml`
+runs equal 900s caps on purpose) and a trap for a task that uses its full turn,
+because firing that watchdog reports the whole task `TIMEOUT`, losing even the
+criteria that passed.
 
 | Experiment | Driver | Used by | max_turns | task_timeout | turn_timeout |
 |------------|--------|---------|-----------|--------------|--------------|

--- a/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
@@ -12,6 +12,7 @@ tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node, node:subflow]
 run_limits:
   expected_turns: 13
   turn_timeout: 1200
+  task_timeout: 2400  # 780s grading + a full turn; inherited 1200 left grading nothing
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_simulated/customer_escalation_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_simulated/customer_escalation_simulated.yaml
@@ -15,7 +15,10 @@ run_limits:
   # by simulation.max_turns below.
   max_turns: 90
   task_timeout: 2400
-  turn_timeout: 1200
+  # The persona answers every question in one message, so the whole six-node
+  # build lands in a single turn — turn_timeout, not task_timeout, is what
+  # bounds it, and 1200s cut the 2026-09-08 run off at `flow validate`.
+  turn_timeout: 1800
 
 # No initial_prompt — the simulator generates turn 1 from its persona + goal.
 


### PR DESCRIPTION
Two of the five 2026-09-08 zero-scores were clock, not capability. This fixes those two and deliberately leaves the other three alone.

## group_to_subflow — grading could not fit

```yaml
run_limits:
  turn_timeout: 1200      # task_timeout omitted -> inherits 1200
```

Its two criteria are worth **780s**. With both watchdogs at 1200, the agent had to finish inside 420s or the task watchdog fired before grading. On 2026-09-08 it fired at exactly `1200.0s` and the run reported `ERROR` with both criteria *"Not evaluated after terminal agent failure"* — the only one of the five killed by the **task** watchdog rather than the turn one.

`slack_weather_pipeline` has the identical turn budget and the identical 780s grading total, and already sets `task_timeout: 2400`. This brings the outlier in line rather than inventing a number.

## customer_escalation_simulated — the build is one turn by design

The persona answers every question in a single message, so the whole six-connector-node build lands in one turn. **`turn_timeout` is what bounds it, not `task_timeout`** — the run hit the 1200s cap having reached `flow validate` with the nodes added and no edges yet, while roughly **1189s of the 2400s task budget went unused**.

`1200 → 1800`. That leaves 495s for the rest of the dialog plus 105s of grading, and `task_timeout` stays at 2400 so the total is still bounded.

## Left alone, deliberately

| task | why not |
|---|---|
| `wiki_pageviews` | Its 1093s of generation went to the group-by search **#3140 now answers**. Changing the clock would confound whether that fix worked. |
| `slack_weather_pipeline` | Died on discovery waste — a `folderKey` re-derived after it was already in the output, Slack pagination, and a hunt for a geocoding node that does not exist. More clock buys more waste. |
| `datafabric-smoke-activation-negative` | Already fixed by #3139 (merged) with a turn cap, not a bigger budget. |

## Documented what the orchestrator only warns about

`tests/README.md` had a run-limits table but never said how the two caps relate. Every one of the ten runs logged:

> `A larger task_timeout cannot extend the agent's single iteration; the agent budget is turn_timeout`

That is now written down, along with the consequence that equal values leave grading nothing and firing that watchdog reports the whole task `TIMEOUT`, losing even the criteria that passed.

## No new guard test — the stronger invariant was already rejected

My first instinct was a static check for `task_timeout >= turn_timeout + grading`. `test_criterion_budgets.py` already records why not:

> An impossibility check, not a sufficiency one — anything stronger needs the agent's real wall clock. An earlier draft demanded `grading + turn_timeout` and broke on `smoke.yaml`, where the two are equal.

So the existing `task_timeout > worst-case grading` check stands. Both changed tasks satisfy it, and now also clear `turn + grading <= task` with 420s and 495s of slack respectively.

`tests/tasks/uipath-maestro-flow` — **1159 passed**, including the budget guard.

Seventh of the maestro-flow nightly triage. Follows #3138, #3139, #3140 (merged), #3141 and #3144.
