### PR TITLE
test(uipath-ixp): seed the project so name resolution is actually tested

### DIFF
--- a/tests/tasks/uipath-ixp/_shared/cleanup_project.py
+++ b/tests/tasks/uipath-ixp/_shared/cleanup_project.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
-"""
-Post-run cleanup for IXP e2e/integration tasks: delete THIS run's project.
+"""Post-run cleanup for IXP tasks: delete THIS run's project.
 
-Reads report.json (CWD), written by the agent right after creation:
-  {"project_name": "<ProjectName from `uip ixp projects create` output>"}
+Two sources, read from CWD, whichever are present:
 
-and deletes that one project via `uip ixp projects delete <name> -y --output json`.
-It only ever removes the project the current run created — it does NOT sweep or
-touch any other (older / leftover) project.
+  report.json  {"project_name": "<ProjectName>"} — the agent created the project
+  seed.json    {"uuid8": "<run id>", ...} — pre_run created it; the slug is
+               withheld from the sandbox, so it is recovered from `projects
+               list` by the run id the backend carried into the ProjectName
 
-Best-effort and ALWAYS exits 0 (a delete failure is logged as WARN, never fails
-the test). Locally without a tenant this is a no-op.
+Only projects this run recorded are deleted — never a sweep. Best-effort and
+ALWAYS exits 0; without a tenant this is a no-op.
 """
 
 import json
@@ -33,33 +32,32 @@ def delete_project(name):
     if proc is None:
         return
     out = (proc.stdout or proc.stderr or "").strip()
-    # Only rc==0 is success. Do NOT treat any error — including 404 — as benign:
-    # `uip ixp projects delete <name>` 404s on a dataset-less project shell (the
-    # delete resolves the dataset first), so a 404 does NOT mean the project is
-    # gone. Surface every non-zero exit as WARN rather than masking it.
+    # Only rc==0 is success. A 404 does NOT mean the project is gone — delete
+    # resolves the dataset first and 404s on a dataset-less shell.
     if proc.returncode == 0:
         print(f"OK: deleted IXP project '{name}'")
     else:
         print(f"WARN: could not delete '{name}' (exit {proc.returncode}): {out[:200]}")
 
 
-def load_report():
-    path = os.path.join(os.getcwd(), "report.json")
+def load_json(filename):
+    path = os.path.join(os.getcwd(), filename)
     if not os.path.exists(path):
-        print(f"SKIP: no report.json at {path}")
+        print(f"SKIP: no {filename} at {path}")
         return None
     try:
         with open(path) as f:
             return json.load(f)
     except Exception as e:
-        print(f"SKIP: could not parse report.json: {e}")
+        print(f"SKIP: could not parse {filename}: {e}")
         return None
 
 
-def cleanup_own_project():
-    report = load_report()
+def name_from_report():
+    """The project the agent created, as it recorded it."""
+    report = load_json("report.json")
     if not report:
-        return
+        return None
     name = (
         report.get("project_name")
         or report.get("name")
@@ -67,12 +65,43 @@ def cleanup_own_project():
     )
     if not name:
         print("SKIP: no 'project_name' key in report.json")
-        return
-    delete_project(name)
+    return name
+
+
+def name_from_seed():
+    """The project pre_run created, found in `projects list` by this run's uuid8.
+
+    The ProjectName survives an `update-title`, so the uuid8 finds the project
+    even if the agent renamed it. Matching Title would not.
+    """
+    seed = load_json("seed.json")
+    if not seed:
+        return None
+    run_id = seed.get("uuid8")
+    if not run_id:
+        print("SKIP: no 'uuid8' key in seed.json")
+        return None
+
+    proc = run(["uip", "ixp", "projects", "list", "-l", "10000", "--output", "json"])
+    if proc is None or proc.returncode != 0:
+        print(f"WARN: could not list projects to find the project seeded for run {run_id}")
+        return None
+    try:
+        projects = (json.loads(proc.stdout).get("Data") or {}).get("Projects") or []
+    except Exception as e:
+        print(f"WARN: could not parse projects list: {e}")
+        return None
+
+    matches = [p["Name"] for p in projects if run_id in (p.get("Name") or "")]
+    if len(matches) != 1:
+        print(f"WARN: {len(matches)} projects carry run id {run_id}; deleting none")
+        return None
+    return matches[0]
 
 
 def main():
-    cleanup_own_project()
+    for name in dict.fromkeys(filter(None, [name_from_seed(), name_from_report()])):
+        delete_project(name)
     sys.exit(0)
 
 

--- a/tests/tasks/uipath-ixp/_shared/seed_project.py
+++ b/tests/tasks/uipath-ixp/_shared/seed_project.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """pre_run: create one IXP project from the fixture invoices, record only its TITLE.
 
