### PR TITLE
fix(uipath-planner): rename the <SYSTEM> placeholder in the SDD templates

### DIFF
--- a/skills/uipath-planner/assets/templates/agent-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/agent-sdd-template.md
@@ -295,7 +295,7 @@ flowchart LR
 
 | Connector | System | Access Method | Used By |
 |---|---|---|---|
-| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <TOOLS> |
+| <CONNECTOR_NAME> | <SYSTEM_NAME> | <ACCESS_METHOD> | <TOOLS> |
 
 ### IXP / Document Understanding Models
 

--- a/skills/uipath-planner/assets/templates/api-workflow-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/api-workflow-sdd-template.md
@@ -210,7 +210,7 @@ flowchart LR
 
 | Connector | System | Access Method | Used By |
 |---|---|---|---|
-| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <STEPS> |
+| <CONNECTOR_NAME> | <SYSTEM_NAME> | <ACCESS_METHOD> | <STEPS> |
 
 ---
 

--- a/skills/uipath-planner/assets/templates/bpmn-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/bpmn-sdd-template.md
@@ -267,7 +267,7 @@ flowchart LR
 
 | Connector | System | Access Method | Used By |
 |---|---|---|---|
-| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <NODES> |
+| <CONNECTOR_NAME> | <SYSTEM_NAME> | <ACCESS_METHOD> | <NODES> |
 
 ### IXP / Document Understanding Models
 

--- a/skills/uipath-planner/assets/templates/coded-app-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/coded-app-sdd-template.md
@@ -202,7 +202,7 @@ See sdd-generation-guide.md Phase 3 Step 2 item 4 for the format spec.
 
 | Connector | System | Access Method | Used By |
 |---|---|---|---|
-| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <PAGES_OR_COMPONENTS> |
+| <CONNECTOR_NAME> | <SYSTEM_NAME> | <ACCESS_METHOD> | <PAGES_OR_COMPONENTS> |
 
 ---
 

--- a/skills/uipath-planner/assets/templates/flow-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/flow-sdd-template.md
@@ -228,7 +228,7 @@ flowchart LR
 
 | Connector | System | Access Method | Used By |
 |---|---|---|---|
-| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <NODES> |
+| <CONNECTOR_NAME> | <SYSTEM_NAME> | <ACCESS_METHOD> | <NODES> |
 
 ### IXP / Document Understanding Models
 

--- a/skills/uipath-planner/assets/templates/rpa-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/rpa-sdd-template.md
@@ -332,7 +332,7 @@ public enum <EnumName>
 
 | Connector | System | Access Method | Used By |
 |---|---|---|---|
-| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <STEPS_OR_APPS> |
+| <CONNECTOR_NAME> | <SYSTEM_NAME> | <ACCESS_METHOD> | <STEPS_OR_APPS> |
 
 ### IXP / Document Understanding Models
 


### PR DESCRIPTION
> **Stacked on #3184** — review that one first; this PR's diff is the 6 template files only.

## What

`<SYSTEM>` → `<SYSTEM_NAME>` in the Integrations table placeholder row of all six product SDD templates (agent, api-workflow, bpmn, coded-app, flow, rpa).

```
| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <NODES> |     → <SYSTEM_NAME>
```

## Why

`<SYSTEM>` matches the injection scanner's XML-style system-tag pattern — `/<\s*\/?\s*system\s*>/i`, high, `promptInjectionDetector.ts:232`. Every read of those templates gets `⚠️ Security Notice` appended (`outputScanner.ts:193-199`), and a model that reads the notice as a stop signal refuses the run. This is the same failure mode as #3184 but on **agent / api-workflow / bpmn / coded-app / flow / rpa** SDD generation, not Case — the Case template writes `<target system>`, which does not match.

## Nothing consumes the placeholder

- `SYSTEM>` does not occur anywhere outside `assets/templates/` — checked scripts, tests, evals and the other skills.
- The SDD validators match section headings, not placeholder names (no `CONNECTOR_NAME` / `ACCESS_METHOD` reference in `skills/uipath-planner/scripts/` or `tests/`).
- `<SYSTEM_NAME>` is already the house placeholder style (`uipath-human-in-the-loop/references/hitl-node-apptask.md`, and elsewhere in `api-workflow-sdd-template.md`).
- Generated SDDs are unchanged — the authoring agent overwrites the row when it renders the Integrations section.

## Evidence

- Planner tree scan against the 33 shipped patterns: **11 → 2** with #3184 plus this PR. The 2 remaining are `sdd-viewer.html`'s functional `<script>` tags (host-side fix only).
- `node scripts/compose-skill-flavor.mjs validate` → OK · `node scripts/check-skill-links.mjs` → all 6780 links resolve.
- `skill-flavors/studioweb/uipath-planner/assets/templates/rpa-sdd-template.md` replaces only the `packaging-solution*` blocks, so the flavor inherits this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
