### PR TITLE
fix(uipath-maestro-flow): raise DF query/e2e turn budgets and documen…

### DIFF
--- a/skills/uipath-maestro-flow/references/author/plugins/connector-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/connector-trigger/impl.md
@@ -315,6 +315,7 @@ A no-op filter — used when the user wants all events to fire the trigger — i
 | `Contains` / `NotContains` | Substring match | string |
 | `StartsWith` / `NotStartsWith` / `EndsWith` / `NotEndsWith` | Prefix / suffix match | string |
 | `IsEmpty` / `IsNotEmpty` | Value is / is not empty string | string (no `value` needed) |
+| `IsNull` / `IsNotNull` | Value is / is not null | any type (no `value` needed) |
 | `Is` / `IsNot` | Boolean is true / false | boolean (no `value` needed) |
 | `In` / `NotIn` / `IsOneOf` / `IsNotOneOf` | Membership — pass comma-separated values in `value.value` | string, number |
 | `Before` / `BeforeOrEqual` / `After` / `AfterOrEqual` / `DateTimeEquals` / `DateTimeNotEqual` | Date-time comparison (ISO-8601 strings) | date-time |

--- a/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
@@ -36,7 +36,7 @@ Definitions in `definitions[]` are CLI-owned. `uip maestro flow node add` copies
 An activity is `4.0.0` when its `configuration` JSON reports `"version":"4.0.0"`. Author it through the Configuration workflow below like any other connector activity; `describe`/version mechanics are in [/uipath:uipath-platform — resources.md § `--activity-version`](../../../../../uipath-platform/references/integration-service/resources.md#--activity-version). Four deltas:
 
 1. **`objectName` source** — read the definition's `configuration` `objectName` (the `model.context[]` `objectName` entry is declared with no value). It is the `describe` positional, but do NOT pass it in `--detail` — `node configure` reads it from the definition itself. If configuration carries no `objectName`, the registry copy is stale: run `uip maestro flow registry pull --force`, delete the `definitions[]` entry, and re-add the node.
-2. **`method` / `endpoint`** — from `connectorMethodInfo` (`registry get`) or `availableOperations[]` (`is resources describe <connector-key> <object-name> --activity-version 4.0.0`). If `endpoint` contains a `{placeholder}`, pass the same-named key in `pathParameters`.
+2. **`method` / `endpoint`** — from `connectorMethodInfo` (`registry get`) or `availableOperations[]` (`is resources describe <connector-key> <object-name> --activity-version 4.0.0`).
 3. **Operation label ≠ HTTP verb** — a semantic operation (e.g. `Update`) pairs with any verb (e.g. `POST /usergroups.users.update`). `flow validate` accepts it; do not "fix" the method to match the label.
 4. **Not connection-scoped** — `--connection-id` on `registry get` adds no custom fields.
 

--- a/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
@@ -36,7 +36,7 @@ Definitions in `definitions[]` are CLI-owned. `uip maestro flow node add` copies
 An activity is `4.0.0` when its `configuration` JSON reports `"version":"4.0.0"`. Author it through the Configuration workflow below like any other connector activity; `describe`/version mechanics are in [/uipath:uipath-platform — resources.md § `--activity-version`](../../../../../uipath-platform/references/integration-service/resources.md#--activity-version). Four deltas:
 
 1. **`objectName` source** — read the definition's `configuration` `objectName` (the `model.context[]` `objectName` entry is declared with no value). It is the `describe` positional, but do NOT pass it in `--detail` — `node configure` reads it from the definition itself. If configuration carries no `objectName`, the registry copy is stale: run `uip maestro flow registry pull --force`, delete the `definitions[]` entry, and re-add the node.
-2. **`method` / `endpoint`** — from `connectorMethodInfo` (`registry get`) or `availableOperations[]` (`is resources describe <connector-key> <object-name> --activity-version 4.0.0`).
+2. **`method` / `endpoint`** — from `connectorMethodInfo` (`registry get`) or `availableOperations[]` (`is resources describe <connector-key> <object-name> --activity-version 4.0.0`). If `endpoint` contains a `{placeholder}`, pass the same-named key in `pathParameters`.
 3. **Operation label ≠ HTTP verb** — a semantic operation (e.g. `Update`) pairs with any verb (e.g. `POST /usergroups.users.update`). `flow validate` accepts it; do not "fix" the method to match the label.
 4. **Not connection-scoped** — `--connection-id` on `registry get` adds no custom fields.
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/contractregistry_crud_filters.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/contractregistry_crud_filters.yaml
@@ -37,6 +37,8 @@ initial_prompt: |
   6. Map the created, queried, updated, and retrieved values to the flow
      output where the activity supports output mapping.
 
+  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for these operations — not the native `core.datafabric.*` nodes.
+
   The Flow is not complete until `uip maestro flow validate` passes.
 
   This run is headless. No user is present and nobody will answer a question or

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/contractregistry_crud_filters.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/contractregistry_crud_filters.yaml
@@ -37,7 +37,9 @@ initial_prompt: |
   6. Map the created, queried, updated, and retrieved values to the flow
      output where the activity supports output mapping.
 
-  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for these operations — not the native `core.datafabric.*` nodes.
+  Use the Data Fabric Integration Service connector activities
+  (`uipath.connector.uipath-uipath-dataservice.*`) for these operations, not
+  the native `core.datafabric.*` nodes.
 
   The Flow is not complete until `uip maestro flow validate` passes.
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/e2e_contract_intake_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/e2e_contract_intake_pipeline.yaml
@@ -10,8 +10,8 @@ description: >
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, uipath-uipath-dataservice]
 
 run_limits:
-  expected_turns: 40
-  max_turns: 100
+  expected_turns: 80
+  max_turns: 150
   turn_timeout: 1800
   task_timeout: 2400
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/e2e_contract_intake_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/e2e_contract_intake_pipeline.yaml
@@ -10,10 +10,10 @@ description: >
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, uipath-uipath-dataservice]
 
 run_limits:
-  expected_turns: 80
-  max_turns: 150
-  turn_timeout: 1800
-  task_timeout: 2400
+  expected_turns: 40
+  max_turns: 100
+  turn_timeout: 2700
+  task_timeout: 5400
 
 pre_run:
   - command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/preflight_connections.py" uipath-uipath-dataservice'
@@ -48,7 +48,9 @@ initial_prompt: |
   5. Delete Entity Record — bind recordId to the create activity's
      output Id.
 
-  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for these operations — not the native `core.datafabric.*` nodes.
+  Use the Data Fabric Integration Service connector activities
+  (`uipath.connector.uipath-uipath-dataservice.*`) for these operations, not
+  the native `core.datafabric.*` nodes.
 
   The Flow is not complete until `uip maestro flow validate` passes.
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/e2e_contract_intake_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/e2e_contract_intake_pipeline.yaml
@@ -48,6 +48,8 @@ initial_prompt: |
   5. Delete Entity Record — bind recordId to the create activity's
      output Id.
 
+  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for these operations — not the native `core.datafabric.*` nodes.
+
   The Flow is not complete until `uip maestro flow validate` passes.
 
   This run is headless. No user is present and nobody will answer a question or

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/integration_create_get.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/integration_create_get.yaml
@@ -39,7 +39,9 @@ initial_prompt: |
   at expansionLevel=1, expansionLevel=2, and expansionLevel=3. Delete when
   done.
 
-  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for these operations — not the native `core.datafabric.*` nodes.
+  Use the Data Fabric Integration Service connector activities
+  (`uipath.connector.uipath-uipath-dataservice.*`) for these operations, not
+  the native `core.datafabric.*` nodes.
 
   The Flow is not complete until `uip maestro flow validate` passes.
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/integration_create_get.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/integration_create_get.yaml
@@ -39,6 +39,8 @@ initial_prompt: |
   at expansionLevel=1, expansionLevel=2, and expansionLevel=3. Delete when
   done.
 
+  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for these operations — not the native `core.datafabric.*` nodes.
+
   The Flow is not complete until `uip maestro flow validate` passes.
 
   This run is headless. No user is present and nobody will answer a question or

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_create_all_types.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_create_all_types.yaml
@@ -32,7 +32,9 @@ initial_prompt: |
   * lastUpdated: "2024-03-10T09:00:00" (DATETIME)
   * externalId: any valid UUID value of your choice
 