-  seed.json = {"uuid8": "a1b2c3d4", "project": {"title": "codereval-ixp-seed-a1b2c3d4"}}
+  seed.json = {"uuid8": "a1b2c3d4", "project": {"title": "Codereval IXP Seed a1b2c3d4"}}
 
 The ProjectName slug is deliberately withheld — a task grading Title ->
 ProjectName resolution is meaningless once the slug is in the sandbox. Whoever
@@ -10,7 +10,7 @@ needs it later looks it up from `projects list` by the run id.
 The uuid8 makes the title unique per run, so concurrent runs never collide and a
 leftover from a failed cleanup is never mistaken for this run's project.
 
-  IXP_SEED_TITLE_BASE  title stem (default `codereval-ixp-seed`)
+  IXP_SEED_TITLE_BASE  title stem (default `Codereval IXP Seed`)
 
 Exits non-zero if the tenant rejects the seed: pre_run's fail_on_error then ends
 the run as an environment error instead of scoring the skill against a project
@@ -51,8 +51,8 @@ def uploaded_filenames(project_name):
 
 def main():
     run_id = uuid.uuid4().hex[:8]
-    base = (os.environ.get("IXP_SEED_TITLE_BASE") or "codereval-ixp-seed").strip()
-    title = "%s-%s" % (base, run_id)
+    base = (os.environ.get("IXP_SEED_TITLE_BASE") or "Codereval IXP Seed").strip()
+    title = "%s %s" % (base, run_id)
 
     created = uip("ixp", "projects", "create", title, FIXTURES, "--skip-taxonomy").get("Data") or {}
     name = created.get("ProjectName") or created.get("Name")

