### PR TITLE
fix(test): re-add task_timeout: 2400 to e2e_01, lost since the original July fix

### DIFF
--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -13,6 +13,15 @@ tags: [uipath-human-in-the-loop, e2e, green-field, invoice, approval-gate, write
 run_limits:
   expected_turns: 19
   max_turns: 60
+  # task_timeout must be >= turn_timeout or it silently becomes the binding
+  # cap regardless of the larger per-turn budget below — nightly experiment
+  # default is task_timeout 1200 / turn_timeout 900 (tests/experiments/
+  # nightly.yaml). This test declared turn_timeout 2400 without also raising
+  # task_timeout (previously fixed in 34aa3c773, since lost) so it kept
+  # inheriting the 1200s default and dying mid-first-turn at exactly that
+  # mark, as re-confirmed on 2026-09-10 run 2026-09-10_04-18-49
+  # ("Task timed out after 1200s", iteration_count 1).
+  task_timeout: 2400
   turn_timeout: 2400
 
 initial_prompt: |

--- a/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
@@ -18,6 +18,11 @@ skip: true
 run_limits:
   expected_turns: 25
   max_turns: 60
+  # task_timeout must be >= turn_timeout or the nightly default (1200s) silently
+  # caps this regardless of the larger per-turn budget below — see e2e_01's
+  # history (34aa3c773, re-fixed 2026-09-10) for the failure mode this avoids.
+  # Currently skip: true, so dormant until the test is unblocked.
+  task_timeout: 1800
   turn_timeout: 1800
 
 initial_prompt: |


### PR DESCRIPTION
## Summary
uipath-human-in-the-loop sat at 22/23 in today's nightly (2026-09-10_04-18-49, claude-sonnet-5). skill-hitl-e2e-invoice-approval-greenfield failed: TIMEOUT, "Task timed out after 1200s", killed mid-first-turn.

The nightly experiment default is task_timeout 1200 / turn_timeout 900 (tests/experiments/nightly.yaml). This test sets turn_timeout to 2400 without a task_timeout override, so it inherits the 1200s default. A task_timeout below turn_timeout becomes the binding cap.

34aa3c773 (2026-07-10) set task_timeout: 2400 alongside turn_timeout: 2400. 42d3802c9 (2026-07-14, "tag path-to-ga tasks") merged from a branch based on the pre-fix blob and dropped task_timeout again.

## Evidence
- 2026-09-10_04-18-49: TIMEOUT at exactly 1200s.
- 2026-07-13_04-26-06, under task_timeout: 2400: SUCCESS, score 1.0, duration 640.7s, all 7 criteria passed.
- The July run finished in 640s, under the old 1200s cap too, so it never exercised the extra headroom. Today's run exceeded 1200s under the same task. The task takes longer now than it did in July. A coder-eval run against the current skill and task version is needed to confirm 2400s covers it.

## Fix
- Add task_timeout: 2400 alongside turn_timeout: 2400 in e2e_01.
- Add task_timeout: 1800 alongside turn_timeout: 1800 in e2e_07 (skip: true, dormant until unblocked).

A repo-wide scan for turn_timeout raised above 1200 without a task_timeout override found the same gap in 5 files in other skills, left for their owners:
- uipath-planner/case/bpmn_vs_case_management.yaml
- uipath-maestro-bpmn/expressions/computed_js.yaml
- uipath-maestro-bpmn/connector/integration_service_boundary.yaml
- uipath-maestro-bpmn/structural/message_send_receive_pair.yaml
- uipath-maestro-bpmn/single_node/agent_job.yaml
- uipath-platform/data-fabric/e2e_product_catalogue.yaml

## Test plan
- [x] 2026-09-10_04-18-49 run.json: TIMEOUT, 1200s duration
- [x] tests/experiments/nightly.yaml default: task_timeout 1200, turn_timeout 900
- [x] 2026-07-13_04-26-06 task.json: SUCCESS, score 1.0, duration 640.7s
- [ ] Coder-eval run against this branch to confirm 2400s covers the current task

🤖 Generated with [Claude Code](https://claude.com/claude-code)