-  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for this operation — not the native `core.datafabric.*` nodes.
+  Use the Data Fabric Integration Service connector activities
+  (`uipath.connector.uipath-uipath-dataservice.*`) for this operation, not
+  the native `core.datafabric.*` nodes.
 
   The Flow is not complete until `uip maestro flow validate` passes.
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_create_all_types.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_create_all_types.yaml
@@ -32,6 +32,8 @@ initial_prompt: |
   * lastUpdated: "2024-03-10T09:00:00" (DATETIME)
   * externalId: any valid UUID value of your choice
 
+  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for this operation — not the native `core.datafabric.*` nodes.
+
   The Flow is not complete until `uip maestro flow validate` passes.
 
   This run is headless. No user is present and nobody will answer a question or

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_error.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_error.yaml
@@ -24,7 +24,9 @@ initial_prompt: |
      FlowCodeEvalEntity for title='ErrorTestRecord'.
   3. In the same parallel branch, Query FlowCodeEvalEntity with no filter.
 
-  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for these operations — not the native `core.datafabric.*` nodes.
+  Use the Data Fabric Integration Service connector activities
+  (`uipath.connector.uipath-uipath-dataservice.*`) for these operations, not
+  the native `core.datafabric.*` nodes.
 
   The Flow is not complete until `uip maestro flow validate` passes.
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_error.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_error.yaml
@@ -24,6 +24,8 @@ initial_prompt: |
      FlowCodeEvalEntity for title='ErrorTestRecord'.
   3. In the same parallel branch, Query FlowCodeEvalEntity with no filter.
 
+  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for these operations — not the native `core.datafabric.*` nodes.
+
   The Flow is not complete until `uip maestro flow validate` passes.
 
   This run is headless. No user is present and nobody will answer a question or

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_file_activities.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_file_activities.yaml
@@ -38,6 +38,10 @@ initial_prompt: |
   4. DeleteFileFromRecordFieldV2 — bind recordId to the same create activity
      output Id used in step 3.
 
+  Use the Data Fabric Integration Service connector activities
+  (`uipath.connector.uipath-uipath-dataservice.*`) for these operations, not
+  the native `core.datafabric.*` nodes.
+
   The Flow is not complete until `uip maestro flow validate` passes.
 
   This run is headless. No user is present and nobody will answer a question or

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_query.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_query.yaml
@@ -6,7 +6,7 @@ description: >
 tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, connector, uipath-uipath-dataservice]
 
 run_limits:
-  max_turns: 150
+  max_turns: 100
   turn_timeout: 2400
   task_timeout: 3600
 
@@ -41,7 +41,9 @@ initial_prompt: |
   tree, sort, and limit, but use offset/start 2 for the next page. Query 3 must
   filter active equals true, sort by score descending, and use a limit of 4.
 
-  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for these operations — not the native `core.datafabric.*` nodes.
+  Use the Data Fabric Integration Service connector activities
+  (`uipath.connector.uipath-uipath-dataservice.*`) for these operations, not
+  the native `core.datafabric.*` nodes.
 
   The Flow is not complete until `uip maestro flow validate` passes.
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_query.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_query.yaml
@@ -41,6 +41,8 @@ initial_prompt: |
   tree, sort, and limit, but use offset/start 2 for the next page. Query 3 must
   filter active equals true, sort by score descending, and use a limit of 4.
 
+  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for these operations — not the native `core.datafabric.*` nodes.
+
   The Flow is not complete until `uip maestro flow validate` passes.
 
   This run is headless. No user is present and nobody will answer a question or

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_query.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_query.yaml
@@ -6,7 +6,7 @@ description: >
 tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, connector, uipath-uipath-dataservice]
 
 run_limits:
-  max_turns: 100
+  max_turns: 150
   turn_timeout: 2400
   task_timeout: 3600
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_update.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_update.yaml
@@ -26,7 +26,9 @@ initial_prompt: |
   3. Retrieves the record by Id to confirm.
   4. Deletes the record.
 
-  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for these operations — not the native `core.datafabric.*` nodes.
+  Use the Data Fabric Integration Service connector activities
+  (`uipath.connector.uipath-uipath-dataservice.*`) for these operations, not
+  the native `core.datafabric.*` nodes.
 
   The Flow is not complete until `uip maestro flow validate` passes.
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_update.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/smoke_update.yaml
@@ -26,6 +26,8 @@ initial_prompt: |
   3. Retrieves the record by Id to confirm.
   4. Deletes the record.
 
