### PR TITLE
cherry-pick(release/v1.201): replace stale nested-root caseplan.json test seeds with a real fixture

### DIFF
--- a/tests/tasks/uipath-human-in-the-loop/quality_12_case_path_selection.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_12_case_path_selection.yaml
@@ -12,6 +12,9 @@ agent:
 
 sandbox:
   python: {}
+  template_sources:
+    - type: template_dir
+      path: templates/case_single_stage_no_app
 
 initial_prompt: |
   I have a UiPath case management project. Our agent extracts vendor
@@ -20,99 +23,13 @@ initial_prompt: |
   the missing fields and submit. I do NOT have a deployed Action Center
   app for this — please use whatever approach works without one.
 
-  First, create the starting caseplan.json at ./caseplan.json:
-
-  {
-    "root": {
-      "id": "root",
-      "name": "Vendor Enrichment Case",
-      "type": "case-management:root",
-      "caseIdentifier": "VEN",
-      "caseAppEnabled": false,
-      "caseIdentifierType": "constant",
-      "version": "v19",
-      "publishVersion": 2,
-      "data": {
-        "intsvcActivityConfig": "v2",
-        "uipath": {
-          "variables": {
-            "inputs": [
-              { "id": "var_rawExtract", "name": "rawExtract", "type": "string" }
-            ],
-            "outputs": [],
-            "inputOutputs": []
-          },
-          "bindings": []
-        }
-      },
-      "description": "Vendor data enrichment case"
-    },
-    "nodes": [
-      {
-        "id": "trigger_xY2mNp",
-        "type": "case-management:Trigger",
-        "position": { "x": 200, "y": 0 },
-        "data": { "label": "Start" }
-      },
-      {
-        "id": "Stage_aB3kL9",
-        "type": "case-management:Stage",
-        "position": { "x": 100, "y": 200 },
-        "style": { "width": 304, "opacity": 0.8 },
-        "measured": { "width": 304, "height": 128 },
-        "width": 304,
-        "zIndex": 1001,
-        "data": {
-          "label": "Enrich",
-          "parentElement": { "id": "root", "type": "case-management:root" },
-          "isInvalidDropTarget": false,
-          "isPendingParent": false,
-          "entryConditions": [
-            {
-              "id": "Condition_uqCYDc",
-              "displayName": "Case Entered",
-              "rules": [ [ { "id": "Rule_GGCJC6", "rule": "case-entered" } ] ]
-            }
-          ],
-          "exitConditions": [
-            {
-              "id": "Condition_FSPwx7",
-              "displayName": "Stage Done",
-              "rules": [ [ { "id": "Rule_M3P1RF", "rule": "required-tasks-completed" } ] ],
-              "marksStageComplete": true
-            }
-          ],
-          "tasks": []
-        }
-      }
-    ],
-    "edges": [
-      {
-        "id": "edge_Qz7hVr",
-        "type": "case-management:TriggerEdge",
-        "source": "trigger_xY2mNp",
-        "target": "Stage_aB3kL9",
-        "sourceHandle": "trigger_xY2mNp____source____right",
-        "targetHandle": "Stage_aB3kL9____target____left",
-        "data": {}
-      }
-    ],
-    "metadata": {
-      "caseExitRules": [
-        {
-          "id": "Condition_xC1XyX",
-          "displayName": "Case resolved",
-          "marksCaseComplete": true,
-          "rules": [
-            [ { "id": "Rule_jdBFrJ", "rule": "required-stages-completed" } ]
-          ]
-        }
-      ]
-    }
-  }
+  The starting caseplan.json already exists on disk at ./caseplan.json.
+  It has one stage (Stage_aB3kL9, "Review") and no HITL task yet.
 
   Add a HITL action task to Stage_aB3kL9. The reviewer:
-    - sees the raw extract from the agent (read-only, bound to vars.var_rawExtract)
+    - sees the raw extract from the agent (read-only, bound to an
+      existing case variable — read the available variables from
+      caseplan.json)
     - fills in vendorName (text, required) and costCenter (text, required)
     - clicks Submit
 

