### PR TITLE
chore: verify every required context reports on a post-merge PR

### DIFF
--- a/docs/REQUIRED-CHECKS.md
+++ b/docs/REQUIRED-CHECKS.md
@@ -189,6 +189,8 @@ Adding a context before the job has reported once blocks every open PR. Sequence
 
    The script builds the PUT body from the **live** ruleset and replaces only the required-status-check list. `name`, `enforcement`, `bypass_actors` and the `pull_request` parameters are carried through: GitHub's behaviour for fields omitted from `PUT /repos/{owner}/{repo}/rulesets/{id}` is undocumented, so sending a literal body risks clearing admin bypass on `main`, and hardcoding the review count silently reverts a change someone made in the Rules UI.
 
+<!-- Throwaway edit to verify all 24 contexts report on a post-merge PR. Revert. -->
+
 ## Checking for drift
 
 Every test in `tests/scripts/test_required_checks_contract.py` reads this doc and validates it against the workflows. **Nothing in CI compares it to the live ruleset**, and that direction fails in two ways no test can see:


### PR DESCRIPTION
**Throwaway — do not review, do not merge. Closing as soon as the checks land.**

#3100 removed the `paths:` filters that stopped 13 checks from reporting on every PR, but the evidence it collected predates its own merge commit (`c7837b296`). A `pull_request` workflow runs from the base+head merge, so a PR only picks up the new workflow definitions on an event fired *after* that merge. #3150 was pushed 34s before it and is still missing 17 of the 24 target contexts.

This PR is the post-merge evidence that `docs/REQUIRED-CHECKS.md` § Applying a change step 2 requires. The ruleset is not applied until all 24 contexts are seen reporting here — requiring a context that never reports blocks every open PR.

Doc-only edit on purpose: that is exactly the PR shape the old filters excluded.