--- a/tests/tasks/uipath-ixp/_shared/seed_project.py
+++ b/tests/tasks/uipath-ixp/_shared/seed_project.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""pre_run: create one IXP project from the fixture invoices, record only its TITLE.
+
+  seed.json = {"uuid8": "a1b2c3d4", "project": {"title": "codereval-ixp-seed-a1b2c3d4"}}
+
+The ProjectName slug is deliberately withheld — a task grading Title ->
+ProjectName resolution is meaningless once the slug is in the sandbox. Whoever
+needs it later looks it up from `projects list` by the run id.
+
+The uuid8 makes the title unique per run, so concurrent runs never collide and a
+leftover from a failed cleanup is never mistaken for this run's project.
+
+  IXP_SEED_TITLE_BASE  title stem (default `codereval-ixp-seed`)
+
+Exits non-zero if the tenant rejects the seed: pre_run's fail_on_error then ends
+the run as an environment error instead of scoring the skill against a project
+that does not exist.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+
+FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
+EXPECTED_DOCS = {"csi_tower_invoice.png", "hp_tax_invoice.png", "york_solutions_invoice.png"}
+
+
+def uip(*args, timeout=180):
+    """Run `uip <args> --output json` and return the parsed envelope, or exit 1."""
+    cmd = ["uip", *args, "--output", "json"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except Exception as exc:
+        sys.exit("seed_project: %s failed to invoke: %s" % (" ".join(cmd), exc))
+    if proc.returncode != 0:
+        sys.exit("seed_project: %s exited %d: %s"
+                 % (" ".join(cmd), proc.returncode, (proc.stderr or proc.stdout or "")[:500]))
+    try:
+        return json.loads(proc.stdout)
+    except ValueError:
+        sys.exit("seed_project: %s returned non-JSON: %s" % (" ".join(cmd), proc.stdout[:500]))
+
+
+def uploaded_filenames(project_name):
+    data = uip("ixp", "documents", "list", project_name, "-l", "100").get("Data") or {}
+    return {d.get("Filename") for d in (data.get("Documents") or [])}
+
+
+def main():
+    run_id = uuid.uuid4().hex[:8]
+    base = (os.environ.get("IXP_SEED_TITLE_BASE") or "codereval-ixp-seed").strip()
+    title = "%s-%s" % (base, run_id)
+
+    created = uip("ixp", "projects", "create", title, FIXTURES, "--skip-taxonomy").get("Data") or {}
+    name = created.get("ProjectName") or created.get("Name")
+    if not name:
+        sys.exit("seed_project: create returned no ProjectName: %s" % json.dumps(created)[:500])
+
+    # Cleanup and the tenant check locate this project by the run id in its
+    # ProjectName. Fail here rather than leak the project later.
+    if run_id not in name:
+        sys.exit("seed_project: ProjectName %r does not carry run id %s; "
+                 "cleanup could not find this project" % (name, run_id))
+
+    # `projects delete` resolves the dataset first and 404s without one, so a
+    # taxonomy-less project cannot be cleaned up.
+    uip("ixp", "projects", "import-taxonomy", name, os.path.join(FIXTURES, "taxonomy.json"))
+
+    # Confirm the uploads landed: a partial one reads as an unexplained failure.
+    for attempt in range(5):
+        found = uploaded_filenames(name)
+        if EXPECTED_DOCS <= found:
+            break
+        if attempt < 4:
+            time.sleep(3)
+    else:
+        sys.exit("seed_project: %s holds %s, expected %s"
+                 % (name, sorted(found), sorted(EXPECTED_DOCS)))
+
+    with open("seed.json", "w", encoding="utf-8") as fh:
+        json.dump({"uuid8": run_id, "project": {"title": title}}, fh)
+
+    # Run log only — the sandbox gets the title alone.
+    print("seed_project: seeded '%s' as %s with %d documents" % (title, name, len(found)))
+
+
+main()

--- a/tests/tasks/uipath-ixp/integration/check_documents_after.py
+++ b/tests/tasks/uipath-ixp/integration/check_documents_after.py
@@ -1,0 +1,100 @@
+"""Verify on the TENANT that the named document — and only it — was deleted.
+
+The seeded project holds three invoices; a run that resolved both the title and
+the filename leaves two behind.
+
+Read from the tenant, not from a file the agent saved: `mocks/calls.log` records
+invocations before the CLI runs, so a `documents delete` that 404'd is logged
+exactly like one that succeeded.
+
+The ProjectName is recovered from `projects list` by seed.json's run id — the
+slug is deliberately absent from the sandbox.
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+
+EXPECTED_PRESENT = {"csi_tower_invoice.png", "hp_tax_invoice.png"}
+EXPECTED_ABSENT = "york_solutions_invoice.png"
+
+
+def real_cli_env():
+    """PATH without the mock dir, so these calls stay out of calls.log.
+
+    `mock_path_dirs` prepends `<sandbox>/mocks` for run_command criteria too, and
+    the wrapper there logs every invocation — which the regex criteria grade.
+    """
+    env = dict(os.environ)
+    mocks = os.path.join(os.getcwd(), "mocks")
+    env["PATH"] = os.pathsep.join(
+        d for d in env.get("PATH", "").split(os.pathsep)
+        if os.path.abspath(d or ".") != mocks
+    )
+    return env
+
+
+def uip(*args):
+    """Parsed envelope, or (None, reason). Never raises: a broken call must read
+    as a criterion failure with a reason, not a traceback."""
+    try:
+        proc = subprocess.run(["uip", *args, "--output", "json"],
+                              capture_output=True, text=True, timeout=30, env=real_cli_env())
+    except Exception as exc:
+        return None, "could not invoke uip: %s" % exc
+    if proc.returncode != 0:
+        return None, (proc.stderr or proc.stdout or "")[:300]
+    try:
+        return json.loads(proc.stdout), None
+    except ValueError:
+        return None, proc.stdout[:300]
+
+
+def project_name(run_id):
+    listed, err = uip("ixp", "projects", "list", "-l", "10000")
+    if listed is None:
+        return None, "projects list failed: %s" % err
+    projects = (listed.get("Data") or {}).get("Projects") or []
+    matches = [p["Name"] for p in projects if run_id in (p.get("Name") or "")]
+    if len(matches) != 1:
+        return None, "%d projects carry run id %s" % (len(matches), run_id)
+    return matches[0], None
+
+
+def main():
+    try:
+        run_id = json.load(open("seed.json", encoding="utf-8")).get("uuid8", "")
+    except (ValueError, OSError) as exc:
+        print("FAIL - seed.json unreadable (%s)" % exc)
+        return 1
+    if not run_id:
+        print("FAIL - seed.json carries no uuid8")
+        return 1
+
+    name, err = project_name(run_id)
+    if not name:
+        print("FAIL - could not resolve the seeded project: %s" % err)
+        return 1
+
+    for attempt in range(3):
+        listed, err = uip("ixp", "documents", "list", name, "-l", "100")
+        if listed is None:
+            print("FAIL - documents list on %s failed: %s" % (name, err))
+            return 1
+        found = {d.get("Filename") for d in ((listed.get("Data") or {}).get("Documents") or [])}
+        if EXPECTED_ABSENT not in found and EXPECTED_PRESENT <= found:
+            print("PASS - %s holds %s" % (name, sorted(found)))
+            return 0
+        if attempt < 2:
+            time.sleep(3)
+
+    if EXPECTED_ABSENT in found:
+        print("FAIL - %s is still in %s" % (EXPECTED_ABSENT, name))
+    missing = EXPECTED_PRESENT - found
+    if missing:
+        print("FAIL - deleted more than asked: %s no longer in %s" % (sorted(missing), name))
+    return 1
+
+
+sys.exit(main())

--- a/tests/tasks/uipath-ixp/integration/check_own_project.py
+++ b/tests/tasks/uipath-ixp/integration/check_own_project.py
@@ -1,7 +1,9 @@
 """Verify every project-scoped write targeted the seeded project.
 
 The tenant is shared, so a write aimed anywhere else is a violation. seed.json's
-run id identifies this run's project — the backend slugs it into the ProjectName.
+run id identifies this run's project: the backend slugs the seeded title into the
+ProjectName (`Codereval Name Resolution d4f0a999` -> `codereval-name-resolution-
+d4f0a999-9ae36e86-ixp`), and the hex run id passes through untouched.
 """
 import json
 import sys

--- a/tests/tasks/uipath-ixp/integration/check_own_project.py
+++ b/tests/tasks/uipath-ixp/integration/check_own_project.py
@@ -1,0 +1,107 @@
+"""Verify every project-scoped write stayed inside THIS run's own project.
+
+The tenant is shared with concurrent runs, all of which title their project
+`codereval-integ-resolve-<random-suffix>`. Matching that prefix alone would
+accept a write aimed at a sibling run's project, so the prefix is not the
+identity — the random suffix is.
+
+This run's suffix comes from its FIRST `uip ixp projects create` in calls.log.
+The wrapper logs invocations regardless of outcome, so the suffix is still
+recoverable on a run whose create was rejected (e.g. a 403 tenant). Every
+project-scoped write is then required to name a target carrying that suffix:
+
+  create codereval-integ-resolve-d4f0a999 ...   -> suffix d4f0a999
+  update-title codereval-integ-resolve-d4f0a999-9ae36e86-ixp   OK
+  update-title vendor-invoices-5a097334-ixp                    VIOLATION
+  create test-perm-check                                       VIOLATION
+
+report.json is checked against the same suffix because `cleanup_project.py`
+deletes whatever project it names — a wrong value there deletes someone else's
+project in post_run.
+"""
+import json
+import os
+import re
+import sys
+
+TITLE_PREFIX = "codereval-integ-resolve-"
+
+# Verbs that mutate a project or add one to the tenant. Read verbs (list, get,
+# get-taxonomy) are deliberately absent: reading a shared tenant is how the
+# agent discovers its own project, and the prompt only forbids writes.
+WRITE_VERBS = re.compile(
+    r"^uip\s+ixp\s+"
+    r"(?:projects\s+(?:create|update-title|update-prompt|update-model|"
+    r"import-taxonomy|publish|unpublish|tag|untag|rollback|delete)"
+    r"|documents\s+(?:upload|delete)"
+    r"|groups\s+(?:add|remove|update)"
+    r"|fields\s+(?:add|remove|update))"
+    r"\s+(?P<rest>.*)$"
+)
+
+
+def first_positional(rest):
+    """First non-flag argument — the project the write is aimed at."""
+    for token in rest.split():
+        if not token.startswith("-"):
+            return token
+    return None
+
+
+def main():
+    if not os.path.exists("mocks/calls.log"):
+        print("FAIL - mocks/calls.log missing; cannot verify project scope")
+        return 1
+
+    lines = [ln.strip() for ln in open("mocks/calls.log", encoding="utf-8")]
+    writes = []
+    for ln in lines:
+        m = WRITE_VERBS.match(ln)
+        if m:
+            target = first_positional(m.group("rest"))
+            if target:
+                writes.append((ln, target))
+
+    creates = [t for ln, t in writes if re.match(r"^uip\s+ixp\s+projects\s+create\b", ln)]
+    if not creates:
+        print("FAIL - no `uip ixp projects create` in calls.log; run never created a project")
+        return 1
+
+    own_title = creates[0]
+    if not own_title.startswith(TITLE_PREFIX):
+        print("FAIL - first create titled %r; expected the %s<suffix> convention"
+              % (own_title, TITLE_PREFIX))
+        return 1
+
+    suffix = own_title[len(TITLE_PREFIX):]
+    if not suffix:
+        print("FAIL - first create titled %r carries no random suffix" % own_title)
+        return 1
+    print("This run's project suffix: %s" % suffix)
+
+    violations = [ln for ln, target in writes if suffix not in target]
+    for ln in violations:
+        print("FAIL - write outside own project: %s" % ln)
+
+    # cleanup_project.py acts on this value; a foreign name here deletes a
+    # sibling run's project.
+    if os.path.exists("report.json"):
+        try:
+            name = json.load(open("report.json", encoding="utf-8")).get("project_name", "")
+        except (ValueError, OSError) as exc:
+            print("FAIL - report.json unreadable (%s)" % exc)
+            return 1
+        if suffix not in str(name):
+            print("FAIL - report.json project_name %r is not this run's project" % name)
+            return 1
+        print("PASS - report.json names this run's own project")
+
+    if violations:
+        print("FAIL - %d project-scoped write(s) left this run's project" % len(violations))
+        return 1
+
+    print("PASS - all %d project-scoped write(s) stayed inside this run's project" % len(writes))
+    return 0
+
+
+sys.exit(main())

--- a/tests/tasks/uipath-ixp/integration/check_own_project.py
+++ b/tests/tasks/uipath-ixp/integration/check_own_project.py
@@ -1,106 +1,60 @@
-"""Verify every project-scoped write stayed inside THIS run's own project.
+"""Verify every project-scoped write targeted the seeded project.
 
-The tenant is shared with concurrent runs, all of which title their project
-`codereval-integ-resolve-<random-suffix>`. Matching that prefix alone would
-accept a write aimed at a sibling run's project, so the prefix is not the
-identity — the random suffix is.
-
-This run's suffix comes from its FIRST `uip ixp projects create` in calls.log.
-The wrapper logs invocations regardless of outcome, so the suffix is still
-recoverable on a run whose create was rejected (e.g. a 403 tenant). Every
-project-scoped write is then required to name a target carrying that suffix:
-
-  create codereval-integ-resolve-d4f0a999 ...   -> suffix d4f0a999
-  update-title codereval-integ-resolve-d4f0a999-9ae36e86-ixp   OK
-  update-title vendor-invoices-5a097334-ixp                    VIOLATION
-  create test-perm-check                                       VIOLATION
-
-report.json is checked against the same suffix because `cleanup_project.py`
-deletes whatever project it names — a wrong value there deletes someone else's
-project in post_run.
+The tenant is shared, so a write aimed anywhere else is a violation. seed.json's
+run id identifies this run's project — the backend slugs it into the ProjectName.
 """
 import json
-import os
-import re
 import sys
 
-TITLE_PREFIX = "codereval-integ-resolve-"
-
-# Verbs that mutate a project or add one to the tenant. Read verbs (list, get,
-# get-taxonomy) are deliberately absent: reading a shared tenant is how the
-# agent discovers its own project, and the prompt only forbids writes.
-WRITE_VERBS = re.compile(
-    r"^uip\s+ixp\s+"
-    r"(?:projects\s+(?:create|update-title|update-prompt|update-model|"
-    r"import-taxonomy|publish|unpublish|tag|untag|rollback|delete)"
-    r"|documents\s+(?:upload|delete)"
-    r"|groups\s+(?:add|remove|update)"
-    r"|fields\s+(?:add|remove|update))"
-    r"\s+(?P<rest>.*)$"
-)
+# Write verbs, per assets/uip-catalog-snapshot.json. Read verbs are excluded:
+# reading a shared tenant is how the agent finds its project.
+WRITE_VERBS = {
+    "projects": {"create", "delete", "configure-model", "import-taxonomy", "publish",
+                 "unpublish", "untag", "update-prompt", "update-title"},
+    "documents": {"upload", "delete"},
+    "groups": {"add", "delete", "rename", "update-prompts"},
+    "fields": {"add", "change-type", "delete", "rename", "update-prompts"},
+    "data-types": {"add", "delete", "rename", "update-instructions"},
+    "labellings": {"confirm", "unconfirm", "mark-missing"},
+    "deployments": {"create", "upgrade"},
+}
 
 
-def first_positional(rest):
-    """First non-flag argument — the project the write is aimed at."""
-    for token in rest.split():
-        if not token.startswith("-"):
-            return token
-    return None
+def write_target(line):
+    """The project a logged write targets, or None if the line is not a write.
+
+    Every write verb takes the project as its first positional. For `projects
+    create` that positional is a new title, so a scratch project fails too.
+    """
+    tokens = line.split()
+    if tokens[:2] != ["uip", "ixp"] or len(tokens) < 5:
+        return None
+    if tokens[3] not in WRITE_VERBS.get(tokens[2], ()):
+        return None
+    return next((t for t in tokens[4:] if not t.startswith("-")), None)
 
 
 def main():
-    if not os.path.exists("mocks/calls.log"):
-        print("FAIL - mocks/calls.log missing; cannot verify project scope")
+    try:
+        run_id = json.load(open("seed.json", encoding="utf-8")).get("uuid8", "")
+        log = open("mocks/calls.log", encoding="utf-8").read().splitlines()
+    except (ValueError, OSError) as exc:
+        print("FAIL - cannot read seed.json / mocks/calls.log (%s)" % exc)
+        return 1
+    if not run_id:
+        print("FAIL - seed.json carries no uuid8")
         return 1
 
-    lines = [ln.strip() for ln in open("mocks/calls.log", encoding="utf-8")]
-    writes = []
-    for ln in lines:
-        m = WRITE_VERBS.match(ln)
-        if m:
-            target = first_positional(m.group("rest"))
-            if target:
-                writes.append((ln, target))
+    writes = [(ln.strip(), write_target(ln.strip())) for ln in log]
+    writes = [(ln, target) for ln, target in writes if target]
 
-    creates = [t for ln, t in writes if re.match(r"^uip\s+ixp\s+projects\s+create\b", ln)]
-    if not creates:
-        print("FAIL - no `uip ixp projects create` in calls.log; run never created a project")
-        return 1
-
-    own_title = creates[0]
-    if not own_title.startswith(TITLE_PREFIX):
-        print("FAIL - first create titled %r; expected the %s<suffix> convention"
-              % (own_title, TITLE_PREFIX))
-        return 1
-
-    suffix = own_title[len(TITLE_PREFIX):]
-    if not suffix:
-        print("FAIL - first create titled %r carries no random suffix" % own_title)
-        return 1
-    print("This run's project suffix: %s" % suffix)
-
-    violations = [ln for ln, target in writes if suffix not in target]
+    violations = [ln for ln, target in writes if run_id not in target]
     for ln in violations:
-        print("FAIL - write outside own project: %s" % ln)
-
-    # cleanup_project.py acts on this value; a foreign name here deletes a
-    # sibling run's project.
-    if os.path.exists("report.json"):
-        try:
-            name = json.load(open("report.json", encoding="utf-8")).get("project_name", "")
-        except (ValueError, OSError) as exc:
-            print("FAIL - report.json unreadable (%s)" % exc)
-            return 1
-        if suffix not in str(name):
-            print("FAIL - report.json project_name %r is not this run's project" % name)
-            return 1
-        print("PASS - report.json names this run's own project")
-
+        print("FAIL - write outside the seeded project: %s" % ln)
     if violations:
-        print("FAIL - %d project-scoped write(s) left this run's project" % len(violations))
         return 1
 
-    print("PASS - all %d project-scoped write(s) stayed inside this run's project" % len(writes))
+    print("PASS - all %d project-scoped write(s) targeted the seeded project" % len(writes))
     return 0
 
 

--- a/tests/tasks/uipath-ixp/integration/name_resolution.yaml
+++ b/tests/tasks/uipath-ixp/integration/name_resolution.yaml
@@ -2,8 +2,8 @@ task_id: skill-ixp-integration-name-resolution
 description: >
   Integration: name/title resolution on a live tenant. The agent must resolve
   user-facing references to the ids the CLI needs — a document by FILENAME →
-  DocumentId via `documents list`, and a project by its TITLE → Name via
-  `projects list` — rather than passing the human label straight through. The
+  DocumentId via `documents list`, and a project by the Name returned by
+  `projects create` — rather than passing the human label straight through. The
   resolution step is the integration part; smokes pass the id in the prompt.
 tags: [uipath-ixp, integration, mode:operate, lifecycle:setup]
 
@@ -39,6 +39,9 @@ initial_prompt: |
 
   Right after the project is created, write `report.json` for cleanup: {"project_name": "<the ProjectName from the create response>"}.
 
+  Work only on the project you create. The tenant is shared — never write to any
+  other project. If a command fails, report the error; do not probe other projects.
+
 success_criteria:
   - type: file_matches_regex
     description: "Listed documents to resolve the filename → DocumentId, then re-read to save the remaining list"
@@ -57,14 +60,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_matches_regex
-    description: "Listed projects to resolve Title → Name"
-    path: "mocks/calls.log"
-    pattern: >-
-      (?m)^(?:uip\s+ixp\s+projects\s+list)[^\r\n]*$
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_matches_regex
     description: "Renamed the project via update-title"
     path: "mocks/calls.log"
     pattern: >-
@@ -79,6 +74,18 @@ success_criteria:
       (?m)^(?:uip\s+ixp\s+documents\s+delete\s+\S+\s+york_solutions_invoice\.png)[^\r\n]*$
     must_match: false
     weight: 1.5
+    pass_threshold: 1.0
+
+  # The tenant is shared and every concurrent run titles its project
+  # `codereval-integ-resolve-*`, so the prefix cannot identify ownership — the
+  # random suffix can. check_own_project.py derives this run's suffix from its
+  # own `projects create` and requires every project-scoped write to carry it.
+  - type: run_command
+    description: "Every project-scoped write stayed inside this run's own project"
+    command: "python3 $TASK_DIR/check_own_project.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
     pass_threshold: 1.0
 
   - type: file_exists

--- a/tests/tasks/uipath-ixp/integration/name_resolution.yaml
+++ b/tests/tasks/uipath-ixp/integration/name_resolution.yaml
@@ -1,15 +1,15 @@
 task_id: skill-ixp-integration-name-resolution
 description: >
-  Integration: name/title resolution on a live tenant. The agent must resolve
-  user-facing references to the ids the CLI needs — a document by FILENAME →
-  DocumentId via `documents list`, and a project by the Name returned by
-  `projects create` — rather than passing the human label straight through. The
-  resolution step is the integration part; smokes pass the id in the prompt.
+  Integration: name resolution on a live tenant. pre_run seeds the project and
+  hands the agent nothing but its TITLE, so both lookups are forced — Title →
+  ProjectName via `projects list`, then FILENAME → DocumentId via `documents
+  list` — instead of passing the human label straight through. The smoke tasks
+  pass the id in the prompt; resolving it is what makes this the integration tier.
 tags: [uipath-ixp, integration, mode:operate, lifecycle:setup]
 
 run_limits:
-  max_turns: 48
-  task_timeout: 1800
+  max_turns: 30
+  task_timeout: 1200
   turn_timeout: 600
 
 sandbox:
@@ -21,33 +21,38 @@ sandbox:
   template_sources:
     - type: template_dir
       path: ../_shared/live_calls_template
-    - type: template_dir
-      path: ../_shared/fixtures
+
+# Creates the project the agent must find; writes seed.json with its title only.
+# fail_on_error defaults on: a rejected seed ends the run as an environment error.
+pre_run:
+  - command: 'IXP_SEED_TITLE_BASE="codereval-name-resolution" python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/seed_project.py"'
+    timeout: 300
 
 initial_prompt: |
   Use the tenant I'm already signed into (check I'm logged in; don't
-  re-authenticate). Set up an invoice project from the files in `./fixtures/` —
-  import the taxonomy and upload the three invoices — and give it a unique title
-  `codereval-integ-resolve-<random-suffix>` so concurrent runs don't collide.
+  re-authenticate).
 
