### PR TITLE
fix(hitl-skill): restore asking for facts the agent cannot infer

### DIFF
--- a/skills/uipath-human-in-the-loop/SKILL.md
+++ b/skills/uipath-human-in-the-loop/SKILL.md
@@ -211,10 +211,10 @@ Infer the right option from the description below — do not pull the registry f
 
 ## Step 4 — Common configuration
 
-Never block on these — use the stated default when no answer is available, write it into the node, and note the default in the final report so the user can change it.
+These are facts you cannot infer with confidence — ask, don't guess, when a reply is possible. Ask both in one message. If the environment is non-interactive (no reply will come, or the request says not to ask for approval/confirmation), use the stated default instead of waiting. Either way, write the resulting value into the node's field — asking or defaulting is not enough on its own; the value must land in the node.
 
-| Timeout | Default: 24 hours. If the description states or implies a different duration, use that instead. |
-| Priority | Default: Low. If the description states or implies urgency (e.g. "high priority", "urgent", "time-sensitive"), use High or Medium accordingly. Write the chosen value into the node's `priority` field — asking the question is not enough; the value must land in the node. |
+| Timeout | "How long before the task times out if nobody acts?" Default if not asked or not answered: 24 hours. |
+| Priority | "What priority should this task have — Low, Medium, or High?" Default if not asked or not answered: Low. Also use the description's own urgency language ("high priority", "urgent", "time-sensitive") when present, whether or not you ask. |
 
 ---
 

--- a/skills/uipath-human-in-the-loop/references/hitl-casetask-action.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-casetask-action.md
@@ -23,14 +23,14 @@ Two paths exist. **Never block on choosing — infer the path from the business 
 
 ## Step 1 — Extract the Task Configuration Through Conversation
 
-**Never block on this.** Infer each answer below from the business description; only ask if the user is actually present and it would help. Defaults when nothing in the description settles it: recipient → a group named after the relevant team (e.g. "finance-team", "data-enrichment-team" — infer the team name from context); priority → Low, per Step 4.
+These are facts you cannot infer with confidence. If the business description doesn't already answer them, ask — in a single message, all at once — and use the reply. Only skip asking when the environment is non-interactive (no reply will come, or the request says not to ask for approval/confirmation): in that case, infer from the description using the fallbacks below and proceed without waiting.
 
-| What you need to know | Where to infer it from |
-|---|---|
-| What the reviewer sees | Data the automation already extracted or produced upstream |
-| What they decide or fill in | Whether the description says "approve/reject" (decision only) or "fill in", "correct", "enrich" (data entry) |
-| Who receives the task | A named person/email or team/group mentioned in the description; otherwise infer a sensible team name from the business context |
-| Priority | Any urgency language in the description ("urgent", "high priority") → High/Medium; otherwise Low |
+| What you need to know | Question to ask | Fallback if you can't ask |
+|---|---|---|
+| What the reviewer sees | "What information does the reviewer need to make their decision?" | Data the automation already extracted or produced upstream |
+| What they decide or fill in | "Does the reviewer just approve/reject, or do they need to enter data?" | "approve/reject" language → decision only; "fill in"/"correct"/"enrich" → data entry |
+| Who receives the task | "Who should receive this task — a specific user (email) or a group?" | A named person/email or team/group mentioned in the description; otherwise a sensible team name inferred from the business context |
+| Priority | "What priority should this task have — Low, Medium, or High?" | Any urgency language in the description ("urgent", "high priority") → High/Medium; otherwise Low, per Step 4 |
 
 **Common business descriptions → path selection:**
 

--- a/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
@@ -6,7 +6,7 @@ The agent writes the `uipath.human-in-the-loop.quick-form` node directly into th
 
 ## Step 1 — Extract the Schema Through Conversation
 
-**Never block on this.** Infer the answers to the questions below from the prompt and any upstream `.flow` data, and proceed straight to schema design — do not wait for a reply. If the user is present and volunteers this information unprompted, use it. Only stop and report the open decision if the request is genuinely too ambiguous to pick a sensible default.
+These are facts you cannot infer with confidence. If the prompt or upstream `.flow` data doesn't already answer them, ask — in a single message, all at once — and use the reply. Only skip asking when the environment is non-interactive (no reply will come, or the request says not to ask for approval/confirmation): in that case, infer from the prompt and any upstream data and proceed to schema design without waiting. Only stop and report the open decision if the request is genuinely too ambiguous to pick a sensible default even after inferring.
 
 | What you need to know | Question to ask |
 |---|---|


### PR DESCRIPTION
## Summary

Follow-up to #3107, which turned every ask-and-wait point in this skill into infer-and-proceed. That fixed four tests whose prompts explicitly forbade asking for approval or confirmation, but it went too far in three spots that ask for facts the agent has no way to know on its own: Step 4 (timeout/priority) in SKILL.md, and the two "Step 1 - Extract ... Through Conversation" sections in hitl-node-quickform.md and hitl-casetask-action.md.

Confirmed regression: skill-flow-hitl-schema-design-simulated (run 2026-09-08_04-17-10) still fails on priority, unchanged from before #3107. Its prompt has no "don't ask" instruction at all and is built around a simulated persona who only reveals the real priority (High) when asked. With #3107's blanket "infer from the description, never ask" wording, the agent stopped asking entirely, so it never learns the real value and writes the wrong default cleanly, passing the earlier "the value must land in the node" fix while still failing on content.

The distinction that got collapsed: not asking for approval or confirmation of a decision the agent already has enough information to make (the actual problem #3107 fixed) is different from not asking a clarifying question when a fact is genuinely missing and someone is available to answer it.

Fixed by restoring the question in those three spots: ask in a single message when a reply is possible, same as before #3107. Only skip asking when the environment is genuinely non-interactive or the prompt says not to ask for approval/confirmation; fall back to the stated default without waiting in that case. #3107's actual fix (write the resulting value into the node) is unchanged.

Left Critical Rule 1 (schema confirmation), Step 2b (proactive recommendation), and Step 3 (path selection) alone. Those are decisions the agent can make from context, not facts it has to be told, so their non-blocking treatment from #3107 stays correct.

## Test plan

- [x] Diff scoped to exactly the three information-gathering spots; the decision-style spots from #3107 are untouched
- [ ] Re-run skill-flow-hitl-schema-design-simulated to confirm priority now resolves correctly (pending, needs this merged and picked up by the next eval run)
- [ ] Confirm the three tests #3107 fixed (which explicitly forbid asking for approval/confirmation) still pass, since none of them ask for the specific facts touched here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
