### PR TITLE
fix(release): sync the Codex marketplace version with package.json

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,7 +15,7 @@
         "path": "./"
       },
       "description": "UiPath plugin for Codex - custom skills for UiPath workflows, UI automation, UI testing, and UiPath troubleshooting.",
-      "version": "0.0.36",
+      "version": "1.203.0",
       "author": {
         "name": "UiPath"
       },

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -12,6 +12,7 @@ The complete default tree is published as **`@uipath/skills`**, versioned in loc
 | `.claude-plugin/plugin.json` | `version` | Claude Code plugin version — always equals `package.json`'s base `M.N.P` (pre-release suffix stripped) — the canonical plugin version |
 | `.claude-plugin/marketplace.json` | `plugins[0].version` | Always equals `plugin.json` `version` |
 | `.codex-plugin/plugin.json` | `version` | Codex plugin version — always equals `plugin.json` `version` |
+| `.agents/plugins/marketplace.json` | `plugins[0].version` | Codex marketplace index — always equals `plugin.json` `version` |
 | `.cursor-plugin/plugin.json` | `version` | Cursor plugin version — always equals `plugin.json` `version` |
 
 ### One version line
@@ -25,9 +26,9 @@ All channels carry `package.json`'s version; the pre-release channels (`dev`, `p
 | `@uipath/skills` | `dev` | GitHub Packages | `M.N.<release>-dev.<run>` | per push to `main`, or dev dispatch |
 | `@uipath/skills-studioweb` | `preview` | GitHub Packages | `M.N.<release>-preview.<run>` | per push to `release/v*`, or preview dispatch |
 | `@uipath/skills-studioweb` | `dev` | GitHub Packages | `M.N.<release>-dev.<run>` | per push to `main`, or dev dispatch |
