### PR TITLE
fix(uipath-maestro-flow): the scheduled trigger's cycle expression lives in timerValue

### DIFF
--- a/skills/uipath-maestro-flow/references/author/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/author/editing-operations-json.md
@@ -281,7 +281,7 @@ Only `inout` variables can be updated; `in` variables are read-only. `expression
 "inputs": {
   "entryPointId": "<existing-uuid>",
   "timerType": "timeCycle",
-  "timerPreset": "R/PT1H"
+  "timerValue": "R/PT1H"
 }
 ```
 

--- a/skills/uipath-maestro-flow/references/author/plugins/scheduled-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/scheduled-trigger/impl.md
@@ -8,11 +8,11 @@
 
 Run `uip maestro flow registry get core.trigger.scheduled --output json`.
 
-Confirm that the definition has no input port, output port `output`, and required inputs `timerType` and `timerPreset`. Set the node instance `typeVersion` to the response `version` field; do not hardcode it because this node has advanced past `1.0`.
+Confirm that the definition has no input port, output port `output`, and the required input `timerValue`. Set the node instance `typeVersion` to the response `version` field; do not hardcode it because this node has advanced past `1.0`.
 
 ## JSON Structure
 
-### Preset Frequency
+### Repeating Interval
 
 ```json
 {
@@ -23,7 +23,7 @@ Confirm that the definition has no input port, output port `output`, and require
   "inputs": {
     "entryPointId": "<uuid>",
     "timerType": "timeCycle",
-    "timerPreset": "R/PT1H"
+    "timerValue": "R/PT1H"
   },
   "outputs": {
     "output": {
@@ -36,19 +36,18 @@ Confirm that the definition has no input port, output port `output`, and require
 }
 ```
 