--- a/tests/tasks/uipath-human-in-the-loop/smoke_09_case_quickform.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_09_case_quickform.yaml
@@ -8,6 +8,9 @@ tags: [uipath-human-in-the-loop, smoke, lifecycle:edit, node:hitl, feature:appro
 
 sandbox:
   python: {}
+  template_sources:
+    - type: template_dir
+      path: templates/case_single_stage_no_app
 
 initial_prompt: |
   I have a UiPath case management project with a caseplan.json that has
@@ -15,97 +18,10 @@ initial_prompt: |
   using the QuickForm path (separate .hitl.json schema file — no deployed
   Action Center app needed).
 
-  First, create the starting caseplan.json at ./caseplan.json:
-
-  {
-    "root": {
-      "id": "root",
-      "name": "Invoice Review Case",
-      "type": "case-management:root",
-      "caseIdentifier": "INV",
-      "caseAppEnabled": false,
-      "caseIdentifierType": "constant",
-      "version": "v19",
-      "publishVersion": 2,
-      "data": {
-        "intsvcActivityConfig": "v2",
-        "uipath": {
-          "variables": {
-            "inputs": [
-              { "id": "var_invoiceId", "name": "invoiceId", "type": "string" },
-              { "id": "var_amount", "name": "amount", "type": "number" }
-            ],
-            "outputs": [],
-            "inputOutputs": []
-          },
-          "bindings": []
-        }
-      },
-      "description": "Invoice review case"
-    },
-    "nodes": [
-      {
-        "id": "trigger_xY2mNp",
-        "type": "case-management:Trigger",
-        "position": { "x": 200, "y": 0 },
-        "data": { "label": "Start" }
-      },
-      {
-        "id": "Stage_aB3kL9",
-        "type": "case-management:Stage",
-        "position": { "x": 100, "y": 200 },
-        "style": { "width": 304, "opacity": 0.8 },
-        "measured": { "width": 304, "height": 128 },
-        "width": 304,
-        "zIndex": 1001,
-        "data": {
-          "label": "Review",
-          "parentElement": { "id": "root", "type": "case-management:root" },
-          "isInvalidDropTarget": false,
-          "isPendingParent": false,
-          "entryConditions": [
-            {
-              "id": "Condition_uqCYDc",
-              "displayName": "Case Entered",
-              "rules": [ [ { "id": "Rule_GGCJC6", "rule": "case-entered" } ] ]
-            }
-          ],
-          "exitConditions": [
-            {
-              "id": "Condition_FSPwx7",
-              "displayName": "Stage Done",
-              "rules": [ [ { "id": "Rule_M3P1RF", "rule": "required-tasks-completed" } ] ],
-              "marksStageComplete": true
-            }
-          ],
-          "tasks": []
-        }
-      }
-    ],
-    "edges": [
-      {
-        "id": "edge_Qz7hVr",
-        "type": "case-management:TriggerEdge",
-        "source": "trigger_xY2mNp",
-        "target": "Stage_aB3kL9",
-        "sourceHandle": "trigger_xY2mNp____source____right",
-        "targetHandle": "Stage_aB3kL9____target____left",
-        "data": {}
-      }
-    ],
-    "metadata": {
-      "caseExitRules": [
-        {
-          "id": "Condition_xC1XyX",
-          "displayName": "Case resolved",
-          "marksCaseComplete": true,
-          "rules": [
-            [ { "id": "Rule_jdBFrJ", "rule": "required-stages-completed" } ]
-          ]
-        }
-      ]
-    }
-  }
+  The starting caseplan.json already exists on disk at ./caseplan.json.
+  It has one stage (Stage_aB3kL9, "Review") with no HITL task yet, and
+  declares two case variables: invoiceId (string, id var_invoiceId) and
+  amount (number, id var_amount).
 
   Now add a QuickForm action task to Stage_aB3kL9:
   - Reviewer sees: invoiceId (text, bound to vars.var_invoiceId) and

--- a/tests/tasks/uipath-human-in-the-loop/templates/case_single_stage_no_app/caseplan.json
+++ b/tests/tasks/uipath-human-in-the-loop/templates/case_single_stage_no_app/caseplan.json
@@ -1,0 +1,108 @@
+{
+    "id": "case-HuBt1LqApp",
+    "version": "30.0.0",
+    "name": "HITL Case Fixture",
+    "description": "Bare case (no HITL task yet, no deployed Action Center app) for HITL case-surface tests: one stage, two case variables.",
+    "metadata": {
+        "caseIdentifier": "HITL",
+        "caseIdentifierType": "constant",
+        "caseAppEnabled": false,
+        "publishVersion": 2,
+        "caseExitRules": [
+            {
+                "id": "Condition_xC1XyX",
+                "displayName": "Case Resolved",
+                "marksCaseComplete": true,
+                "rules": [
+                    [
+                        {
+                            "id": "Rule_jdBFrJ",
+                            "rule": "required-stages-completed"
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    "bindings": [],
+    "variables": {
+        "inputOutputs": [
+            {
+                "id": "var_invoiceId",
+                "name": "invoiceId",
+                "type": "string",
+                "custom": true,
+                "elementId": "root"
+            },
+            {
+                "id": "var_amount",
+                "name": "amount",
+                "type": "number",
+                "custom": true,
+                "elementId": "root"
+            }
+        ]
+    },
+    "nodes": [
+        {
+            "id": "trigger_1",
+            "type": "uipath.case.trigger",
+            "data": {
+                "typeVersion": "1.0.0",
+                "display": {
+                    "label": "Trigger 1"
+                },
+                "inputs": {
+                    "serviceType": "None"
+                }
+            }
+        },
+        {
+            "id": "Stage_aB3kL9",
+            "type": "case-management:Stage",
+            "data": {
+                "label": "Review",
+                "parentElement": {
+                    "id": "root",
+                    "type": "case-management:root"
+                },
+                "isInvalidDropTarget": false,
+                "isPendingParent": false,
+                "isRequired": true,
+                "entryConditions": [
+                    {
+                        "id": "Condition_uqCYDc",
+                        "displayName": "Case Entered",
+                        "isInterrupting": false,
+                        "rules": [
+                            [
+                                {
+                                    "id": "Rule_GGCJC6",
+                                    "rule": "case-entered"
+                                }
+                            ]
+                        ]
+                    }
+                ],
+                "exitConditions": [
+                    {
+                        "id": "Condition_FSPwx7",
+                        "displayName": "Stage Done",
+                        "type": "exit-only",
+                        "marksStageComplete": true,
+                        "rules": [
+                            [
+                                {
+                                    "id": "Rule_M3P1RF",
+                                    "rule": "required-tasks-completed"
+                                }
+                            ]
+                        ]
+                    }
+                ],
+                "tasks": []
+            }
+        }
+    ],
+    "edges": []
+}


### PR DESCRIPTION
Cherry-pick of #3173 onto release/v1.201. Clean cherry-pick, no conflicts.

See #3173 for the full explanation and verification steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)