### PR TITLE
fix(uipath-planner): gate Activation Mode against its entry rule in a…

### DIFF
--- a/skills/uipath-planner/scripts/case/audit_sdd.py
+++ b/skills/uipath-planner/scripts/case/audit_sdd.py
@@ -66,6 +66,26 @@ TASK_DETAIL_MARKERS = {
     "api-workflow": ("Process / Agent / RPA / API Workflow Task Detail", "**Resolved Resource:**"),
 }
 
+# Activation Mode -> the entry rule(s) that mode MUST produce
+# (case-design-layers-guide.md § Sequencing & activation).
+# Presence, not exclusivity: a fan-in convergence task legally ORs one
+# `selected-tasks-completed` row per branch WITH a `current-stage-entered` +
+# inverse-guard row for the no-branch path.
+MODE_ENTRY_RULES = {
+    "sequential": ("runs-sequentially",),
+    "parallel-after-predecessor": ("runs-sequentially",),
+    "parallel": ("current-stage-entered",),
+    "event-triggered": ("wait-for-connector", "sla-status-change"),
+    "adhoc": ("adhoc",),
+    "fan-in": ("selected-tasks-completed",),
+    "conditional-gate": ("selected-tasks-completed",),
+}
+
+# Modes that express order through task-set placement, never through a gate on the
+# immediate predecessor ("Never duplicate selected-tasks-completed("<previous>")
+# to express simple order" — same guide section).
+MODES_WITHOUT_TASK_GATES = ("sequential", "parallel-after-predecessor")
+
 CASE_VARIABLES_HEADER = "| Name | Category | Type | sourceTriggers | sourceFields | Default | Description |"
 
 STAGE_HEADING = re.compile(r"^###\s+(Stage\s+\d+|Secondary Stage):\s*(.+?)\s*$", re.M)
@@ -583,6 +603,29 @@ def contract_findings(text: str, facts: dict) -> list[str]:
                     rule = rule_name(cells[0])
                     if rule and rule not in task_entry_legal and (rule in facts["yes_when"] | facts["no_when"] | stage_entry_legal):
                         findings.append(f"task {task_name!r}: entry WHEN {rule!r} is not a legal task-entry rule (case-design-layers-guide.md § Lifecycle gates)")
+
+            # Activation Mode must produce its own entry rule. The label alone is inert:
+            # a task can read `parallel-after-predecessor` while its WHEN translates the
+            # requirement phrase ("after Collect Fees") into a predecessor gate, which
+            # emits separate event-driven tasks instead of one shared task set.
+            mode_marker = re.search(r"^\*\*Activation Mode:\*\*\s*(.+?)\s*$", task_block, re.M)
+            mode = mode_marker.group(1).strip().strip("`").strip() if mode_marker else ""
+            expected = MODE_ENTRY_RULES.get(mode)
+            if expected and entry_tbl:
+                rules = {rule_name(cells[0]) for _, cells in table_rows(entry_tbl.group(1))}
+                rules.discard(None)
+                if not rules & set(expected):
+                    findings.append(
+                        f"task {task_name!r}: Activation Mode {mode!r} has no {' or '.join(expected)} entry row "
+                        f"(found: {', '.join(sorted(rules)) or 'none'}) — the mode label does not sequence the task, "
+                        "its entry rule does (case-design-layers-guide.md § Sequencing & activation)"
+                    )
+                if mode in MODES_WITHOUT_TASK_GATES and "selected-tasks-completed" in rules:
+                    findings.append(
+                        f"task {task_name!r}: Activation Mode {mode!r} gates on selected-tasks-completed — order comes "
+                        "from task-set placement, not a gate on the immediate predecessor; duplicating that gate across "
+                        "siblings emits them as separate task sets instead of one parallel set"
+                    )
             recipient = re.search(r"^\*\*Recipient:\*\*\s*([^\n]+)", task_block, re.M)
             if recipient:
                 value = recipient.group(1).strip().strip("`")