-| plugin manifests (`.claude-plugin/plugin.json`, `marketplace.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`) | — | — | `M.N.<release>` (base version, no pre-release suffix) | per `package.json` bump — drives Claude Code / Codex / Cursor plugin auto-update |
+| plugin manifests (`.claude-plugin/plugin.json`, `marketplace.json`, `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, `.cursor-plugin/plugin.json`) | — | — | `M.N.<release>` (base version, no pre-release suffix) | per `package.json` bump — drives Claude Code / Codex / Cursor plugin auto-update |
 
-`sync-version.mjs` enforces the line: the plugin version always equals `package.json`'s base `M.N.P` — there is **no independent plugin patch counter**. It **refuses to downgrade** (plugin auto-update never goes backwards, so a reverted `package.json` would freeze users), and it strips pre-release suffixes so the `dev`/`preview` stamps from `publish.yml` never land in the plugin manifests. The marketplace, Codex, and Cursor versions must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line. To bump the plugin version, bump `package.json` and run the sync — that is the only lever.
+`sync-version.mjs` enforces the line: the plugin version always equals `package.json`'s base `M.N.P` — there is **no independent plugin patch counter**. It **refuses to downgrade** (plugin auto-update never goes backwards, so a reverted `package.json` would freeze users), and it strips pre-release suffixes so the `dev`/`preview` stamps from `publish.yml` never land in the plugin manifests. Both marketplace indexes (`.claude-plugin/marketplace.json` for Claude Code, `.agents/plugins/marketplace.json` for Codex), the Codex plugin, and the Cursor versions must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line. To bump the plugin version, bump `package.json` and run the sync — that is the only lever.
 
 Run after any version change:
 

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -9,6 +9,7 @@
  *   - .claude-plugin/plugin.json   .version (== package.json base version)
  *   - .claude-plugin/marketplace.json  .plugins[0].version (== plugin.json)
  *   - .codex-plugin/plugin.json    .version (== plugin.json — Codex channel)
+ *   - .agents/plugins/marketplace.json .plugins[0].version (== plugin.json)
  *   - .cursor-plugin/plugin.json   .version (== plugin.json — Cursor channel)
  *
  * `targetCli` is derived as the matching @uipath/cli minor line
@@ -26,8 +27,8 @@
  *     version (errors out if package.json's base version is BELOW the plugin
  *     version — plugin auto-update never downgrades, so a lower version
  *     would freeze users)
- *   - marketplace .plugins[0].version, .codex-plugin/plugin.json .version,
- *     and .cursor-plugin/plugin.json .version must always equal
+ *   - both marketplace manifests' .plugins[0].version, .codex-plugin/plugin.json
+ *     .version, and .cursor-plugin/plugin.json .version must always equal
  *     .claude-plugin/plugin.json .version
  * See docs/RELEASE.md.
  *
@@ -58,6 +59,7 @@ const PATHS = {
   plugin: join(ROOT, ".claude-plugin", "plugin.json"),
   marketplace: join(ROOT, ".claude-plugin", "marketplace.json"),
   codexPlugin: join(ROOT, ".codex-plugin", "plugin.json"),
+  codexMarketplace: join(ROOT, ".agents", "plugins", "marketplace.json"),
   cursorPlugin: join(ROOT, ".cursor-plugin", "plugin.json"),
 };
 
@@ -147,19 +149,28 @@ if (plugin.version !== pluginVersion) {
   writes.push(() => writeJson(PATHS.plugin, plugin));
 }
 
+/**
+ * Sync one marketplace manifest's `plugins[0].version` to the canonical plugin
+ * version. Both marketplaces (Claude Code's and Codex's) carry the version
+ * nested in a `plugins[]` array rather than at the top level, so an absent or
+ * empty array is a hard error: there is no version to sync, and treating that
+ * as a no-op is how a manifest silently stops tracking releases.
+ */
+function syncMarketplaceVersion(label, path) {
+  const doc = readJson(path);
+  if (!Array.isArray(doc.plugins) || doc.plugins.length === 0) {
+    console.error(`✗ ${label} has no plugins[] entry to sync.`);
+    process.exit(1);
+  }
+  if (doc.plugins[0].version !== pluginVersion) {
+    drift.push(`${label}: ${doc.plugins[0].version} -> ${pluginVersion}`);
+    doc.plugins[0].version = pluginVersion;
+    writes.push(() => writeJson(path, doc));
+  }
+}
+
 // .claude-plugin/marketplace.json — must equal plugin.json exactly.
-const marketplace = readJson(PATHS.marketplace);
-if (!Array.isArray(marketplace.plugins) || marketplace.plugins.length === 0) {
-  console.error("✗ .claude-plugin/marketplace.json has no plugins[] entry to sync.");
-  process.exit(1);
-}
-if (marketplace.plugins[0].version !== pluginVersion) {
-  drift.push(
-    `.claude-plugin/marketplace.json: ${marketplace.plugins[0].version} -> ${pluginVersion}`,
-  );
-  marketplace.plugins[0].version = pluginVersion;
-  writes.push(() => writeJson(PATHS.marketplace, marketplace));
-}
+syncMarketplaceVersion(".claude-plugin/marketplace.json", PATHS.marketplace);
 
 // .codex-plugin/plugin.json — Codex distribution channel; must equal plugin.json.
 const codexPlugin = readJson(PATHS.codexPlugin);
@@ -170,6 +181,12 @@ if (codexPlugin.version !== pluginVersion) {
   codexPlugin.version = pluginVersion;
   writes.push(() => writeJson(PATHS.codexPlugin, codexPlugin));
 }
+
+// .agents/plugins/marketplace.json — the marketplace entry Codex CLI reads via
+// `codex plugin marketplace add UiPath/skills`; must equal plugin.json. This is
+// a separate file from .codex-plugin/plugin.json above: that one is the plugin
+// manifest, this one is the marketplace index that points at it.
+syncMarketplaceVersion(".agents/plugins/marketplace.json", PATHS.codexMarketplace);
 
 // .cursor-plugin/plugin.json — Cursor distribution channel; must equal plugin.json.
 const cursorPlugin = readJson(PATHS.cursorPlugin);


### PR DESCRIPTION
## Summary

- add `.agents/plugins/marketplace.json` to the manifests `sync-version.mjs` owns
- sync its `plugins[0].version` from `0.0.36` to `1.203.0`
- route both marketplace indexes through one `syncMarketplaceVersion()` helper
- document the file in `docs/RELEASE.md`

## Context

`.agents/plugins/marketplace.json` is the marketplace index Codex CLI reads via `codex plugin marketplace add UiPath/skills`. It carried `"version": "0.0.36"` while the plugin shipped `1.203.0`.

`scripts/sync-version.mjs` propagates `package.json`'s version to five derived manifests, and this file was not one of them — it is absent from `PATHS`. So nothing propagated a bump into it, and `npm run version:check` passed the entire time it was 196 releases stale. The check could not have caught this: it only inspects the files in `PATHS`.

Noticed while reviewing #2620, which edited this same manifest's `source.path`. That PR was correct to leave the version alone — it is a derived field and belongs to the sync script.

The `plugins[0]` nesting is shared with `.claude-plugin/marketplace.json`, so rather than duplicate the empty-`plugins[]` guard, both now call one helper. The Codex file gets that guard for free.

## Validation

- `npm run version:check` **fails before** the sync, naming exactly the new drift: `.agents/plugins/marketplace.json: 0.0.36 -> 1.203.0`
- `npm run version:check` **passes after** — the guard now covers this class of drift
- `node scripts/sync-version.mjs --list-paths` emits the new path, so `sprint-release-cut.yml` stages it with no second edit. A hardcoded `git add` list is what dropped `.cursor-plugin/plugin.json` from the 1.201 cut (#2767)
- empty-`plugins[]` guard exercised on the new file: emptying the array yields `✗ .agents/plugins/marketplace.json has no plugins[] entry to sync.` and exit 1
- the manifest diff is one line — the version was written by `npm run version:sync`, not by hand
- `node --check scripts/sync-version.mjs` clean

Per `docs/RELEASE.md`, a PR that adds a manifest to `PATHS` must run `npm run version:sync` as its last step before merge or it lands the stale value together with the check that rejects it. Done — hence the one-line manifest change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
