### PR TITLE
fix(ci): merge the catalog refresh with --admin, not by racing gh

### DIFF
--- a/.github/workflows/automerge-catalog-refresh.yml
+++ b/.github/workflows/automerge-catalog-refresh.yml
@@ -138,6 +138,18 @@ jobs:
             fi
 
             echo "All checks green — squashing."
-            gh pr merge "$PR" --squash --delete-branch
+            # `--admin` merges through this PAT's ruleset bypass (Repository
+            # admin is a bypass actor on both `main` rulesets). Without it gh
+            # refuses client-side, before it ever calls the merge API: `main`
+            # requires an approving review, so an unreviewed bot PR sits at
+            # mergeStateStatus BLOCKED forever and gh reports "the base branch
+            # policy prohibits the merge". The merges that did land only won a
+            # race — a push to `main` resets an open PR to mergeability
+            # UNKNOWN, which slips past that client-side gate.
+            # NOT `--auto`: repo auto-merge is off by design (see header), and
+            # enabling it would only queue behind the approval that never comes.
+            # The required-check gate above remains the real safety boundary —
+            # `--admin` skips gh's local refusal, not this job's verification.
+            gh pr merge "$PR" --squash --delete-branch --admin
             echo "::endgroup::"
           done


### PR DESCRIPTION
## Problem

The nightly catalog refresh stopped auto-merging — [#3159](https://github.com/UiPath/skills/pull/3159) sat green and unmerged, and [run 34310432381](https://github.com/UiPath/skills/actions/runs/34310432381) shows why:

```
Required status checks (7): [...]
::group::PR #3159
All checks green — squashing.
X Pull request UiPath/skills#3159 is not mergeable: the base branch policy prohibits the merge.
```

`gh pr merge --squash` refuses **client-side** whenever `mergeStateStatus == BLOCKED` — it never reaches the merge API. That's what the "add `--auto` / add `--admin`" hint in the error is.

And these PRs are `BLOCKED` permanently: both `main` rulesets (`Require PR` #13681075, `main` #14795269) carry a `pull_request` rule with `required_approving_review_count: 1` and `require_code_owner_review: true`, unchanged since April. A bot PR never gets a review, so no amount of green checks clears that state.

## Why it ever worked

By race. A push to `main` invalidates open PRs' mergeability to `UNKNOWN`, which slips past gh's client-side gate; the merge API then completes it, because `GH_PAT`'s owner is a repo admin and therefore a bypass actor on both rulesets. The correlation is exact:

| refresh PR | preceding push to `main` | merged |
|---|---|---|
| #3130 | 12:10:40 | 12:12:18 — after refusals at 05:39, 05:47, 06:01, 07:42, 09:08, 09:16, 11:33 |
| #3111 | 07:29:39 | 07:30:46 — after 10 consecutive refusals |

On #3111 two runs fired off the same push: one merged, its twin was refused. That's ~3.9k failed runs of this workflow to date. #3159 simply lost the race for good — `main` went quiet at 03:20 UTC, its checks turned green at 04:18, and no further `check_suite` event arrived to retry.

## Fix

Use that bypass deliberately instead of by accident:

```diff
-gh pr merge "$PR" --squash --delete-branch
+gh pr merge "$PR" --squash --delete-branch --admin
```

`--auto` is not the alternative: repo auto-merge is off by design (see the workflow header), and enabling it would only queue behind the approval that never comes.

## Safety

`--admin` skips gh's *local* refusal, not this job's verification. Untouched above the merge: the branch-name filter, the dynamically-fetched required-check list, the fail-closed guard on an empty required set, and the present-and-green count over every required context. Those remain the real boundary — a refresh with red or missing required checks still stays open for a human sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
