### PR TITLE
fix(uipath-maestro-bpmn): scope metadata regeneration away from IS draft handoffs

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -205,6 +205,10 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    by the HITL template's `<uipath:output ... var="...">` (for example
    `=vars.Var_HitlResult == "approve"`), not only a copied or derived script
    variable.
+   For an Integration Service draft or boundary handoff (author locally, hand
+   enrichment to the CLI, no pack/upload/operate asked for), emit **only** the
+   `.bpmn` plus the notes file — do NOT create the four generated package files
+   (Rule 16); authoring them fails the boundary the task tests.
    For Integration Service draft notes, name every CLI-owned blocker literally,
    including the exact phrase `connection binding`, plus dynamic schemas,
    generated outputs, `bindings_v2.json`, and package metadata. Avoid softer

--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -205,6 +205,15 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    by the HITL template's `<uipath:output ... var="...">` (for example
    `=vars.Var_HitlResult == "approve"`), not only a copied or derived script
    variable.
+   When the task is an Integration Service **draft or boundary handoff** —
+   author the process locally and hand connector enrichment to the CLI, with no
+   pack/upload/operate step asked for — do NOT create `bindings_v2.json`,
+   `entry-points.json`, `operate.json`, or `package-descriptor.json`. Those four
+   are CLI-owned generated package files; authoring them yourself crosses the
+   boundary the task is testing. Produce only the `.bpmn` source shape plus a
+   notes/README file listing the CLI-owned blockers. (This overrides the general
+   "create the package metadata files" instruction below, which applies only
+   once you are actually packaging.)
    For Integration Service draft notes, name every CLI-owned blocker literally,
    including the exact phrase `connection binding`, plus dynamic schemas,
    generated outputs, `bindings_v2.json`, and package metadata. Avoid softer

--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -205,15 +205,6 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    by the HITL template's `<uipath:output ... var="...">` (for example
    `=vars.Var_HitlResult == "approve"`), not only a copied or derived script
    variable.
-   When the task is an Integration Service **draft or boundary handoff** —
-   author the process locally and hand connector enrichment to the CLI, with no
-   pack/upload/operate step asked for — do NOT create `bindings_v2.json`,
-   `entry-points.json`, `operate.json`, or `package-descriptor.json`. Those four
-   are CLI-owned generated package files; authoring them yourself crosses the
-   boundary the task is testing. Produce only the `.bpmn` source shape plus a
-   notes/README file listing the CLI-owned blockers. (This overrides the general
-   "create the package metadata files" instruction below, which applies only
-   once you are actually packaging.)
    For Integration Service draft notes, name every CLI-owned blocker literally,
    including the exact phrase `connection binding`, plus dynamic schemas,
    generated outputs, `bindings_v2.json`, and package metadata. Avoid softer
@@ -342,6 +333,12 @@ and honestly surfaced to the user as gaps when asked.
    business rule task. Never do that work at authoring time or hardcode its
    result. Bare "agent" in any process description means a UiPath agent, never
    you.
+16. **Generated package files are CLI-owned.** Never hand-author
+   `bindings_v2.json`, `entry-points.json`, `operate.json`, or
+   `package-descriptor.json`. Run `uip maestro bpmn update-metadata` to
+   generate them, and only once the user asked to package or operate. An
+   Integration Service draft or boundary handoff asks for none of those — emit
+   only the `.bpmn` plus a `.md` notes file naming the CLI-owned blockers.
 
 ## References
 

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -2,6 +2,8 @@
 
 Use this guide when BPMN source changed and local package metadata must be refreshed or verified before packaging, upload, debug, publish, or deploy.
 
+**Do NOT apply it to an Integration Service draft or boundary handoff.** When the task is to author a local BPMN draft and hand connector enrichment to the CLI (no upload/pack yet), `entry-points.json`, `bindings_v2.json`, `operate.json`, and `package-descriptor.json` stay CLI-owned — do not hand-author or pre-generate them. Author only the `.bpmn` source shape plus notes naming the CLI-owned blockers; regeneration below applies only once you are actually packaging an enriched project.
+
 ## Ownership
 
 - `.bpmn` is the source of record for process structure, root variables, root bindings, entry point IDs, mappings, diagrams, and documented non-Integration-Service UiPath XML.

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -2,7 +2,7 @@
 
 Use this guide when BPMN source changed and local package metadata must be refreshed or verified before packaging, upload, debug, publish, or deploy.
 
-**Do NOT apply it to an Integration Service draft or boundary handoff.** When the task is to author a local BPMN draft and hand connector enrichment to the CLI (no upload/pack yet), `entry-points.json`, `bindings_v2.json`, `operate.json`, and `package-descriptor.json` stay CLI-owned — do not hand-author or pre-generate them. Author only the `.bpmn` source shape plus notes naming the CLI-owned blockers; regeneration below applies only once you are actually packaging an enriched project.
+**Do NOT apply it to an Integration Service draft or boundary handoff.** When the task is to author a local BPMN draft and hand connector enrichment to the CLI (no upload/pack yet), `entry-points.json`, `bindings_v2.json`, `operate.json`, and `package-descriptor.json` stay CLI-owned — do not hand-author or pre-generate them. Author only the `.bpmn` source shape plus a `.md` notes file **inside the project directory** naming the CLI-owned blockers; regeneration below applies only once you are actually packaging an enriched project.
 
 ## Ownership
 


### PR DESCRIPTION
## Summary
Fixes the `integration-service-boundary` failure from the claude-code nightly `2026-09-08_04-17-10`, where the agent hand-authored the CLI-owned generated files (`bindings_v2.json`, `entry-points.json`, `operate.json`, `package-descriptor.json`) in a draft/boundary task that forbids it.

## Fix (two parts, both in `skills/uipath-maestro-bpmn/`)
1. **`SKILL.md`** — `Rule 16` in `## Rules` (generated package files are CLI-owned) as the canonical statement, plus a **2-line directive at the IS-draft point in workflow step 3** that points to Rule 16. The point-of-use directive is what changes behavior (see below).
2. **`references/shared/local-metadata-regeneration-guide.md`** — a scoping caveat (defense-in-depth): the guide does not apply to an IS draft/boundary handoff; emit only the `.bpmn` plus a `.md` notes file inside the project directory.

## What's load-bearing (A/B evidence on this branch)
| Version | `integration_service_boundary` |
|---|---|
| Reference-guide caveat only | **FAIL 0.167** (run 34374080786) |
| + 9-line SKILL.md block at point of use | PASS 1/1 (run 34376331497) |
| Block replaced by Rules-list `Rule 16` only | **FAIL 0.167** (run 34387920591) |
| `Rule 16` + 2-line point-of-use directive | **PASS 2/2, 1.000** (run 34391861917) |

The agent reads `SKILL.md` linearly during authoring; a rule only in the trailing `## Rules` list, or buried in a gated reference guide, does not change behavior. The guidance has to sit in the authoring workflow at the point of use.

## Merge order
The PR's smoke gate is red **solely** on `minimal_fault_triage`, the false negative #3151 fixes. **Merge #3151 first**, then re-run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
