### PR TITLE
fix(case-tests): skeleton failures name the field that is actually checked

### DIFF
--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -196,7 +196,19 @@ def task_is_skeleton(task: dict) -> bool:
         from ``case spec``; always has ≥1 entry when the connector resolved)
     - ``action``: ``data.inputs`` present (bare ``taskTitle`` / ``priority`` is still skeleton-equivalent)
     - everything else (``process`` / ``agent`` / ``rpa`` / ``api-workflow`` / ``case-management``):
-      ``data.name`` AND ``data.folderPath`` (both as ``=bindings.<id>`` refs)
+      ``data.name`` AND ``data.folderPath``, both non-empty.
+
+    Only presence is checked, not spelling. ``uip maestro case tasks add``
+    writes these as ``=bindings.<id>`` references and registers the matching
+    entries in ``plan.bindings[]``; a literal name/path also passes here. If
+    the runtime turns out to require the binding indirection, this predicate is
+    too weak — but tightening it is a behavioural claim to verify against the
+    product first, not a spelling preference to assert here.
+
+    Note this says nothing about ``taskTypeId``. That is an argument to
+    ``tasks add --task-type-id``, used to look the resource up and enrich the
+    task; the id itself is never persisted to the document, so no caseplan
+    assertion should reference it.
     """
     data = task.get("data") or {}
     if not data:

--- a/tests/tasks/uipath-maestro-case/single_node/agent/check_agent_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/check_agent_case.py
@@ -16,8 +16,9 @@ def main():
     task = assert_task_type_present("agent")
     if task_is_skeleton(task):
         sys.exit(
-            "FAIL: agent task is a skeleton — debug requires a resolved "
-            "CountLetters registry entry with a real taskTypeId"
+            "FAIL: agent task is a skeleton — data.name and data.folderPath "
+            "are unset. Resolve the CountLetters registry entry and wire it "
+            "into the task; debug cannot run against an unwired reference."
         )
     run_debug(timeout=600)
     print(

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/check_api_workflow_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/check_api_workflow_case.py
@@ -17,8 +17,9 @@ def main():
     task = assert_task_type_present("api-workflow")
     if task_is_skeleton(task):
         sys.exit(
-            "FAIL: api-workflow task is a skeleton — debug requires a "
-            "resolved name-to-age registry entry with a real taskTypeId"
+            "FAIL: api-workflow task is a skeleton — data.name and "
+            "data.folderPath are unset. Resolve the name-to-age registry entry and "
+            "wire it into the task; debug cannot run against an unwired reference."
         )
     run_debug(timeout=540)
     print(

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/check_case_management_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/check_case_management_case.py
@@ -17,8 +17,9 @@ def main():
     task = assert_task_type_present("case-management")
     if task_is_skeleton(task):
         sys.exit(
-            "FAIL: case-management task is a skeleton — debug requires a "
-            "resolved CaseTest registry entry with a real taskTypeId"
+            "FAIL: case-management task is a skeleton — data.name and "
+            "data.folderPath are unset. Resolve the CaseTest registry entry and "
+            "wire it into the task; debug cannot run against an unwired reference."
         )
     run_debug(timeout=540)
     print(

--- a/tests/tasks/uipath-maestro-case/single_node/process/check_process_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/process/check_process_case.py
@@ -16,8 +16,9 @@ def main():
     task = assert_task_type_present("process")
     if task_is_skeleton(task):
         sys.exit(
-            "FAIL: process task is a skeleton — debug requires a resolved "
-            "ProcurementProcess registry entry with a real taskTypeId"
+            "FAIL: process task is a skeleton — data.name and data.folderPath "
+            "are unset. Resolve the ProcurementProcess registry entry and wire it "
+            "into the task; debug cannot run against an unwired reference."
         )
     run_debug(timeout=720)
     print(

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/check_rpa_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/check_rpa_case.py
@@ -16,8 +16,9 @@ def main():
     task = assert_task_type_present("rpa")
     if task_is_skeleton(task):
         sys.exit(
-            "FAIL: rpa task is a skeleton — debug requires a resolved "
-            "HelpDeskLookup registry entry with a real taskTypeId"
+            "FAIL: rpa task is a skeleton — data.name and data.folderPath "
+            "are unset. Resolve the HelpDeskLookup registry entry and wire it "
+            "into the task; debug cannot run against an unwired reference."
         )
     run_debug(timeout=720)
     print(


### PR DESCRIPTION
Message-only fix. **No predicate changes, no behavioural change.**

## The problem

Five single-node graders fail with:

> `FAIL: process task is a skeleton — debug requires a resolved ProcurementProcess registry entry with a real taskTypeId`

But the predicate they run is `task_is_skeleton`, which for process / agent / rpa / api-workflow / case-management is:

```python
return not (data.get("name") and data.get("folderPath"))
```

It never looks at `taskTypeId`.

## `taskTypeId` is not a caseplan field

It's an argument to `uip maestro case tasks add --task-type-id`, documented as *"Task type ID to enrich with bindings, inputs, and outputs"*. The handler uses it as a lookup key and discards it:

```js
const [enrichError, enrichment] =
  await catchError(enrichTask(options.type, taskTypeId, { elementId }));

task.elementId  = elementId;
data.name       = `=bindings.${usedNameBinding.id}`;
data.folderPath = `=bindings.${usedFolderBinding.id}`;
data.inputs     = enrichment.inputs;
data.outputs    = enrichment.outputs;
```

`enrichTask` returns `{name, type, folderPath, inputs, outputs}`; `buildTaskData` writes only `name` and `folderPath`. The id is never persisted, and appears nowhere in the case-schema grammar.

## Why it matters

Reading that message as a requirement is a live failure mode, not a hypothetical. In the 2026-09-09 case eval, the `single-process` agent resolved the entity key (`4fc450ab-…`), found no way to declare it through the SDK, and **hand-patched `data.taskTypeId` into the compiled `caseplan.json`** — desyncing source from artifact for no gain, since the next `compile` discards it. Its `validate` passed either way, because the field is inert.

The messages now name `data.name` / `data.folderPath`, and keep the resource name, which was the genuinely useful half:

> `FAIL: process task is a skeleton — data.name and data.folderPath are unset. Resolve the ProcurementProcess registry entry and wire it into the task; debug cannot run against an unwired reference.`

## One docstring correction

`task_is_skeleton` claimed it checks name and folderPath *"(both as `=bindings.<id>` refs)"*. Only presence is checked. `tasks add` does write them as `=bindings.<id>` with matching entries in `plan.bindings[]`, while a literal passes too.

That gap is real — `io_binding/check_io_binding_case.py` hard-fails on a literal, so the two graders disagree about the same shape — but tightening this predicate is a behavioural claim about what the runtime requires, and I haven't verified it. The docstring now records the divergence rather than overstating the code.

## Verification

- Predicate untouched; re-checked against literal refs, `=bindings.` refs, empty data, name-only, an inert `taskTypeId` with no name, and both action shapes — identical results.
- `pytest tests/tasks/uipath-maestro-case` → **138 passed**.

Remaining `taskTypeId` mentions are all correct: the `_METADATA_KEYS` ignore-list, a journal test fixture, and one comment in `check_branching_exit.py` referring to the prompt's unresolved-fallback convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
