### PR TITLE
test(case): fix case-multi-fan-in-join test

### DIFF
--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
@@ -216,7 +216,7 @@ initial_prompt: |
 
   ### Stage 4: Join (`join`)
   **Type:** Stage
-  **Description:** Joins both branches; activates after BOTH upstream branches have completed.
+  **Description:** Fan-in stage downstream of both parallel branches; carries one entry row per upstream branch.
   **Required for Case Completion:** Yes
   #### Stage Entry Conditions
   | WHEN | IF | Interrupting |


### PR DESCRIPTION
What changed and why: 
the Join stage's description was the only place in the SDD claiming AND-gating ("activates after BOTH upstream branches have completed"). Since separate objects in entryConditions[] are OR'd, that prose told the agent the two-row table was wrong and the correct build was one merged AND condition — which is exactly what it produced. The new wording describes the fan-in structurally without asserting gating semantics, so the two-row table is the only shape signal left.

I deliberately did not add a hint like "two separate conditions, not one merged AND rule" — the skill already states that rule at [impl-json.md:30], and spelling it out in the SDD would be teaching to the test rather than exercising the skill.

Verified: 
YAML still parses (2 success criteria intact). 
https://github.com/UiPath/skills/actions/runs/34416772187
https://github.com/UiPath/skills/actions/runs/34416751413