-### Custom Frequency
+### Cron Expression
 
 ```json
 {
   "id": "scheduledStart",
   "type": "core.trigger.scheduled",
   "typeVersion": "<DEFINITION_VERSION>",
-  "display": { "label": "Every 45 Minutes" },
+  "display": { "label": "Every Hour On The Hour" },
   "inputs": {
     "entryPointId": "<uuid>",
     "timerType": "timeCycle",
-    "timerPreset": "custom",
-    "timerValue": "R/PT45M"
+    "timerValue": "0 0 */1 * * ? *"
   },
   "outputs": {
     "output": {
@@ -71,7 +70,7 @@ Use [Edit/Write: Replace manual trigger with scheduled trigger](../../editing-op
 
 | Error | Cause | Fix |
 | --- | --- | --- |
-| Invalid timer value | Malformed ISO 8601 repeating interval | Check format: `R/P[duration]` (e.g., `R/PT1H`) |
-| Missing `timerValue` | `timerPreset: "custom"` but no `timerValue` | Add `timerValue` with an ISO 8601 repeating interval |
+| Cycle expression must be either an ISO 8601 repeating interval or a Quartz cron expression | Malformed `timerValue` | Use `R/P[duration]` (e.g. `R/PT1H`) or a 6-7 field cron (e.g. `0 0 */1 * * ? *`) |
+| `[REQUIRED_FIELD] "timerValue" is required` | Cycle expression written to `timerPreset` | `core.trigger.scheduled` has no `timerPreset` input — put the cycle expression in `timerValue` |
 | BPMN timer event not emitted | `core.trigger.scheduled` definition wrong or missing | Re-copy from `uip maestro flow registry get core.trigger.scheduled --output json` — the definition carries `model.eventDefinition: "bpmn:TimerEventDefinition"` |
 | Two triggers in flow | Both manual and scheduled triggers exist | Remove one — flows must have exactly one trigger |

--- a/skills/uipath-maestro-flow/references/author/plugins/scheduled-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/scheduled-trigger/impl.md
@@ -38,27 +38,7 @@ Confirm that the definition has no input port, output port `output`, and the req
 
 ### Cron Expression
 
-```json
-{
-  "id": "scheduledStart",
-  "type": "core.trigger.scheduled",
-  "typeVersion": "<DEFINITION_VERSION>",
-  "display": { "label": "Every Hour On The Hour" },
-  "inputs": {
-    "entryPointId": "<uuid>",
-    "timerType": "timeCycle",
-    "timerValue": "0 0 */1 * * ? *"
-  },
-  "outputs": {
-    "output": {
-      "type": "object",
-      "description": "The return value of the trigger.",
-      "source": "=result.response",
-      "var": "output"
-    }
-  }
-}
-```
+Same node with a clock-aligned `timerValue`: `"timerValue": "0 0 9 ? * MON-FRI"` (weekdays at 09:00).
 
 Do not add BPMN type (`bpmn:StartEvent`) or event definition (`bpmn:TimerEventDefinition`) to the instance; they come from the `core.trigger.scheduled` entry in `definitions[]`.
 
@@ -70,7 +50,7 @@ Use [Edit/Write: Replace manual trigger with scheduled trigger](../../editing-op
 
 | Error | Cause | Fix |
 | --- | --- | --- |
-| Cycle expression must be either an ISO 8601 repeating interval or a Quartz cron expression | Malformed `timerValue` | Use `R/P[duration]` (e.g. `R/PT1H`) or a 6-7 field cron (e.g. `0 0 */1 * * ? *`) |
+| Cycle expression must be either an ISO 8601 repeating interval or a Quartz cron expression | Malformed `timerValue` | Use `R/P[duration]` (e.g. `R/PT1H`) or a 6-7 field cron (e.g. `0 0 9 ? * MON-FRI`) |
 | `[REQUIRED_FIELD] "timerValue" is required` | Cycle expression written to `timerPreset` | `core.trigger.scheduled` has no `timerPreset` input — put the cycle expression in `timerValue` |
 | BPMN timer event not emitted | `core.trigger.scheduled` definition wrong or missing | Re-copy from `uip maestro flow registry get core.trigger.scheduled --output json` — the definition carries `model.eventDefinition: "bpmn:TimerEventDefinition"` |
 | Two triggers in flow | Both manual and scheduled triggers exist | Remove one — flows must have exactly one trigger |

--- a/skills/uipath-maestro-flow/references/author/plugins/scheduled-trigger/planning.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/scheduled-trigger/planning.md
@@ -25,13 +25,19 @@ Use a Scheduled Trigger to start the flow on a recurring schedule instead of man
 
 | Input | Required | Description |
 | --- | --- | --- |
-| `timerType` | Yes | Always `timeCycle` for scheduled triggers |
-| `timerPreset` | Yes | Preset value or `custom` |
-| `timerValue` | Conditional | Required when `timerPreset: "custom"` (ISO 8601 repeating interval) |
+| `timerValue` | Yes | The cycle expression — ISO 8601 repeating interval or Quartz cron |
+| `timerType` | No | `timeCycle` for scheduled triggers |
 
-## Frequency Presets
+There is no `timerPreset` input on this node. Every frequency, common or not,
+goes in `timerValue`.
 
-| Preset Value | Frequency |
+## Cycle Expression Formats
+
+### ISO 8601 Repeating Interval
+
+`R/P[duration]` — `R` means repeat indefinitely, followed by duration.
+
+| Value | Frequency |
 | --- | --- |
 | `R/PT5M` | Every 5 minutes |
 | `R/PT15M` | Every 15 minutes |
@@ -41,13 +47,18 @@ Use a Scheduled Trigger to start the flow on a recurring schedule instead of man
 | `R/PT12H` | Every 12 hours |
 | `R/P1D` | Daily |
 | `R/P1W` | Weekly |
-| `custom` | Use `timerValue` for custom ISO 8601 repeating interval |
 
-## ISO 8601 Repeating Interval Format
+Any other interval uses the same form: `R/PT10M` (every 10 min), `R/P2D` (every 2 days).
 
-`R/P[duration]` — `R` means repeat indefinitely, followed by duration.
+Exactly one duration unit, non-zero, and in range — `Y` 1-9999, `M` 1-12, `W` 1-52, `D` 1-31, `H` 1-23, `T…M` 1-59, `S` 1-59. `R/PT2H30M` (two units), `R/PT24H` (out of range), and `R/PT0H` (zero) are all rejected. Express those as a cron expression instead.
 
-Examples: `R/PT10M` (every 10 min), `R/P2D` (every 2 days), `R/PT2H30M` (every 2.5 hours)
+An interval may be anchored to a start instant: `R/2026-05-14T09:00:00Z/P1W`.
+
+### Quartz Cron
+
+Six or seven whitespace-separated fields, for schedules a single-unit interval cannot express (every 2.5 hours, 09:00 every weekday).
+
+Examples: `0 0 */1 * * ? *` (hourly on the hour), `0 30 */2 * * ? *` (every 2.5 hours), `0 0 9 ? * MON-FRI` (weekdays at 09:00)
 
 ## Key Rules
 

--- a/skills/uipath-maestro-flow/references/author/plugins/scheduled-trigger/planning.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/scheduled-trigger/planning.md
@@ -33,8 +33,8 @@ without `timerType` passes `validate`, but `model.values` maps
 `timerType -> inputs.timerType` to build the BPMN timer event. Omitting it
 leaves the event without its cycle type.
 
-There is no `timerPreset` input on this node. Every frequency, common or not,
-goes in `timerValue`.
+The definition the registry serves (1.2) has no `timerPreset` input. Every
+frequency, common or not, goes in `timerValue`.
 
 ## Cycle Expression Formats
 
@@ -71,15 +71,20 @@ Six or seven whitespace-separated fields. Use it for a clock-aligned schedule
 an interval cannot express: a fixed time of day, a set of weekdays, a day of
 the month.
 
-Examples: `0 0 */1 * * ? *` (hourly on the hour), `0 0 9 ? * MON-FRI` (weekdays at 09:00), `0 0 2 1 * ? *` (02:00 on the 1st)
+Examples: `0 0 9 ? * MON-FRI` (weekdays at 09:00), `0 0 2 1 * ? *` (02:00 on the 1st)
+
+Put `?` in day-of-month or day-of-week, never a value in both.
+
+`validate` checks cron field shape only, never semantics: `0 0 12 * * *` (no
+`?`) and even `ABC ABC ABC ABC ABC ABC` pass it. Read the expression back field
+by field before shipping.
 
 Cron does not extend the set of *periods* available. An arbitrary period is
-expressible in neither form: the interval takes one in-range unit (`R/PT2H30M`,
-`R/PT150M`, and `R/PT90M` are all rejected) and no single cron expression
-carries a sub-hour period across the hour boundary. Every 2.5 hours and every
-90 minutes have no representation here — pick a period one of the two forms
-accepts (`R/PT2H`, `R/PT3H`) and say so, rather than shipping a cron that
-silently fires on a different cadence.
+expressible in neither form: the interval takes one in-range unit and no single
+cron expression carries a sub-hour period across the hour boundary. Every 2.5
+hours and every 90 minutes have no representation here — pick a period one of
+the two forms accepts (`R/PT2H`, `R/PT3H`) and say so, rather than shipping a
+cron that silently fires on a different cadence.
 
 ## Key Rules
 

--- a/skills/uipath-maestro-flow/references/author/plugins/scheduled-trigger/planning.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/scheduled-trigger/planning.md
@@ -26,7 +26,12 @@ Use a Scheduled Trigger to start the flow on a recurring schedule instead of man
 | Input | Required | Description |
 | --- | --- | --- |
 | `timerValue` | Yes | The cycle expression — ISO 8601 repeating interval or Quartz cron |
-| `timerType` | No | `timeCycle` for scheduled triggers |
+| `timerType` | Yes | Always `timeCycle` for scheduled triggers |
+
+Set both. The definition's `required` array names only `timerValue`, so a flow
+without `timerType` passes `validate`, but `model.values` maps
+`timerType -> inputs.timerType` to build the BPMN timer event. Omitting it
+leaves the event without its cycle type.
 
 There is no `timerPreset` input on this node. Every frequency, common or not,
 goes in `timerValue`.
@@ -50,15 +55,31 @@ goes in `timerValue`.
 
 Any other interval uses the same form: `R/PT10M` (every 10 min), `R/P2D` (every 2 days).
 
-Exactly one duration unit, non-zero, and in range — `Y` 1-9999, `M` 1-12, `W` 1-52, `D` 1-31, `H` 1-23, `T…M` 1-59, `S` 1-59. `R/PT2H30M` (two units), `R/PT24H` (out of range), and `R/PT0H` (zero) are all rejected. Express those as a cron expression instead.
+Exactly one duration unit, non-zero, and in range: `Y` 1-9999, `M` 1-12, `W` 1-52, `D` 1-31, `H` 1-23, `T…M` 1-59, `S` 1-59.
+
+| Rejected | Why | Instead |
+| --- | --- | --- |
+| `R/PT24H` | out of range | `R/P1D` |
+| `R/PT0H` | zero, never fires | any non-zero interval |
+| `R/PT2H30M` | two units | not expressible as an interval — see below |
 
 An interval may be anchored to a start instant: `R/2026-05-14T09:00:00Z/P1W`.
 
 ### Quartz Cron
 
-Six or seven whitespace-separated fields, for schedules a single-unit interval cannot express (every 2.5 hours, 09:00 every weekday).
+Six or seven whitespace-separated fields. Use it for a clock-aligned schedule
+an interval cannot express: a fixed time of day, a set of weekdays, a day of
+the month.
 
-Examples: `0 0 */1 * * ? *` (hourly on the hour), `0 30 */2 * * ? *` (every 2.5 hours), `0 0 9 ? * MON-FRI` (weekdays at 09:00)
+Examples: `0 0 */1 * * ? *` (hourly on the hour), `0 0 9 ? * MON-FRI` (weekdays at 09:00), `0 0 2 1 * ? *` (02:00 on the 1st)
+
+Cron does not extend the set of *periods* available. An arbitrary period is
+expressible in neither form: the interval takes one in-range unit (`R/PT2H30M`,
+`R/PT150M`, and `R/PT90M` are all rejected) and no single cron expression
+carries a sub-hour period across the hour boundary. Every 2.5 hours and every
+90 minutes have no representation here — pick a period one of the two forms
+accepts (`R/PT2H`, `R/PT3H`) and say so, rather than shipping a cron that
+silently fires on a different cadence.
 
 ## Key Rules
 

--- a/skills/uipath-maestro-flow/references/shared/file-format.md
+++ b/skills/uipath-maestro-flow/references/shared/file-format.md
@@ -259,7 +259,7 @@ Copy the returned node definition object into your `definitions` array. Dependin
 | Type | Purpose | Key inputs |
 |------|---------|------------|
 | `core.trigger.manual` | Entry point | `entryPointId` |
-| `core.trigger.scheduled` | Recurring schedule trigger | `entryPointId`, `timerType`, `timerPreset` |
+| `core.trigger.scheduled` | Recurring schedule trigger | `entryPointId`, `timerType`, `timerValue` |
 | `core.action.script` | Run JavaScript | `script` |
 | `core.action.http.v2` | HTTP request | `method`, `url`, `headers`, `body` |
 | `core.action.transform` | Map/filter/group data | `collection`, `operations` |

--- a/tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py
@@ -123,10 +123,9 @@ def _check_schedule_config(inputs: dict) -> None:
     cycle = inputs.get("timerValue")
     if not isinstance(cycle, str) or not cycle.strip():
         _fail(
-            "inputs.timerValue missing or empty — it carries the cycle expression "
-            "and is the node's only required input. `core.trigger.scheduled` has no "
-            "`timerPreset`; a cycle expression written there fails validate with "
-            'REQUIRED_FIELD "timerValue".'
+            "inputs.timerValue missing or empty — it carries the cycle expression. "
+            "`core.trigger.scheduled` has no `timerPreset`; a cycle expression "
+            'written there fails validate with REQUIRED_FIELD "timerValue".'
         )
 
     if not CYCLE_RE.match(cycle):

--- a/tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py
@@ -137,7 +137,7 @@ def _check_schedule_config(inputs: dict) -> None:
             'written there fails validate with REQUIRED_FIELD "timerValue".'
         )
 
-    if not CYCLE_RE.match(cycle):
+    if not CYCLE_RE.fullmatch(cycle):
         _fail(
             f"inputs.timerValue={cycle!r} is neither an ISO 8601 repeating interval "
             "with a single non-zero duration unit (e.g. R/PT1H, R/P1D) nor a Quartz "

--- a/tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py
@@ -16,11 +16,11 @@ trigger and carries a valid recurring schedule:
      `edges[]` must contain no entry whose `targetNodeId` is the trigger id).
   4. Valid schedule config on the node `inputs`:
        - `timerType == "timeCycle"`;
-       - `timerPreset` present and non-empty;
-       - the effective cycle expression — `timerValue` when
-         `timerPreset == "custom"`, otherwise `timerPreset` — is a valid ISO
-         8601 repeating interval (`R/...`), matching the registry's own
-         pattern. `custom` without a non-empty `timerValue` fails.
+       - `timerValue` present, non-empty, and matching the registry's own
+         `timerValue` pattern — an ISO 8601 repeating interval (`R/PT1H`) or a
+         Quartz cron expression (`0 0 9 ? * MON-FRI`).
+     `core.trigger.scheduled` has no `timerPreset` input; a cycle expression
+     written there fails `validate` with `REQUIRED_FIELD timerValue`.
   5. `typeVersion` present and non-empty (the agent-under-test copies the
      `version` field from the registry, so we do NOT pin a specific value —
      this node has already advanced past 1.0).
@@ -47,14 +47,24 @@ SCHEDULED = "core.trigger.scheduled"
 MANUAL = "core.trigger.manual"
 TRIGGER_PREFIX = "core.trigger."
 
-# ISO 8601 repeating-interval pattern, copied verbatim from the
-# `core.trigger.scheduled` registry definition (inputDefinition.then for
-# timerValue). Accepts R/PT1H, R/P1D, R/P1W, R/PT45M, R/2026-05-14T09:00:00Z/P1W, ...
+# `timerValue` pattern, copied verbatim from the `core.trigger.scheduled`
+# registry definition (inputDefinition.properties.timerValue.pattern) so this
+# checker accepts exactly what `uip maestro flow validate` accepts. Two shapes:
+# an ISO 8601 repeating interval with exactly ONE non-zero duration unit
+# (R/PT1H, R/P1D, R/2026-05-14T09:00:00Z/P1W — but NOT R/PT2H30M or R/PT24H),
+# or a 6-7 field Quartz cron (0 0 */1 * * ? *). Refresh with:
+#   uip maestro flow registry get core.trigger.scheduled --output json
 CYCLE_RE = re.compile(
-    r"^R\d*\/(P(?=\d|T)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?"
-    r"(\/\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?)?)?"
-    r"|\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?)?"
-    r"\/P(?=\d|T)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?)$"
+    r"^(?:R\d*\/(?:P(?:[1-9][0-9]{0,3}Y|(?:[1-9]|1[0-2])M|(?:[1-9]|[1-4][0-9]|5[0-2])W"
+    r"|(?:[1-9]|[12][0-9]|3[01])D|T(?:(?:[1-9]|1[0-9]|2[0-3])H|(?:[1-9]|[1-5][0-9])M"
+    r"|(?:[1-9]|[1-5][0-9])S))(?:\/\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?"
+    r"(?:Z|[+-]\d{2}:\d{2})?)?)?|\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?"
+    r"(?:Z|[+-]\d{2}:\d{2})?)?\/P(?:[1-9][0-9]{0,3}Y|(?:[1-9]|1[0-2])M"
+    r"|(?:[1-9]|[1-4][0-9]|5[0-2])W|(?:[1-9]|[12][0-9]|3[01])D"
+    r"|T(?:(?:[1-9]|1[0-9]|2[0-3])H|(?:[1-9]|[1-5][0-9])M|(?:[1-9]|[1-5][0-9])S)))"
+    r"|(?:\d+[LW]?|[A-Z]{3}|LW|L|W|\?|\*)(?:[,/#-](?:\d+[LW]?|[A-Z]{3}|LW|L|W|\?|\*))*"
+    r"(?:\s+(?:\d+[LW]?|[A-Z]{3}|LW|L|W|\?|\*)"
+    r"(?:[,/#-](?:\d+[LW]?|[A-Z]{3}|LW|L|W|\?|\*))*){5,6})$"
 )
 
 
@@ -110,34 +120,20 @@ def _check_schedule_config(inputs: dict) -> None:
             '"timeCycle".'
         )
 
-    timer_preset = inputs.get("timerPreset")
-    if not isinstance(timer_preset, str) or not timer_preset.strip():
-        _fail("inputs.timerPreset missing or empty — required for a scheduled trigger.")
-
-    if timer_preset == "custom":
-        cycle = inputs.get("timerValue")
-        if not isinstance(cycle, str) or not cycle.strip():
-            _fail(
-                "inputs.timerPreset is 'custom' but inputs.timerValue is missing or "
-                "empty — add an ISO 8601 repeating interval (e.g. R/PT45M)."
-            )
-        label = "inputs.timerValue"
-    else:
-        cycle = timer_preset
-        label = "inputs.timerPreset"
+    cycle = inputs.get("timerValue")
+    if not isinstance(cycle, str) or not cycle.strip():
+        _fail(
+            "inputs.timerValue missing or empty — it carries the cycle expression "
+            "and is the node's only required input. `core.trigger.scheduled` has no "
+            "`timerPreset`; a cycle expression written there fails validate with "
+            'REQUIRED_FIELD "timerValue".'
+        )
 
     if not CYCLE_RE.match(cycle):
         _fail(
-            f"{label}={cycle!r} is not a valid ISO 8601 repeating interval "
-            "(e.g. R/PT1H, R/P1D, R/PT45M)."
-        )
-    # A grammatically-valid but all-zero duration (e.g. R/PT0H) is a
-    # never-firing schedule. Every real recurring interval has a non-zero
-    # component, so require at least one.
-    if not re.search(r"[1-9]", cycle):
-        _fail(
-            f"{label}={cycle!r} is an all-zero, never-firing schedule — "
-            "use a non-zero recurring interval such as R/PT1H."
+            f"inputs.timerValue={cycle!r} is neither an ISO 8601 repeating interval "
+            "with a single non-zero duration unit (e.g. R/PT1H, R/P1D) nor a Quartz "
+            "cron expression (e.g. 0 0 9 ? * MON-FRI)."
         )
 
 
@@ -190,7 +186,7 @@ def main():
 
     print(
         f"OK: start node is {SCHEDULED} (manual trigger replaced); "
-        f"timerType={inputs.get('timerType')!r}, timerPreset={inputs.get('timerPreset')!r}; "
+        f"timerType={inputs.get('timerType')!r}, timerValue={inputs.get('timerValue')!r}; "
         f"typeVersion set; definition carries bpmn:StartEvent + bpmn:TimerEventDefinition"
     )
 

--- a/tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py
@@ -18,7 +18,11 @@ trigger and carries a valid recurring schedule:
        - `timerType == "timeCycle"`;
        - `timerValue` present, non-empty, and matching the registry's own
          `timerValue` pattern — an ISO 8601 repeating interval (`R/PT1H`) or a
-         Quartz cron expression (`0 0 9 ? * MON-FRI`).
+         Quartz cron expression (`0 0 9 ? * MON-FRI`);
+       - `timerValue == REQUESTED_CYCLE`. The grammar check alone would award
+         full credit to a daily flow when the task asked for an hourly one, so
+         the cadence the prompt names is graded too. CYCLE_RE still runs first
+         so a malformed value reports as bad syntax rather than wrong cadence.
      `core.trigger.scheduled` has no `timerPreset` input; a cycle expression
      written there fails `validate` with `REQUIRED_FIELD timerValue`.
   5. `typeVersion` present and non-empty (the agent-under-test copies the
@@ -46,6 +50,11 @@ from _shared.flow_check import find_flow_file  # noqa: E402
 SCHEDULED = "core.trigger.scheduled"
 MANUAL = "core.trigger.manual"
 TRIGGER_PREFIX = "core.trigger."
+
+# The cadence scheduled_trigger.yaml asks for ("every hour, expressed as
+# R/PT1H"). Grammar validity is necessary but not sufficient: R/P1D is a
+# well-formed cycle expression and the wrong answer to this task.
+REQUESTED_CYCLE = "R/PT1H"
 
 # `timerValue` pattern, copied verbatim from the `core.trigger.scheduled`
 # registry definition (inputDefinition.properties.timerValue.pattern) so this
@@ -133,6 +142,12 @@ def _check_schedule_config(inputs: dict) -> None:
             f"inputs.timerValue={cycle!r} is neither an ISO 8601 repeating interval "
             "with a single non-zero duration unit (e.g. R/PT1H, R/P1D) nor a Quartz "
             "cron expression (e.g. 0 0 9 ? * MON-FRI)."
+        )
+
+    if cycle != REQUESTED_CYCLE:
+        _fail(
+            f"inputs.timerValue={cycle!r} is a valid cycle expression but not the "
+            f"one the task asked for ({REQUESTED_CYCLE!r}, every hour)."
         )
 
 

--- a/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
@@ -7,7 +7,7 @@ description: >
   (`core.trigger.scheduled`) that REPLACES the default manual trigger and
   carries a valid recurring schedule. Exercises the previously-untested
   scheduled-trigger plugin: the manual->scheduled replacement procedure, the
-  `timeCycle`/`timerPreset` input shape, and the `bpmn:TimerEventDefinition`
+  cycle-expression input shape, and the `bpmn:TimerEventDefinition`
   that the node definition must carry. Validate-only and pure-OOTB — no tenant,
   no `flow debug` (a scheduled BPMN timer fires only inside a live engine the
   test sandbox cannot provision).
@@ -26,8 +26,8 @@ initial_prompt: |
     - The start node `type` must be `core.trigger.scheduled`.
     - Keep the existing `entryPointId` from the manual trigger's `inputs`.
     - `inputs.timerType` must be `"timeCycle"`.
-    - `inputs.timerPreset` must be `"R/PT1H"` (every hour — an ISO 8601
-      repeating interval). Do NOT use `"custom"` for this smoke test.
+    - The schedule is every hour, expressed as `R/PT1H`. Take the input field
+      that carries it from the node's own definition — do not guess.
     - Set the node `typeVersion` from its authoritative node definition.
     - Remove the `core.trigger.manual` node AND its `definitions[]` entry, and
     include the authoritative `core.trigger.scheduled` definition

--- a/tests/tasks/uipath-maestro-flow/smoke/test_check_scheduled_trigger_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/test_check_scheduled_trigger_flow.py
@@ -32,7 +32,7 @@ def _out(r: subprocess.CompletedProcess[str]) -> str:
 
 
 def _scheduled_node(**inputs: Any) -> dict[str, Any]:
-    base = {"entryPointId": "ep-1", "timerType": "timeCycle", "timerPreset": "R/PT1H"}
+    base = {"entryPointId": "ep-1", "timerType": "timeCycle", "timerValue": "R/PT1H"}
     base.update(inputs)
     return {
         "id": "start",
@@ -57,18 +57,52 @@ def _well_formed() -> dict[str, Any]:
     }
 
 
-def test_preset_passes(tmp_path: Path) -> None:
+def test_interval_passes(tmp_path: Path) -> None:
     _write_flow(tmp_path, _well_formed())
     r = _run(tmp_path)
     assert r.returncode == 0, r.stdout + r.stderr
 
 
-def test_custom_with_timer_value_passes(tmp_path: Path) -> None:
+def test_anchored_interval_passes(tmp_path: Path) -> None:
     p = _well_formed()
-    p["nodes"][0] = _scheduled_node(timerPreset="custom", timerValue="R/PT45M")
+    p["nodes"][0] = _scheduled_node(timerValue="R/2026-05-14T09:00:00Z/P1W")
     _write_flow(tmp_path, p)
     r = _run(tmp_path)
     assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_cron_passes(tmp_path: Path) -> None:
+    """A cron expression is the documented escape hatch for a schedule the
+    single-unit interval form cannot express (09:00 every weekday)."""
+    p = _well_formed()
+    p["nodes"][0] = _scheduled_node(timerValue="0 0 9 ? * MON-FRI")
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_stray_timer_preset_is_ignored(tmp_path: Path) -> None:
+    """`timerPreset` is not in the node's schema; validate tolerates it as an
+    extra key, so an agent that writes both must not be docked here."""
+    p = _well_formed()
+    p["nodes"][0] = _scheduled_node(timerPreset="R/PT1H")
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_cycle_in_timer_preset_only_fails(tmp_path: Path) -> None:
+    """The exact regression this checker missed: the cycle expression written to
+    `timerPreset` with no `timerValue` passed the old checker but failed
+    `uip maestro flow validate` with REQUIRED_FIELD timerValue."""
+    p = _well_formed()
+    node = _scheduled_node(timerPreset="R/PT1H")
+    node["inputs"].pop("timerValue")
+    p["nodes"][0] = node
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "timervalue" in _out(r)
 
 
 def test_manual_node_present_fails(tmp_path: Path) -> None:
@@ -100,27 +134,51 @@ def test_wrong_timer_type_fails(tmp_path: Path) -> None:
     assert "timecycle" in _out(r)
 
 
-def test_bad_preset_fails(tmp_path: Path) -> None:
+def test_bad_cycle_fails(tmp_path: Path) -> None:
     p = _well_formed()
-    p["nodes"][0] = _scheduled_node(timerPreset="hourly")
+    p["nodes"][0] = _scheduled_node(timerValue="hourly")
     _write_flow(tmp_path, p)
     r = _run(tmp_path)
     assert r.returncode != 0
     assert "iso 8601" in _out(r)
 
 
-def test_zero_duration_preset_fails(tmp_path: Path) -> None:
+def test_zero_duration_fails(tmp_path: Path) -> None:
+    """R/PT0H is a never-firing schedule; the registry pattern rejects a zero
+    duration outright, so no separate all-zero guard is needed."""
     p = _well_formed()
-    p["nodes"][0] = _scheduled_node(timerPreset="R/PT0H")
+    p["nodes"][0] = _scheduled_node(timerValue="R/PT0H")
     _write_flow(tmp_path, p)
     r = _run(tmp_path)
     assert r.returncode != 0
-    assert "all-zero" in _out(r)
+    assert "iso 8601" in _out(r)
 
 
-def test_custom_missing_timer_value_fails(tmp_path: Path) -> None:
+def test_multi_unit_duration_fails(tmp_path: Path) -> None:
+    """The registry pattern allows exactly one duration unit — R/PT2H30M is
+    rejected by `validate`, so the checker must reject it too."""
     p = _well_formed()
-    p["nodes"][0] = _scheduled_node(timerPreset="custom")
+    p["nodes"][0] = _scheduled_node(timerValue="R/PT2H30M")
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "iso 8601" in _out(r)
+
+
+def test_out_of_range_duration_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["nodes"][0] = _scheduled_node(timerValue="R/PT24H")
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "iso 8601" in _out(r)
+
+
+def test_missing_timer_value_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    node = _scheduled_node()
+    node["inputs"].pop("timerValue")
+    p["nodes"][0] = node
     _write_flow(tmp_path, p)
     r = _run(tmp_path)
     assert r.returncode != 0

--- a/tests/tasks/uipath-maestro-flow/smoke/test_check_scheduled_trigger_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/test_check_scheduled_trigger_flow.py
@@ -134,6 +134,20 @@ def test_wrong_timer_type_fails(tmp_path: Path) -> None:
     assert "timecycle" in _out(r)
 
 
+def test_missing_timer_type_fails(tmp_path: Path) -> None:
+    """`validate` tolerates a missing `timerType` (the definition's `required`
+    array names only `timerValue`), but `model.values` consumes it, so the task
+    and this checker both demand it."""
+    p = _well_formed()
+    node = _scheduled_node()
+    node["inputs"].pop("timerType")
+    p["nodes"][0] = node
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "timecycle" in _out(r)
+
+
 def test_bad_cycle_fails(tmp_path: Path) -> None:
     p = _well_formed()
     p["nodes"][0] = _scheduled_node(timerValue="hourly")

--- a/tests/tasks/uipath-maestro-flow/smoke/test_check_scheduled_trigger_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/test_check_scheduled_trigger_flow.py
@@ -5,6 +5,7 @@ Run with ``pytest tests/tasks/uipath-maestro-flow/smoke/test_check_scheduled_tri
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
@@ -12,6 +13,12 @@ from pathlib import Path
 from typing import Any
 
 CHECKER = Path(__file__).resolve().parent / "check_scheduled_trigger_flow.py"
+
+_spec = importlib.util.spec_from_file_location("_check_scheduled_trigger", CHECKER)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+CYCLE_RE = _mod.CYCLE_RE
+REQUESTED_CYCLE = _mod.REQUESTED_CYCLE
 
 
 def _write_flow(tmp_path: Path, payload: dict[str, Any]) -> None:
@@ -63,22 +70,21 @@ def test_interval_passes(tmp_path: Path) -> None:
     assert r.returncode == 0, r.stdout + r.stderr
 
 
-def test_anchored_interval_passes(tmp_path: Path) -> None:
+def test_valid_but_wrong_cadence_fails(tmp_path: Path) -> None:
+    """Grammar validity is not the bar. The task asks for hourly; a daily flow
+    is well-formed and the wrong answer, and must not score full credit."""
     p = _well_formed()
-    p["nodes"][0] = _scheduled_node(timerValue="R/2026-05-14T09:00:00Z/P1W")
+    p["nodes"][0] = _scheduled_node(timerValue="R/P1D")
     _write_flow(tmp_path, p)
     r = _run(tmp_path)
-    assert r.returncode == 0, r.stdout + r.stderr
+    assert r.returncode != 0
+    assert "not the one the task asked for" in _out(r)
 
 
-def test_cron_passes(tmp_path: Path) -> None:
-    """A cron expression is the documented escape hatch for a schedule the
-    single-unit interval form cannot express (09:00 every weekday)."""
-    p = _well_formed()
-    p["nodes"][0] = _scheduled_node(timerValue="0 0 9 ? * MON-FRI")
-    _write_flow(tmp_path, p)
-    r = _run(tmp_path)
-    assert r.returncode == 0, r.stdout + r.stderr
+def test_requested_cycle_matches_the_task_yaml() -> None:
+    """The pinned cadence must stay in step with the prompt that asks for it."""
+    yaml = (Path(__file__).resolve().parent / "scheduled_trigger.yaml").read_text()
+    assert f"`{REQUESTED_CYCLE}`" in yaml
 
 
 def test_stray_timer_preset_is_ignored(tmp_path: Path) -> None:
@@ -246,3 +252,34 @@ def test_missing_scheduled_definition_fails(tmp_path: Path) -> None:
     r = _run(tmp_path)
     assert r.returncode != 0
     assert "definitions" in _out(r)
+
+
+# ── Cycle-expression grammar (registry pattern, independent of cadence) ──────
+
+
+def test_grammar_accepts_midnight_cron_with_no_digit_one_to_nine() -> None:
+    """Regression for the deleted all-zero guard. The old checker rejected any
+    cycle expression containing no digit 1-9 as "never-firing"; that reasoning
+    holds for an interval but not for cron, where `0 0 0 * * ? *` is daily at
+    midnight. Every other cron fixture here contains a 9 or a 2, so only this
+    case would catch the guard being reintroduced."""
+    assert CYCLE_RE.match("0 0 0 * * ? *")
+
+
+def test_grammar_accepts_cron_and_anchored_intervals() -> None:
+    for value in (
+        "0 0 */1 * * ? *",              # hourly on the hour
+        "0 0 9 ? * MON-FRI",            # weekdays at 09:00
+        "0 0 2 1 * ? *",                # 02:00 on the 1st
+        "R/2026-05-14T09:00:00Z/P1W",   # weekly, anchored to a start instant
+        "R/PT5M",
+        "R/P1W",
+    ):
+        assert CYCLE_RE.match(value), value
+
+
+def test_grammar_rejects_multi_unit_out_of_range_and_zero_durations() -> None:
+    """The interval form takes exactly ONE non-zero, in-range unit — so no
+    arbitrary period (every 2.5 hours, every 90 minutes) is expressible."""
+    for value in ("R/PT2H30M", "R/PT150M", "R/PT90M", "R/PT24H", "R/PT60M", "R/PT0H", "custom", "hourly"):
+        assert not CYCLE_RE.match(value), value

--- a/tests/tasks/uipath-maestro-flow/smoke/test_check_scheduled_trigger_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/test_check_scheduled_trigger_flow.py
@@ -263,7 +263,7 @@ def test_grammar_accepts_midnight_cron_with_no_digit_one_to_nine() -> None:
     holds for an interval but not for cron, where `0 0 0 * * ? *` is daily at
     midnight. Every other cron fixture here contains a 9 or a 2, so only this
     case would catch the guard being reintroduced."""
-    assert CYCLE_RE.match("0 0 0 * * ? *")
+    assert CYCLE_RE.fullmatch("0 0 0 * * ? *")
 
 
 def test_grammar_accepts_cron_and_anchored_intervals() -> None:
@@ -275,11 +275,18 @@ def test_grammar_accepts_cron_and_anchored_intervals() -> None:
         "R/PT5M",
         "R/P1W",
     ):
-        assert CYCLE_RE.match(value), value
+        assert CYCLE_RE.fullmatch(value), value
+
+
+def test_grammar_rejects_a_trailing_newline() -> None:
+    """`fullmatch`, not `match`: Python's `$` also matches before a trailing
+    newline, the JavaScript `$` the platform runs the same pattern under does
+    not."""
+    assert not CYCLE_RE.fullmatch(f"{REQUESTED_CYCLE}\n")
 
 
 def test_grammar_rejects_multi_unit_out_of_range_and_zero_durations() -> None:
     """The interval form takes exactly ONE non-zero, in-range unit — so no
     arbitrary period (every 2.5 hours, every 90 minutes) is expressible."""
     for value in ("R/PT2H30M", "R/PT150M", "R/PT90M", "R/PT24H", "R/PT60M", "R/PT0H", "custom", "hourly"):
-        assert not CYCLE_RE.match(value), value
+        assert not CYCLE_RE.fullmatch(value), value


### PR DESCRIPTION
`skill-flow-scheduled-trigger` failed in [run 34267720883](https://github.com/UiPath/skills/actions/runs/34267720883/job/102201348674):

```
[nodes[start].inputs.timerValue] [REQUIRED_FIELD] "timerValue" is required on "Scheduled trigger"
```

The agent was compliant. The rule was wrong. `core.trigger.scheduled` v1.2 has `props: ['timerType', 'timerValue']` and `required: ['timerValue']`. No `timerPreset`.

## Why it passed for five runs

Three things were wrong together, so they agreed:

| Where | What it said |
|---|---|
| `impl.md` / `planning.md` | `timerPreset` for common frequencies, `timerValue` only when `timerPreset: "custom"` |
| `check_scheduled_trigger_flow.py` | **required** `timerPreset`, read the cycle expression out of it |
| `scheduled_trigger.yaml` | prompt named `inputs.timerPreset` outright |

Any agent that obeyed the skill passed the checker and failed `validate`. The two prior passes came from an agent that noticed the discrepancy and wrote **both** fields. Reads as flaky; deterministic on whether the agent second-guesses the skill.

## Verified against `uip maestro flow validate`

| `inputs` | Result |
|---|---|
| `timerType` + `timerPreset: "R/PT1H"` (what the skill taught) | **Failure** `REQUIRED_FIELD timerValue` |
| `timerValue: "R/PT1H"` / `"0 0 9 ? * MON-FRI"` / `"R/2026-05-14T09:00:00Z/P1W"` | Success |
| `timerValue: "R/PT2H30M"` / `"R/PT24H"` / `"R/PT0H"` | **Failure** |
| no `timerType` | Success |
| stray `timerPreset` alongside `timerValue` | Success, extra key |

## Skill

- Cycle expression moves to `timerValue` in every example, table, and debug row.
- **Interval grammar.** One non-zero, in-range unit only, so the documented `R/PT2H30M` was never valid. Each rejected value carries its own fix: `R/PT24H` wants `R/P1D`, not cron.
- **Cron** was undocumented and now is, scoped to clock alignment. It buys no extra *periods*: every 2.5 hours is expressible in neither form, and the doc says so instead of letting an agent approximate silently.
- **Two cron constraints `validate` cannot enforce** are stated, because it accepts `0 0 12 * * *` (no `?`, which Quartz rejects) and `ABC ABC ABC ABC ABC ABC`. Its cron branch counts fields and character classes, nothing more.
- **`timerType` documented as required** despite the definition's `required` array omitting it: `model.values` maps it into the BPMN timer event, and the checker and prompt both demand it.
- The no-`timerPreset` claim is scoped to definition 1.2. `validate` resolves inputs against the definition in `definitions[]`, not the registry, so it does not hold for a brownfield flow carrying an older one.

## Checker

- `CYCLE_RE` claimed to be copied verbatim from the registry and was not. It accepted `R/PT2H30M` and rejected every cron. Now the registry pattern byte-for-byte, asserted identical, matched with `fullmatch` (Python's `$` also matches before a trailing newline; JavaScript's does not).
- **`REQUESTED_CYCLE` pins the cadence.** `R/P1D` is well formed and the wrong answer to an hourly task. `CYCLE_RE` runs first, so a malformed value still reports as bad syntax. A test holds the constant to the YAML.
- The all-zero guard is gone: the pattern already rejects a zero duration, and the guard misread `0 0 0 * * ? *` (daily at midnight, no digit 1-9) as never-firing. Added as a named regression.
- `timerPreset` is ignored, not banned, so an agent that writes both is not docked.

## Task prompt

`inputs.timerPreset` must be `"R/PT1H"` … Do NOT use `"custom"` becomes:

```
- The schedule is every hour, expressed as `R/PT1H`. Take the input field
  that carries it from the node's own definition — do not guess.