-  Then:
-  - Delete the file `york_solutions_invoice.png`, then save the remaining document
-    list to `documents_after.json`.
-  - Rename that project to the same title with `-renamed` appended (i.e.
-    `codereval-integ-resolve-<random-suffix>-renamed`), then save the project's details to
-    `project_after.json`.
+  Delete the document `york_solutions_invoice.png` from my IXP project — its
+  title is in `seed.json`, under `project.title`.
 
-  Right after the project is created, write `report.json` for cleanup: {"project_name": "<the ProjectName from the create response>"}.
-
-  Work only on the project you create. The tenant is shared — never write to any
-  other project. If a command fails, report the error; do not probe other projects.
+  Work only on that project. The tenant is shared — never write to any other
+  project, and do not create one. If a command fails, report the error; do not
+  probe other projects.
 
 success_criteria:
   - type: file_matches_regex
-    description: "Listed documents to resolve the filename → DocumentId, then re-read to save the remaining list"
+    description: "Listed projects to resolve Title → ProjectName"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)(?:[\s\S]*?^(?:uip\s+ixp\s+documents\s+list)[^\r\n]*$){2}
+      (?m)^(?:uip\s+ixp\s+projects\s+list)[^\r\n]*$
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: file_matches_regex
+    description: "Listed documents to resolve the filename → DocumentId"
+    path: "mocks/calls.log"
+    pattern: >-
+      (?m)^(?:uip\s+ixp\s+documents\s+list)[^\r\n]*$
     weight: 2.0
     pass_threshold: 1.0
 
