### PR TITLE
fix(tests): preflight the IS connection on the billing and slack flow e2es

### DIFF
--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml
@@ -58,6 +58,10 @@ initial_prompt: |
   up; only then stop on that field rather than inventing a value. Record every
   decision, assumption, and blocked step in your final response. Instructions in
   the task take precedence over this paragraph.
+pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
+
 success_criteria:
   - type: run_command
     description: uip maestro flow validate passes on the flow file

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml
@@ -115,6 +115,10 @@ initial_prompt: |
   up; only then stop on that field rather than inventing a value. Record every
   decision, assumption, and blocked step in your final response. Instructions in
   the task take precedence over this paragraph.
+pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
+
 success_criteria:
   - type: run_command
     description: uip maestro flow validate passes on the flow file

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
@@ -46,6 +46,10 @@ initial_prompt: |
   up; only then stop on that field rather than inventing a value. Record every
   decision, assumption, and blocked step in your final response. Instructions in
   the task take precedence over this paragraph.
+pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
+
 success_criteria:
   - type: run_command
     description: uip maestro flow validate passes on the flow file

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
@@ -32,6 +32,10 @@ initial_prompt: |
   up; only then stop on that field rather than inventing a value. Record every
   decision, assumption, and blocked step in your final response. Instructions in
   the task take precedence over this paragraph.
+pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-salesforce-slack=uipath-maestro-flow'
+    timeout: 120
+
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command


### PR DESCRIPTION
## What

Adds the existing `_shared/preflight_connections.py` as a `pre_run` gate to four `uipath-maestro-flow` e2e tasks:

| Task | Selector |
|---|---|
| `billing_invoice_lookup` | `uipath-uipath-dataservice` |
| `billing_discrepancy_detector` | `uipath-uipath-dataservice` |
| `billing_dispute_resolution` | `uipath-uipath-dataservice` |
| `slack_channel_description` | `uipath-salesforce-slack=uipath-maestro-flow` |

4 files, 16 insertions. No new script, no criterion changes, no prompt changes.

## Why

The Data Fabric connection `d61e5d0e` (`aditi.goyal@uipath.com`, folder `Shared`) was `State: Failed` with `403 Failed to receive access token` for the whole 2026-09-09 05:00 eval window. Three tasks scored **FAILURE against the skill** for it:

- Every `query-entity-records` element faulted `[102002] Integration Services operation failed`.
- `node configure` refused the compiled filter with a message blaming field ids and case sensitivity. Both agents followed that advice, re-read a correct entity schema, then **stripped the filter** to get past the refusal and shipped a `limit: 1000` whole-entity scan.

Re-sending the same `--detail` against the now-healthy connection compiles `queryExpression: "invoiceNumber = '{var_...}'"` unchanged. That places the cause on the connection, not the filter tree.

`slack_channel_description` resolved `#office-bellevue` through the `IsDefault` connection in `Shared`, which reaches a workspace without the channel. That is the same misdiagnosis `preflight_connections.py` already records in its docstring for the simulated arm.

A `pre_run` failure lands `FinalStatus.ERROR`, so these four now report an environment failure with the connection named, instead of a skill defect.

## Selector choices

- **Data Service bare, not folder-pinned.** One DS connection serves the tenant, and the `BillingDispute*` entities are tenant-scoped, so any live DS connection reaches them. Bare survives a folder move.
- **Slack pinned to `uipath-maestro-flow`.** Matches what `slack_channel_description_simulated` already pins. Verified: `#office-bellevue` (`C0B50H7DE2F`, `purpose.value` = the address the checker asserts) is reachable from `849e85d8@uipath-maestro-flow` and `e03f734e@uipath-maestro-case`, but not from the `IsDefault` connection in `Shared`.

## Verification

- All four YAMLs parse; `pre_run`, `initial_prompt`, `success_criteria` intact.
- Both selectors exit 0 against the live tenant:
  - `OK: uipath-uipath-dataservice — aditi.goyal@uipath.com (d61e5d0e…) live`
  - `OK: uipath-salesforce-slack — is-sandboxes (849e85d8…) live in folder 'uipath-maestro-flow'`
- Negative path exercised with a real `Failed` connection (`uipath-salesforce-slack=SlackEmojiListTest`): exit 1, `TENANT NOT READY — this is an environment failure, not an agent failure.` That is the exact state the DS connection was in at 04:54.
- `pre_run` runs outside the `task_timeout` watchdog (`test_criterion_budgets.py:546`), so criterion budgets are unaffected. No guard test inspects `pre_run`; the "sync gate" named in the YAML headers is a comment with no implementation in this repo.
- Placement, quoting and `timeout: 120` copied from the three existing call sites (`outlook_trigger_inbox`, `generic_dynamic_node`, `slack_channel_description_simulated`).

## Out of scope

- `billing_dispute_resolution` also depends on an IxP model, an API workflow, and a context index. `preflight_connections.py` covers IS connections only, so those fixtures stay ungated.
- Re-auth ownership is unresolved. The connection belongs to `aditi.goyal@uipath.com`, the eval bot cannot re-authenticate it, and `uip is connections create` needs a browser. This PR converts the misdiagnosis into a clear ERROR; it does not stop the outage. A bot-owned Data Fabric connection is the durable fix.
- About 40 other `uipath-maestro-flow` tasks name a connector key and have no preflight. Largest clusters: `connector_features/datafabric_connector` (12, the same connection that just broke), `jira` (7), `testmanager` (7), `slack` (4), `outlook365` (2). Deliberately left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
