### PR TITLE
fix(tests): preflight the datafabric connector suite, repin outlook to its mailbox

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/contractregistry_crud_filters.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/contractregistry_crud_filters.yaml
@@ -11,6 +11,8 @@ run_limits:
   task_timeout: 3600
 
 pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/ensure_entity.py" "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/contract_registry.entity.json"'
     timeout: 60
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/e2e_contract_intake_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/e2e_contract_intake_pipeline.yaml
@@ -16,6 +16,8 @@ run_limits:
   task_timeout: 2400
 
 pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/ensure_entity.py" "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/contract_registry.entity.json"'
     timeout: 60
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/integration_create_get.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/integration_create_get.yaml
@@ -14,6 +14,8 @@ run_limits:
   turn_timeout: 1200
 
 pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/ensure_entity.py" "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/flow_code_eval_entity.entity.json"'
     timeout: 60
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_create_all_types.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_create_all_types.yaml
@@ -13,6 +13,8 @@ run_limits:
   task_timeout: 3600
 
 pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/ensure_entity.py" "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/flow_code_eval_entity.entity.json"'
     timeout: 60
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_error.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_error.yaml
@@ -10,6 +10,8 @@ run_limits:
   task_timeout: 2400
 
 pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/ensure_entity.py" "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/flow_code_eval_entity.entity.json"'
     timeout: 60
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_file_activities.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_file_activities.yaml
@@ -15,6 +15,8 @@ run_limits:
   task_timeout: 5400
 
 pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/ensure_entity.py" "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/flow_code_eval_entity.entity.json"'
     timeout: 60
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_query.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_query.yaml
@@ -11,6 +11,8 @@ run_limits:
   task_timeout: 3600
 
 pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/ensure_entity.py" "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/flow_code_eval_entity.entity.json"'
     timeout: 60
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/seed_flow_code_eval_records.py"'

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_update.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_update.yaml
@@ -13,6 +13,8 @@ run_limits:
   task_timeout: 3600
 
 pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/ensure_entity.py" "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/flow_code_eval_entity.entity.json"'
     timeout: 60
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_update_existing_flow.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_update_existing_flow.yaml
@@ -13,6 +13,8 @@ run_limits:
   task_timeout: 2400
 
 pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/ensure_entity.py" "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/flow_code_eval_entity.entity.json"'
     timeout: 60
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/scaffold_movie_report_flow.py"'

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/trigger_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/trigger_lifecycle.yaml
@@ -12,6 +12,8 @@ run_limits:
   task_timeout: 3600
 
 pre_run:
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
+    timeout: 120
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/ensure_entity.py" "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/contract_registry.entity.json"'
     timeout: 60
 

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -45,7 +45,7 @@ initial_prompt: |
   decision, assumption, and blocked step in your final response. Instructions in
   the task take precedence over this paragraph.
 pre_run:
-  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-microsoft-outlook365'
+  - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-microsoft-outlook365=uipath-maestro-flow'
     timeout: 120
 
 success_criteria:


### PR DESCRIPTION
Follow-up to #3168. Same failure mode, same connection.

## What

- Adds the `_shared/preflight_connections.py` gate to **10** `connector_features/datafabric_connector` tasks, selector `uipath-uipath-dataservice`.
- Repins `single_node/outlook_trigger_inbox` from a bare selector to `uipath-microsoft-outlook365=uipath-maestro-flow`.

11 files, 21 insertions, 1 deletion. No new script, no criterion changes, no prompt changes.

## Why the datafabric suite

All ten author or grade a `uipath-uipath-dataservice` node against connection `d61e5d0e`, which was `State: Failed` on 2026-09-09 and took three e2e tasks down with it in #3168.

Only four of the ten run `flow debug`. The other six grade a compiled `queryExpression` or a configured node, and `node configure` reaches the connector over the wire to compile the filter and cache the schema. A dead connection fails those offline structural checks too. **"Grades a live run" is the wrong filter for who needs this gate**, which is worth stating plainly since it is the thing I got wrong first time.

Ordering: the preflight goes **first** in `pre_run`, ahead of `ensure_entity.py` and the record seeders. Those go through the Data Fabric API and succeed while the IS connection is down, so running them first only burns setup before the real blocker surfaces.

### Excluded

`smoke_activation_positive` and `smoke_activation_negative`. Both grade `skill_triggered` advisories at `pass_threshold: 0.0` and never touch a connection. They are skill-routing tests, not connector tests.

## Why the outlook repin

`outlook_trigger_inbox` has carried a bare selector since it was added, and the bare form picks the wrong mailbox:

```
$ preflight_connections.py uipath-microsoft-outlook365
OK: … — Productivity O365 Outlook (5af6fa90…) live

$ preflight_connections.py uipath-microsoft-outlook365=uipath-maestro-flow
OK: … — is-sandboxes-test@uipathsandboxes.onmicrosoft.com (75dfafb4…) live in folder 'uipath-maestro-flow'
```

The tenant has three Enabled Outlook connections. `Productivity O365 Outlook` in `Shared` is a different mailbox from the sandbox one the task's Inbox fixture lives in, so the bare gate passes while the task stays unwinnable. That is exactly the trap the `=<folder>` form was added for, and this task's own header already records the receiving mailbox as unreliable.

This is the general shape of it: **bare is only safe when the connector has exactly one connection tenant-wide.** True for dataservice, jira, and testmanager. Not true for slack, outlook365, or google-drive, which have two or three across folders with a fixture-less default.

## Verification

- All 13 touched or adjacent YAMLs parse; every patched file has the preflight as `pre_run[0]`, and the two excluded ones still have no `pre_run`.
- Both selectors exit 0 against the live tenant, with the contrast above showing the repin resolves a different connection than the bare form it replaces.
- `pre_run` runs outside the `task_timeout` watchdog (`test_criterion_budgets.py:546`), so criterion budgets are unaffected.

## Still open

- The script lives in `tests/tasks/uipath-maestro-flow/_shared/`. Extending to `uipath-platform`, `uipath-api-workflow`, `uipath-maestro-case` or `uipath-maestro-bpmn` means those suites reaching into maestro-flow's private dir. Wants a `tests/tasks/_shared` first.
- It only asserts "at least one live connection". The `bindings/` family needs more: `reconfigure_different_connection` needs two connections of one key, `multi_connector_independence` needs two different keys.
- Remaining candidates, deliberately not in this PR: slack (6, all folder-pinned), outlook (3 more), jira (~8), testmanager (~14 across two suites), plus one-offs for sfdc, azureactivedirectory, gmail and jdbc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