--- a/tests/scripts/test_audit_sdd_activation_mode_rule.py
+++ b/tests/scripts/test_audit_sdd_activation_mode_rule.py
@@ -1,0 +1,135 @@
+"""Guard: a task's Activation Mode must produce the entry rule that mode implies.
+
+`skills/uipath-planner/scripts/case/audit_sdd.py` is the design lane's gate. The
+mode->rule table in case-design-layers-guide.md § Sequencing & activation was read
+in full by the agent on run skill-case-phase-0-case-reasoning-regressions/00 and
+still violated: every Activation Mode label was correct while not one entry rule
+matched it (0 `runs-sequentially` rows in a 716-line SDD). The agent had
+translated the requirement phrases positionally instead — "stage enters" ->
+`current-stage-entered`, "after Collect Fees" ->
+`selected-tasks-completed("Collect Fees")` — which emits the two
+parallel-after-predecessor siblings as separate event-driven tasks rather than
+one shared task set. It then self-verified with this auditor, got AUDIT OK, and
+stopped. Re-reading the guide cannot fix what re-reading the guide already
+failed to prevent; a gate names the contradiction at the point of repair.
+
+    python3 -m pytest tests/scripts/test_audit_sdd_activation_mode_rule.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+AUDIT = REPO / "skills" / "uipath-planner" / "scripts" / "case" / "audit_sdd.py"
+
+spec = importlib.util.spec_from_file_location("audit_sdd", AUDIT)
+audit_sdd = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(audit_sdd)
+
+
+def _sdd(*tasks: str) -> str:
+    body = "".join(tasks)
+    return f"""### Stage 1: Issuing Permit
+
+**Type:** Primary
+
+#### Tasks
+{body}"""
+
+
+def _task(name: str, mode: str, *entry_rows: str) -> str:
+    rows = "\n".join(f"| {row} | — | Entry Rule |" for row in entry_rows)
+    return f"""
+##### Task 1.1: {name}
+
+**Type:** process
+**Activation Mode:** {mode}
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+{rows}
+
+**Task envelope**
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | Yes | — |
+"""
+
+
+def _mode_findings(text: str) -> list[str]:
+    return [
+        f
+        for f in audit_sdd.contract_findings(text, {})
+        if "Activation Mode" in f
+        and ("entry row" in f or "gates on selected-tasks-completed" in f)
+    ]
+
+
+def test_parallel_after_predecessor_gated_on_its_predecessor_is_flagged():
+    """The observed defect: the mode label is right, the rule translates the phrase."""
+    text = _sdd(
+        _task(
+            "Wait for Payment Confirmation",
+            "parallel-after-predecessor",
+            'selected-tasks-completed("Collect Fees")',
+        )
+    )
+    findings = _mode_findings(text)
+    assert findings, "a predecessor gate under parallel-after-predecessor must be reported"
+    assert any("gates on selected-tasks-completed" in f for f in findings), findings
+    assert all("Wait for Payment Confirmation" in f for f in findings), findings
+
+
+def test_parallel_after_predecessor_on_the_shared_task_set_is_clean():
+    """The negative control: the correct authoring must not be flagged."""
+    text = _sdd(_task("Payment Deadline", "parallel-after-predecessor", "runs-sequentially"))
+    assert _mode_findings(text) == []
+
+
+def test_sequential_first_in_run_needs_runs_sequentially():
+    """`runs-sequentially` goes on EVERY task in the run, including the first."""
+    text = _sdd(_task("Collect Fees", "sequential", "current-stage-entered"))
+    findings = _mode_findings(text)
+    assert findings, "a sequential task entering on stage entry must be reported"
+    assert "no runs-sequentially entry row" in findings[0], findings
+
+
+def test_each_mode_paired_with_its_own_rule_is_clean():
+    """Every row of the guide's mode->rule table, authored correctly."""
+    pairs = [
+        ("sequential", "runs-sequentially"),
+        ("parallel-after-predecessor", "runs-sequentially"),
+        ("parallel", "current-stage-entered"),
+        ("event-triggered", 'wait-for-connector("Payment Confirmed")'),
+        ("adhoc", "adhoc"),
+        ("fan-in", 'selected-tasks-completed("Score", "Verify")'),
+        ("conditional-gate", 'selected-tasks-completed("Wait for Payment Confirmation")'),
+    ]
+    for mode, rule in pairs:
+        assert _mode_findings(_sdd(_task("T", mode, rule))) == [], f"{mode} + {rule}"
+
+
+def test_fan_in_may_or_branches_with_a_no_branch_path():
+    """Presence, not exclusivity — a convergence task legally carries both rules."""
+    text = _sdd(
+        _task(
+            "Resolve Outcome",
+            "fan-in",
+            'selected-tasks-completed("Approve")',
+            'selected-tasks-completed("Reject")',
+            "current-stage-entered",
+        )
+    )
+    assert _mode_findings(text) == []
+
+
+def test_an_unknown_or_placeholder_mode_is_not_graded():
+    """The template ships `<sequential | parallel | ...>`; a placeholder is not a defect."""
+    text = _sdd(_task("T", "<sequential \\| parallel \\| adhoc>", "current-stage-entered"))
+    assert _mode_findings(text) == []

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
@@ -216,7 +216,7 @@ initial_prompt: |
 
   ### Stage 4: Join (`join`)
   **Type:** Stage
-  **Description:** Joins both branches; activates after BOTH upstream branches have completed.
+  **Description:** Fan-in stage downstream of both parallel branches; carries one entry row per upstream branch.
   **Required for Case Completion:** Yes
   #### Stage Entry Conditions
   | WHEN | IF | Interrupting |

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
@@ -216,7 +216,7 @@ initial_prompt: |
 
   ### Stage 4: Join (`join`)
   **Type:** Stage
-  **Description:** Fan-in stage downstream of both parallel branches; carries one entry row per upstream branch.
+  **Description:** Joins both branches; activates after BOTH upstream branches have completed.
   **Required for Case Completion:** Yes
   #### Stage Entry Conditions
   | WHEN | IF | Interrupting |


### PR DESCRIPTION
fix(uipath-planner): gate Activation Mode against its entry rule in audit_sdd

skill-case-phase-0-case-reasoning-regressions scored 0.125 on an SDD whose
Activation Mode labels were all correct and whose entry rules matched none of
them — zero `runs-sequentially` rows in 716 lines. The agent translated the
requirement phrases positionally instead ("stage enters" -> current-stage-entered,
"after Collect Fees" -> selected-tasks-completed("Collect Fees")), which emits the
two parallel-after-predecessor payment siblings as separate event-driven tasks
rather than one shared task set.

That run read the mode->rule table in case-design-layers-guide.md § Sequencing &
activation in full and violated it anyway, so restating the rule in the guide
cannot help. audit_sdd.py is what the agent actually consults: it ran twice,
printed AUDIT OK, and the run stopped there. It checked selected-tasks-completed
scope (adhoc target, cross-stage target) but never whether a mode produced its
own rule.

MODE_ENTRY_RULES encodes the table; contract_findings now reports an Activation
Mode with no matching entry row, plus sequential / parallel-after-predecessor
gating on selected-tasks-completed. Presence, not exclusivity — a fan-in
convergence task legally ORs one gate per branch with a current-stage-entered
no-branch row.

The gate is satisfiable and agrees with the eval checker: repairing the failing
SDD until AUDIT OK also makes check_case_reasoning_regressions.py pass. Swept
every SDD in the repo — no existing finding lost, no new finding in any
tests/tasks fixture or skill template.