### PR TITLE
fix(uipath-planner): rename the <SYSTEM> placeholder in the SDD templates [CP to release/v1.201]

### DIFF
--- a/skills/uipath-planner/assets/templates/agent-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/agent-sdd-template.md
@@ -295,7 +295,7 @@ flowchart LR
 
 | Connector | System | Access Method | Used By |
 |---|---|---|---|
-| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <TOOLS> |
+| <CONNECTOR_NAME> | <SYSTEM_NAME> | <ACCESS_METHOD> | <TOOLS> |
 
 ### IXP / Document Understanding Models
 

--- a/skills/uipath-planner/assets/templates/api-workflow-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/api-workflow-sdd-template.md
@@ -210,7 +210,7 @@ flowchart LR
 
 | Connector | System | Access Method | Used By |
 |---|---|---|---|
-| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <STEPS> |
+| <CONNECTOR_NAME> | <SYSTEM_NAME> | <ACCESS_METHOD> | <STEPS> |
 
 ---
 

--- a/skills/uipath-planner/assets/templates/bpmn-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/bpmn-sdd-template.md
@@ -267,7 +267,7 @@ flowchart LR
 
 | Connector | System | Access Method | Used By |
 |---|---|---|---|
-| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <NODES> |
+| <CONNECTOR_NAME> | <SYSTEM_NAME> | <ACCESS_METHOD> | <NODES> |
 
 ### IXP / Document Understanding Models
 

--- a/skills/uipath-planner/assets/templates/coded-app-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/coded-app-sdd-template.md
@@ -202,7 +202,7 @@ See sdd-generation-guide.md Phase 3 Step 2 item 4 for the format spec.
 
 | Connector | System | Access Method | Used By |
 |---|---|---|---|
-| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <PAGES_OR_COMPONENTS> |
+| <CONNECTOR_NAME> | <SYSTEM_NAME> | <ACCESS_METHOD> | <PAGES_OR_COMPONENTS> |
 
 ---
 

--- a/skills/uipath-planner/assets/templates/flow-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/flow-sdd-template.md
@@ -228,7 +228,7 @@ flowchart LR
 
 | Connector | System | Access Method | Used By |
 |---|---|---|---|
-| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <NODES> |
+| <CONNECTOR_NAME> | <SYSTEM_NAME> | <ACCESS_METHOD> | <NODES> |
 
 ### IXP / Document Understanding Models
 

--- a/skills/uipath-planner/assets/templates/rpa-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/rpa-sdd-template.md
@@ -332,7 +332,7 @@ public enum <EnumName>
 
 | Connector | System | Access Method | Used By |
 |---|---|---|---|
-| <CONNECTOR_NAME> | <SYSTEM> | <ACCESS_METHOD> | <STEPS_OR_APPS> |
+| <CONNECTOR_NAME> | <SYSTEM_NAME> | <ACCESS_METHOD> | <STEPS_OR_APPS> |
 
 ### IXP / Document Understanding Models
 


### PR DESCRIPTION
> **Stacked on #3186** — merge that first; this diff is the 6 template files only.

Hotfix cherry-pick of **#3185** to `release/v1.201`. Clean cherry-pick, no conflicts.

## What

`<SYSTEM>` → `<SYSTEM_NAME>` in the Integrations placeholder row of the six product SDD templates (agent, api-workflow, bpmn, coded-app, flow, rpa).

## Why

`<SYSTEM>` matches `/<\s*\/?\s*system\s*>/i` (high, `promptInjectionDetector.ts:232`), so every read of those templates gets a security notice appended and the run can abort — the #3186 failure mode, on every product except Case (the Case template writes `<target system>`, which does not match).

## Nothing consumes it

`SYSTEM>` occurs nowhere outside `assets/templates/` — scripts, tests, evals and other skills checked. The SDD validators match section headings, not placeholder names. `<SYSTEM_NAME>` is already the house style. Generated SDDs are unchanged; the agent overwrites the row.

## Evidence

Planner tree scan against the 33 shipped patterns: 11 → 2 with #3186 plus this PR; the 2 left are `sdd-viewer.html`'s functional `<script>` tags, which need a host-side exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