+  Use the Data Fabric Integration Service connector activities (`uipath.connector.uipath-uipath-dataservice.*`) for these operations — not the native `core.datafabric.*` nodes.
+
   The Flow is not complete until `uip maestro flow validate` passes.
 
   This run is headless. No user is present and nobody will answer a question or

--- a/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/trigger_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/trigger_lifecycle.yaml
@@ -37,6 +37,11 @@ initial_prompt: |
 
   For both flows, keep the configured connection and correct entity on every
   trigger and Data Fabric activity.
+
+  Use the Data Fabric Integration Service connector activities
+  (`uipath.connector.uipath-uipath-dataservice.*`) for these operations, not
+  the native `core.datafabric.*` nodes.
+
   Validate every final flow file.
 
   This run is headless. No user is present and nobody will answer a question or


### PR DESCRIPTION
## Summary

Fixes DF connector-features tests that were failing when the agent built with the newer native `core.datafabric.*` node family — every grader in `tests/tasks/uipath-maestro-flow/connector_features/datafabric_connector/` checks the IS connector suffixes (`.create-entity-record`, `.query-entity-records`, etc.), so a native build validates green and scores zero.

## Changes (3 commits on this branch)

**`230545a9` — turn budget + two generic doc additions** *(later partially reverted, see `1e9f1823f`)*
- Initial `max_turns` bumps on `smoke_query` + `e2e_contract_intake_pipeline` (reverted).
- `connector-trigger/impl.md`: add `IsNull`/`IsNotNull` operator row (retained).
- `connector/impl.md` delta 2: append `pathParameters` note for templated endpoints (later dropped as duplicate of Step 6b).

**`9a98bfa8` — pin DF CRUD tests to the IS connector node family**
- One prompt line in 7 CRUD tests (`smoke_create_all_types`, `smoke_error`, `smoke_update`, `smoke_query`, `contractregistry_crud_filters`, `integration_create_get`, `e2e_contract_intake_pipeline`) naming both node families and picking the IS-connector one.
- Skipped: activation (node type irrelevant), file-activities and trigger_lifecycle (later extended, see below).

**`1e9f1823f` — address review**
- `e2e_contract_intake_pipeline`: revert `max_turns`/`expected_turns` and move the budget to `turn_timeout: 1800→2700` + `task_timeout: 2400→5400`. On the codex driver every CI runner uses (`smoke-skills.yml`, `run-coder-eval.yml`), `max_turns` does not bind — `turn_timeout` is the field that actually aborts. Matches peer `e2e/escalation_orchestrator_paths` at 5400.
- `smoke_query`: revert `max_turns` 150→100. CI showed the task green at 456s with 1 turn — cap never bound.
- `connector/impl.md`: drop the `pathParameters` sentence added to delta 2 — duplicates Step 6b (line 232) and the generic definition (line 20), and mis-frames a generic rule as v4-specific.
- Wrap all 7 pinning lines at ~75 chars to match the surrounding block-scalar wrap.
- Extend the pin to two more tasks the previous skip-list missed:
  - `smoke_file_activities` (grader hard-requires `.create-entity-record` node with `inputs.detail.pathParameters.entityName`)
  - `trigger_lifecycle` (grader hard-requires `.query-entity-records`/`.get-entity-record-by-id`/`.delete-entity-record` suffixes for downstream nodes)

## Native `core.datafabric.*` coverage

Intentionally out of scope for this PR. The pin is temporary until the native family is stable in production. See #3231 for the opposite remedy (grader widening) chosen on the billing e2es — the two branches use different strategies for the same collision.

## Passing-run evidence

Smoke-tagged tasks that ran in this PR's CI gate ([job](https://github.com/UiPath/skills/actions/runs/34505213985), commit `9a98bfa8`) and scored `1.000`:
- `skill-flow-datafabric-smoke-create-all-types`
- `skill-flow-datafabric-smoke-error`
- `skill-flow-datafabric-smoke-query`
- `skill-flow-datafabric-smoke-update`

Not smoke-tagged, did not run in the smoke gate: `integration_create_get`, `contractregistry_crud_filters`, `e2e_contract_intake_pipeline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)