### PR TITLE
chore: refresh uip CLI catalog (1.203.0-dev.8572)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-09-08T04:07:47Z",
-  "cli_version": "1.203.0-dev.8563",
+  "generated_at": "2026-09-09T04:09:10Z",
+  "cli_version": "1.203.0-dev.8572",
   "verbs": [
     "admin",
     "admin audit",
@@ -659,6 +659,9 @@
     "llm-gateway",
     "llm-gateway models",
     "login",
+    "login profiles",
+    "login profiles delete",
+    "login profiles list",
     "login refresh",
     "login status",
     "login tenant",
@@ -1514,7 +1517,6 @@
     "tm testcases list",
     "tm testcases list-automations",
     "tm testcases list-result-history",
-    "tm testcases list-steps",
     "tm testcases list-testsets",
     "tm testcases remove",
     "tm testcases run",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.203.0-dev.8572`. The catalog has 1562 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.