```

Value pinned for determinism, field from the skill. Had it read this way, the stale rule would have failed on run one rather than run five.

## Verification

| Check | Result |
|---|---|
| `skill-flow-scheduled-trigger`, [run 34291009893](https://github.com/UiPath/skills/actions/runs/34291009893/job/102277407059) | SUCCESS, 2/2, `score=1.000` |
| Checker unit tests / full `tests/tasks/uipath-maestro-flow/` | 23 passed / 1169 passed |
| Every cycle expression the docs name, against the live pattern | 19 values, no mismatches |
| `check-skill-links.mjs` / `skills:validate` | 6712 links resolve / OK, default + studioweb |

Cron examples checked by hand against the Quartz field order and the `?` rule.

## Scoped out

- `core.logic.delay` genuinely still requires `timerPreset` (v1.0). Verified, untouched.
- `editing-operations-json.md` never says to update `typeVersion` when replacing the trigger in place (manual 1.0, scheduled 1.2, result fails `validate`). Pre-existing procedure.
- `preview/.../api.md` still describes `SCHEDULE_PRESETS` round-tripping as a named preset. Snapshot of `UiPath/flow-builder-sdk`; fix belongs upstream.

## The rest of that CI run

`Run skill smoke tests` is required and red for reasons outside this diff. Three tasks fail, none of them this one:

| Task | Failure |
|---|---|
| `datafabric-smoke-query` | own checker: `missing filter coverage: boolean, decimal, …` |
| `datafabric-smoke-update` | own checkers: `no update-entity-record node found`, 0/3 |
| `datafabric-smoke-update-existing-flow` | pre-run `scaffold_movie_report_flow.py` exit 1 |

Only the third looks environmental. The first two are content failures and need their own PR.