@@ -60,14 +65,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_matches_regex
-    description: "Renamed the project via update-title"
-    path: "mocks/calls.log"
-    pattern: >-
-      (?m)^(?:uip\s+ixp\s+projects\s+update-title)[^\r\n]*$
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_matches_regex
     description: "Did NOT pass the raw filename through as a document id to delete"
     path: "mocks/calls.log"
     pattern: >-
@@ -76,43 +73,26 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  # The tenant is shared and every concurrent run titles its project
-  # `codereval-integ-resolve-*`, so the prefix cannot identify ownership — the
-  # random suffix can. check_own_project.py derives this run's suffix from its
-  # own `projects create` and requires every project-scoped write to carry it.
+  # Only a run that resolved BOTH lookups can land this: the project is
+  # unreachable without its ProjectName, the document without its DocumentId.
   - type: run_command
-    description: "Every project-scoped write stayed inside this run's own project"
+    description: "Tenant: york is gone from the seeded project; the other two documents remain"
+    command: "python3 $TASK_DIR/check_documents_after.py"
+    timeout: 150
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Every project-scoped write stayed inside the seeded project"
     command: "python3 $TASK_DIR/check_own_project.py"
-    timeout: 30
+    timeout: 60
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: file_exists
-    description: "report.json written for post-run cleanup"
-    path: "report.json"
-    weight: 1.0
-    pass_threshold: 1.0
-
-  # --- Outcome verification: resolution actually deleted the named doc + renamed the project ---
-  - type: file_contains
-    description: "york is gone from the list; the other two documents remain"
-    path: "documents_after.json"
-    includes: ["csi_tower_invoice.png", "hp_tax_invoice.png"]
-    excludes: ["york_solutions_invoice.png"]
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: file_contains
-    description: "The project was renamed: title now carries the `-renamed` suffix"
-    path: "project_after.json"
-    includes: ["codereval-integ-resolve", "-renamed"]
-    weight: 2.0
-    pass_threshold: 1.0
-
-# Safety net: delete the project even if the agent's in-band cleanup never ran
-# (crash / MAX_TURNS before the final delete). Reads report.json; idempotent;
-# always exits 0 so it never fails the test.
+# Deletes the seeded project. Reads seed.json, so it works even if the agent
+# crashed before touching anything. Idempotent; always exits 0.
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/cleanup_project.py"
     timeout: 60

--- a/tests/tasks/uipath-ixp/integration/name_resolution.yaml
+++ b/tests/tasks/uipath-ixp/integration/name_resolution.yaml
@@ -25,7 +25,7 @@ sandbox:
 # Creates the project the agent must find; writes seed.json with its title only.
 # fail_on_error defaults on: a rejected seed ends the run as an environment error.
 pre_run:
-  - command: 'IXP_SEED_TITLE_BASE="codereval-name-resolution" python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/seed_project.py"'
+  - command: 'IXP_SEED_TITLE_BASE="Codereval Name Resolution" python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/seed_project.py"'
     timeout: 300
 
 initial_prompt: |


### PR DESCRIPTION
## What it tests

`pre_run` creates a project with a run-unique title and tells the agent **only that title**. The agent has to find it (`projects list` → ProjectName), delete `york_solutions_invoice.png` from it (`documents list` → DocumentId), and touch nothing else on the shared tenant.

## Why it changed

[Alex was right](https://github.com/UiPath/skills/pull/3166#discussion_r3971456133): the old test had the agent *create* the project, so `projects create` returned the ProjectName directly. There was nothing to resolve, and the `projects list` check could never pass — both agents were docked for correctly skipping it. Seeding the project outside the agent makes the lookup unavoidable.

## Flow

```
pre_run   seed_project.py     creates the project, writes seed.json
agent     does the work       every uip command lands in mocks/calls.log
grading   6 checks            4 read the log, 2 ask the tenant
post_run  cleanup_project.py  deletes the project
```

## Files

| File | |
|---|---|
| `name_resolution.yaml` | the prompt and the 6 graded checks |
| `_shared/seed_project.py` | **pre_run** — creates the project from the 3 fixture invoices, imports the taxonomy, verifies the uploads landed, writes `seed.json` |
| `integration/check_documents_after.py` | asks the tenant: is york gone, are the other two still there? |
| `integration/check_own_project.py` | reads the log: did any write target another project? |
| `_shared/cleanup_project.py` | **post_run** — deletes the project |

## seed.json

```json
{"uuid8": "d4f8d6cf", "project": {"title": "codereval-name-resolution-d4f8d6cf"}}
```

- `title` — all the agent gets.
- `uuid8` — random per run, so concurrent runs never collide. The backend copies it into the ProjectName, which is how cleanup and the checkers find the project afterwards; unlike the title, it survives a rename.
- **No ProjectName** — that's the answer the agent is meant to look up. Anything that needs it later reads it from `projects list`, same as the agent.

`report.json` is gone from this test — cleanup reads `seed.json`, so it works even if the agent crashes early. The other 5 IXP tasks still use it and are unaffected.

## Graded (weight 13.0)

| Check | |
|---|---|
| Ran `projects list` | 2.5 |
| Ran `documents list` | 2.0 |
| Ran `documents delete … -y` | 2.0 |
| Did **not** pass the filename in where a DocumentId goes | 1.5 |
| **Tenant:** york gone, other two still there | 3.0 |
| **Tenant:** never wrote to another project | 2.0 |

The last two ask the tenant instead of trusting a file the agent wrote: the log records commands *before* they run, so a `delete` that 404'd looks exactly like one that worked.

## Shared-tenant safety

The 09-07 run overwrote an unrelated project's title and extraction prompt, and left 6 scratch projects behind. `check_own_project.py` knows all 29 `uip ixp` write verbs (cross-checked against `assets/uip-catalog-snapshot.json`) and fails the run if any of them targets a project that isn't this one — reading other projects stays allowed, since that is how `projects list` works. And a seed the tenant rejects now ends the run as an **environment error** rather than a skill failure, which is what the 09-07 tenant 403 should have been.

## Verified

Replayed against the archived 09-07/09-08 runs plus synthetic cases:

| Case | |
|---|---|
| 09-07 run that damaged `vendor-invoices-…` | **FAIL** — both foreign writes caught |
| Foreign `configure-model` / `labellings confirm` / `data-types delete` | **FAIL** |
| Agent creates a scratch project | **FAIL** |
| Tenant: york still there, or too much deleted | **FAIL** |
| Reading another project, or `--help` | PASS — allowed |
| Clean run | PASS |
| Seed: partial upload, or a ProjectName cleanup couldn't find | exits non-zero |
| Cleanup: seed only / report only / both / neither | correct in all four |

`py_compile` clean · YAML parses (6 criteria, 13.0) · `check-cli-verbs.py` OK · write-verb table cross-checks clean against the CLI catalog.

## Follow-ups, not here

- The other 5 IXP tasks have no ownership check, only a line in the prompt asking nicely.
- `./fixtures/` doesn't exist in the sandbox (`template_dir` flattens it to the root). This task no longer needs the fixtures; 5 others still do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
