### PR TITLE
Remove name based filter for maestro flow

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_flow_utils.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_flow_utils.py
@@ -65,8 +65,17 @@ def is_real_uuid(value: Any) -> bool:
     return bool(UUID.fullmatch(rendered)) and not STUB_UUID.match(rendered)
 
 
+def _generated_flows(pattern: str) -> list[Path]:
+    cwd = Path.cwd()
+    return sorted(
+        path
+        for path in cwd.rglob(pattern)
+        if not EXCLUDED_GENERATED_PARTS.intersection(path.relative_to(cwd).parts)
+    )
+
+
 def load_flow(expected_name: str) -> tuple[Path, dict[str, Any], list[dict[str, Any]]]:
-    """Load an explicit Flow path or find exactly one generated Flow by name."""
+    """Load an explicit Flow path or find exactly one generated Flow, by name first."""
     if len(sys.argv) > 2:
         fail(f"usage: {Path(sys.argv[0]).name} [{expected_name}]")
 
@@ -75,16 +84,14 @@ def load_flow(expected_name: str) -> tuple[Path, dict[str, Any], list[dict[str, 
         if not path.is_file():
             fail(f"Flow path does not name a file: {path}")
     else:
-        cwd = Path.cwd()
-        candidates = sorted(
-            path
-            for path in cwd.rglob(expected_name)
-            if not EXCLUDED_GENERATED_PARTS.intersection(path.relative_to(cwd).parts)
-        )
+        # The expected basename is a preference: a Studio Web build keeps the
+        # scaffolded ``new.flow`` name, so an empty match falls back to any
+        # generated ``.flow`` — still exactly one, or the check refuses.
+        candidates = _generated_flows(expected_name) or _generated_flows("*.flow")
         if len(candidates) != 1:
             fail(
-                f"expected exactly one generated {expected_name}, found {len(candidates)}: "
-                f"{[str(path) for path in candidates]}"
+                f"expected exactly one generated {expected_name} (or a lone .flow), "
+                f"found {len(candidates)}: {[str(path) for path in candidates]}"
             )
         path = candidates[0]
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -136,10 +136,23 @@ _DEBUG_RETRY_MARKERS = (
 )
 
 
+def _is_pruned_dir(name: str) -> bool:
+    """Directories discovery never descends into.
+
+    ``node_modules``: the preview workspace symlinks the baked SDK tree there,
+    and ``glob`` follows directory symlinks under ``**``. Dot-directories: the
+    agent's own scratch space (``.venv``, ``.flow-auto/``, ``.smokeeval-scaffold/``
+    — run 2026-09-10_11-06-05 eval-local-crud kept two ``flow init`` attempts in
+    hidden dirs beside the real ``SmokeEval/`` and the checker refused all three
+    as equal 1-node candidates). Studio Web's own search tools hide dot-dirs for
+    the same reason; a deliverable is never hidden.
+    """
+    return name == "node_modules" or name.startswith(".")
+
+
 def _rglob_pruned(pattern: str) -> list[str]:
-    """``glob.glob(pattern, recursive=True)`` from the CWD, but never descending
-    into ``node_modules`` (the preview workspace symlinks the baked SDK tree
-    there, and ``glob`` follows directory symlinks under ``**``)."""
+    """``glob.glob(pattern, recursive=True)`` from the CWD, skipping the
+    directories :func:`_is_pruned_dir` names."""
     if "**" not in pattern:
         return sorted(glob.glob(pattern, recursive=True))
     prefix, _, suffix = pattern.partition("**")
@@ -147,7 +160,7 @@ def _rglob_pruned(pattern: str) -> list[str]:
     suffix = suffix.lstrip("/")
     matches: list[str] = []
     for dirpath, dirnames, _ in os.walk(root, followlinks=True):
-        dirnames[:] = [d for d in dirnames if d != "node_modules"]
+        dirnames[:] = [d for d in dirnames if not _is_pruned_dir(d)]
         matches.extend(glob.glob(os.path.join(glob.escape(dirpath), suffix)))
     if root == ".":
         matches = [m[2:] if m.startswith("./") else m for m in matches]
@@ -1737,14 +1750,24 @@ def find_flow_files(
     SDK emit. Multiple genuinely distinct root emits are ambiguous and fail
     with their paths rather than selecting one by glob order.
 
+    ``flow_glob`` is a *preference*, not a gate. Its job is to pick the right
+    file when a project holds several flows (a main flow beside a subflow, or
+    the ``after_a.flow`` / ``after_b.flow`` snapshots a bindings task asks
+    for). A correct build does not have to name its flow after the project:
+    Studio Web scaffolds and keeps the file as ``new.flow`` (the studioweb
+    harness exports it verbatim — run 2026-09-10_11-06-05, 20 tasks zeroed on
+    ``No .flow file matching '<Name>*.flow'`` over flows that validated).
+    So when the name matches nothing in the selected project, the project's
+    own ``.flow`` files are returned instead; the caller's single-file
+    contract (:func:`find_flow_file`) still refuses a genuinely ambiguous set.
+    Only an empty project fails here.
+
     Debug callers intentionally do not use this helper: ``uip maestro flow
     debug`` is project-scoped and must continue through :func:`find_project_dir`.
     """
     project_candidates = _rglob_pruned(project_pattern)
     flow_projects = [path for path in project_candidates if _is_flow_project(path)]
-    root_matches = _dedupe_flow_candidates(
-        sorted(glob.glob(os.path.basename(flow_glob)))
-    )
+    root_matches = _dedupe_flow_candidates(_root_flow_matches(flow_glob))
 
     # A preview author may compile a complete root-level SDK source before a
     # later CLI command leaves an untouched trigger-only project scaffold. For
@@ -1771,18 +1794,7 @@ def find_flow_files(
 
     if flow_projects:
         project_dir = _find_project(project_pattern)
-        matches = sorted(
-            glob.glob(
-                os.path.join(project_dir, "**", os.path.basename(flow_glob)),
-                recursive=True,
-            )
-        )
-        if not matches:
-            _fail(
-                f"No .flow file matching {flow_glob!r} under selected Flow "
-                f"project {project_dir}"
-            )
-        return matches
+        return _project_flow_matches(project_dir, flow_glob)
 
     if not root_matches:
         _fail(
@@ -1796,6 +1808,42 @@ def find_flow_files(
             f"guess:\n  - {joined}"
         )
     return root_matches
+
+
+def _project_flow_matches(project_dir: str, flow_glob: str) -> list[str]:
+    """``.flow`` files under ``project_dir``, preferring ``flow_glob``'s basename.
+
+    Falls back to every ``.flow`` in the project when the preferred name is
+    absent (see :func:`find_flow_files`); fails only when the project has no
+    ``.flow`` at all.
+    """
+    name = os.path.basename(flow_glob)
+    matches = sorted(
+        glob.glob(os.path.join(glob.escape(project_dir), "**", name), recursive=True)
+    )
+    if not matches and name != "*.flow":
+        matches = sorted(
+            glob.glob(
+                os.path.join(glob.escape(project_dir), "**", "*.flow"), recursive=True
+            )
+        )
+        if matches:
+            print(
+                f"note: no .flow matching {name!r} under {project_dir}; using the "
+                f"project's own flow file(s): {', '.join(matches)}"
+            )
+    if not matches:
+        _fail(f"No .flow file under selected Flow project {project_dir}")
+    return matches
+
+
+def _root_flow_matches(flow_glob: str) -> list[str]:
+    """Root-level (no project) candidates: the preferred name, else any ``.flow``."""
+    name = os.path.basename(flow_glob)
+    matches = sorted(glob.glob(name))
+    if matches or name == "*.flow":
+        return matches
+    return sorted(glob.glob("*.flow"))
 
 
 def find_flow_file(

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py
@@ -4,9 +4,9 @@
 Usage (from a task's run_command, cwd = sandbox root):
     python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py
     python3 .../flow_contains.py '"uipath.human-in-the-loop.quick-form"' '"end"'
-    python3 .../flow_contains.py --flow-name VendorApproval '"boolean"'
+    python3 .../flow_contains.py '"boolean"'
     python3 .../flow_contains.py --regex '\\$vars\\.[A-Za-z0-9_-]+\\.output'
-    python3 .../flow_contains.py --flow-name ContractReview --absent-regex '\\.output\\.legalNotes'
+    python3 .../flow_contains.py --absent-regex '\\.output\\.legalNotes'
 
 Arguments:
     plain args           substrings that must ALL appear in ONE discovered
@@ -16,8 +16,11 @@ Arguments:
                          replacement for ``file_matches_regex``
     --flow-name NAME     restrict assertions to files named ``NAME.flow``;
                          fails when no discovered file has that basename.
-                         Restores the name enforcement the literal paths had,
-                         while staying wrapper-agnostic
+                         Opt-in and deliberately unused by the task suite: a
+                         correct build may emit a flow file whose name does not
+                         echo the project (``new.flow``), so grading a basename
+                         scores 0.0 on a flow that validates. Pass it only when
+                         the file name is itself under test
     --absent-regex PAT   negative assertion: exits 0 only when discovery
                          succeeded, every target file was read, and NO target
                          file matches PAT (repeatable). Use this (with

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check_discovery.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check_discovery.py
@@ -286,3 +286,109 @@ def test_validate_flow_uses_root_fallback(tmp_path, monkeypatch):
     assert kwargs["capture_output"] is True
     assert kwargs["text"] is True
     assert 0 < kwargs["timeout"] <= 80
+
+
+# ── flow_glob is a preference, not a gate (Studio Web keeps ``new.flow``) ────
+
+
+def _make_studioweb_project(root, name, node_count=3):
+    """Studio Web export shape: ``<Name>/<Name>/new.flow`` — the scaffolded
+    file name is kept, so nothing in the project is called ``<Name>.flow``."""
+    proj = _make_flow_project(root, name, name, node_count)
+    (proj / f"{name}.flow").rename(proj / "new.flow")
+    return proj
+
+
+def test_named_glob_falls_back_to_the_projects_own_flow(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _make_studioweb_project(tmp_path, "TransformMapDemo")
+
+    path = find_flow_file(flow_glob="TransformMapDemo*.flow")
+
+    assert os.path.normpath(path) == os.path.join(
+        "TransformMapDemo", "TransformMapDemo", "new.flow"
+    )
+    assert "no .flow matching 'TransformMapDemo*.flow'" in capsys.readouterr().out
+
+
+def test_named_glob_still_selects_by_name_when_present(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    proj = _make_flow_project(tmp_path, "Sol", "Main", 3)
+    (proj / "Helper.flow").write_text(json.dumps({"nodes": []}))
+
+    path = find_flow_file(flow_glob="Main*.flow")
+
+    assert os.path.normpath(path) == os.path.join("Sol", "Main", "Main.flow")
+    assert capsys.readouterr().out == ""
+
+
+def test_named_glob_fallback_refuses_an_ambiguous_project(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    proj = _make_studioweb_project(tmp_path, "Demo")
+    (proj / "Subflow.flow").write_text(json.dumps({"nodes": []}))
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_flow_file(flow_glob="Demo*.flow")
+    assert "Multiple .flow files match" in str(excinfo.value)
+
+
+def test_named_glob_fails_on_a_project_with_no_flow(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    proj = _make_flow_project(tmp_path, "Sol", "Empty", 1)
+    (proj / "Empty.flow").unlink()
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_flow_files(flow_glob="Empty*.flow")
+    assert "No .flow file under selected Flow project" in str(excinfo.value)
+
+
+def test_root_fallback_accepts_a_differently_named_lone_emit(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "new.flow").write_text(json.dumps({"nodes": []}))
+
+    assert find_flow_files(flow_glob="Demo*.flow") == ["new.flow"]
+
+
+def test_advisory_load_flow_falls_back_to_a_lone_generated_flow(tmp_path, monkeypatch):
+    import advisory_flow_utils
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["advisory_x.py"])
+    _make_studioweb_project(tmp_path, "BillingDisputeAnalyst")
+
+    path, _flow, nodes = advisory_flow_utils.load_flow("BillingDisputeAnalyst.flow")
+
+    assert path.name == "new.flow"
+    assert len(nodes) == 3
+
+
+def test_advisory_load_flow_refuses_two_unnamed_candidates(tmp_path, monkeypatch):
+    import advisory_flow_utils
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["advisory_x.py"])
+    _make_studioweb_project(tmp_path, "A")
+    _make_studioweb_project(tmp_path, "B")
+
+    with pytest.raises(SystemExit) as excinfo:
+        advisory_flow_utils.load_flow("A.flow")
+    assert "found 2" in str(excinfo.value)
+
+
+# ── hidden scratch dirs are not deliverables ─────────────────────────────────
+
+
+def test_hidden_scratch_projects_do_not_compete(tmp_path, monkeypatch, capsys):
+    """eval-local-crud, run 2026-09-10_11-06-05: the agent kept two failed
+    ``flow init`` attempts under dot-dirs beside the real build. All three were
+    1-node flows, so the husk heuristic could not separate them."""
+    monkeypatch.chdir(tmp_path)
+    _make_flow_project(tmp_path, "SmokeEval", "SmokeEval", 1)
+    _make_flow_project(tmp_path / ".flow-auto", "SmokeEvalSolution", "SmokeEval", 1)
+    _make_flow_project(tmp_path, ".smokeeval-scaffold", "SmokeEval", 1)
+
+    assert os.path.normpath(find_project_dir(PATTERN)) == os.path.join("SmokeEval", "SmokeEval")
+    assert [os.path.normpath(p) for p in find_flow_files()] == [
+        os.path.join("SmokeEval", "SmokeEval", "SmokeEval.flow")
+    ]
+    assert capsys.readouterr().out == ""

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_drive_to_slack.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_drive_to_slack.py
@@ -15,12 +15,15 @@ Checks performed:
 
 from __future__ import annotations
 
-import glob
 import json
+import os
 import re
 import sys
 
-FLOW_GLOB = "**/DriveToSlackTest*.flow"
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.flow_check import find_flow_file  # noqa: E402
+
+FLOW_GLOB = "DriveToSlackTest*.flow"
 DRIVE_KEY = "uipath-google-drive"
 SLACK_KEY = "uipath-salesforce-slack"
 
@@ -30,10 +33,8 @@ def _fail(msg: str) -> None:
 
 
 def _flow_path() -> str:
-    flows = glob.glob(FLOW_GLOB, recursive=True)
-    if not flows:
-        _fail(f"No flow file matching {FLOW_GLOB}")
-    return flows[0]
+    # Shared discovery: project-scoped, name-preferring, `new.flow`-tolerant.
+    return find_flow_file(flow_glob=FLOW_GLOB)
 
 
 def main() -> None:

--- a/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
@@ -35,7 +35,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ComplexArrayTest '\"nodes\"' '\"edges\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0
@@ -51,7 +51,7 @@ success_criteria:
 
   - type: run_command
     description: "Advisory: group DM participants referenced in the project (names may resolve to Slack user IDs on a live connection)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ComplexArrayTest 'coder evals' 'e2e-testing'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'coder evals' 'e2e-testing'"
     timeout: 10
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
@@ -34,7 +34,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name DTLLoadByDefaultFalseTest '\"nodes\"' '\"edges\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -42,7 +42,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow has a connector node referencing uipath-automattic-woocommerce"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name DTLLoadByDefaultFalseTest 'uipath-automattic-woocommerce'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-automattic-woocommerce'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
@@ -35,7 +35,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name DTLLoadByDefaultTrueTest '\"nodes\"' '\"edges\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
@@ -38,7 +38,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name EnhancedEnumTest '\"nodes\"' '\"edges\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -46,7 +46,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow has a connector node referencing uipath-automattic-woocommerce"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name EnhancedEnumTest 'uipath-automattic-woocommerce'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-automattic-woocommerce'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
@@ -83,7 +83,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow file exists (path-agnostic discovery)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SlackPaginationTest"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 30
     expected_exit_code: 0
     weight: 1.5
@@ -91,7 +91,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow wires the Slack send-message-to-channel node with the resolved Slack id for channel `simple` (C083AN4E61E)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SlackPaginationTest 'uipath.connector.uipath-salesforce-slack.send-message-to-channel' '\"C083AN4E61E\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath.connector.uipath-salesforce-slack.send-message-to-channel' '\"C083AN4E61E\"'"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -56,7 +56,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name PathParamsTest '\"nodes\"' '\"edges\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -38,7 +38,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name QueryParamsTest '\"nodes\"' '\"edges\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
@@ -34,7 +34,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SearchableJoinsTest '\"nodes\"' '\"edges\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -42,7 +42,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow has a connector node referencing uipath-salesforce-sfdc"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SearchableJoinsTest 'uipath-salesforce-sfdc'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-salesforce-sfdc'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/webhook_waitfor_parallel.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/webhook_waitfor_parallel.yaml
@@ -71,7 +71,7 @@ success_criteria:
 
   - type: run_command
     description: "WebhookSelfTest Flow artifact exists"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name WebhookSelfTest"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 30
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
@@ -66,7 +66,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow file exists (path-agnostic discovery)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ExpenseApproval"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 30
     expected_exit_code: 0
     weight: 2.0

--- a/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
@@ -69,7 +69,7 @@ success_criteria:
 
   - type: run_command
     description: "EvalTypeChoice Flow artifact exists"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name EvalTypeChoice"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 30
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/inline_agent_eval.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/inline_agent_eval.yaml
@@ -69,7 +69,7 @@ success_criteria:
 
   - type: run_command
     description: "TriageEval Flow artifact exists"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name TriageEval"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 30
     expected_exit_code: 0
     weight: 1.0
@@ -77,7 +77,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow contains the inline agent node type"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name TriageEval 'uipath.agent.autonomous'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath.agent.autonomous'"
     timeout: 30
     expected_exit_code: 0
     weight: 1.5

--- a/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
@@ -68,7 +68,7 @@ success_criteria:
 
   - type: run_command
     description: "SmokeEval Flow artifact exists"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SmokeEval"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 30
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
@@ -67,7 +67,7 @@ success_criteria:
 
   - type: run_command
     description: "LocalOnly Flow artifact exists"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name LocalOnly"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 30
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml
@@ -69,7 +69,7 @@ success_criteria:
 
   - type: run_command
     description: "Initialized Flow artifact contains a manual trigger"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SimEval 'core.trigger.manual'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'core.trigger.manual'"
     timeout: 30
     expected_exit_code: 0
     weight: 1.0
@@ -77,7 +77,7 @@ success_criteria:
 
   - type: run_command
     description: "SimEval Flow artifact exists"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SimEval"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 30
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
@@ -51,7 +51,7 @@ success_criteria:
 
   - type: run_command
     description: "HITL node has input-direction fields (read-only context for reviewer)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name VendorPOReview '\"direction\": \"input\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"direction\": \"input\"'"
     timeout: 30
     expected_exit_code: 0
     weight: 2.0
@@ -59,7 +59,7 @@ success_criteria:
 
   - type: run_command
     description: "HITL node has output-direction fields (reviewer fills in)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name VendorPOReview '\"direction\": \"output\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"direction\": \"output\"'"
     timeout: 30
     expected_exit_code: 0
     weight: 2.0
@@ -67,7 +67,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow has Approve and Reject outcomes"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name VendorPOReview 'Approve' 'Reject'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'Approve' 'Reject'"
     timeout: 30
     expected_exit_code: 0
     weight: 2.0
@@ -75,7 +75,7 @@ success_criteria:
 
   - type: run_command
     description: "Priority is set to High"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name VendorPOReview '\"High\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"High\"'"
     timeout: 30
     expected_exit_code: 0
     weight: 1.5

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
@@ -61,7 +61,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow references the HITL output variable"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ExpenseApproval '$vars.' '.output'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '$vars.' '.output'"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0
@@ -69,7 +69,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow has a boolean output field for approved"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ExpenseApproval '\"boolean\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"boolean\"'"
     timeout: 30
     expected_exit_code: 0
     weight: 1.5

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
@@ -54,7 +54,7 @@ success_criteria:
 
   - type: run_command
     description: "HITL node has a boolean output field"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name VendorApproval '\"boolean\"' '\"direction\": \"output\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"boolean\"' '\"direction\": \"output\"'"
     timeout: 30
     expected_exit_code: 0
     weight: 2.0
@@ -62,7 +62,7 @@ success_criteria:
 
   - type: run_command
     description: "Decision node condition references field-level HITL output"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name VendorApproval '$vars.' '.output.approved'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '$vars.' '.output.approved'"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0
@@ -70,7 +70,7 @@ success_criteria:
 
   - type: run_command
     description: "Both Decision branches wired (true and false handles)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name VendorApproval '\"true\"' '\"false\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"true\"' '\"false\"'"
     timeout: 30
     expected_exit_code: 0
     weight: 2.0

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
@@ -55,7 +55,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow contains the original script node"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ContractReview '\"extractMeta\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"extractMeta\"'"
     timeout: 30
     expected_exit_code: 0
     weight: 1.5
@@ -71,7 +71,7 @@ success_criteria:
 
   - type: run_command
     description: "HITL completed handle is wired"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ContractReview 'completed'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'completed'"
     timeout: 30
     expected_exit_code: 0
     weight: 2.0
@@ -79,7 +79,7 @@ success_criteria:
 
   - type: run_command
     description: "HITL has a boolean output field for the approval decision"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ContractReview '\"boolean\"'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"boolean\"'"
     timeout: 30
     expected_exit_code: 0
     weight: 1.5

--- a/tests/tasks/uipath-maestro-flow/interactive/bellevue_weather_simulated/bellevue_weather_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/bellevue_weather_simulated/bellevue_weather_simulated.yaml
@@ -91,7 +91,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named BellevueWeather (elicited from the user)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name BellevueWeather"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/cli_dice_roller_simulated/cli_dice_roller_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/cli_dice_roller_simulated/cli_dice_roller_simulated.yaml
@@ -100,7 +100,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named DiceRoller (elicited from the user)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name DiceRoller"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_simulated/customer_escalation_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_simulated/customer_escalation_simulated.yaml
@@ -101,7 +101,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named CustomerEscalation (elicited from the user)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name CustomerEscalation"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/expense_approval_simulated/expense_approval_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/expense_approval_simulated/expense_approval_simulated.yaml
@@ -102,7 +102,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named ExpenseApproval (elicited from the user)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ExpenseApproval"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/hitl_schema_design_simulated/hitl_schema_design_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/hitl_schema_design_simulated/hitl_schema_design_simulated.yaml
@@ -112,7 +112,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named VendorPOReview (elicited from the user)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name VendorPOReview"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/ixp_invoice_extraction_simulated/ixp_invoice_extraction_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/ixp_invoice_extraction_simulated/ixp_invoice_extraction_simulated.yaml
@@ -103,7 +103,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named InvoiceProcessing (elicited from the user)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name InvoiceProcessing"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/slack_channel_description_simulated/slack_channel_description_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/slack_channel_description_simulated/slack_channel_description_simulated.yaml
@@ -122,7 +122,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named SlackChannelDescription (elicited from the user)"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SlackChannelDescription"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
@@ -87,7 +87,7 @@ success_criteria:
 
   - type: run_command
     description: "All three script nodes are present by name"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ReceiptIntake 'postReceipt' 'sendToValidation' 'logError'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'postReceipt' 'sendToValidation' 'logError'"
     timeout: 30
     expected_exit_code: 0
     weight: 2.5
@@ -95,7 +95,7 @@ success_criteria:
 
   - type: run_command
     description: "Scripts reference the extraction output via $vars expression"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ReceiptIntake '$vars.'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '$vars.'"
     timeout: 30
     expected_exit_code: 0
     weight: 1.5

--- a/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
@@ -36,7 +36,7 @@ success_criteria:
 
   - type: run_command
     description: "Initialized flow has the default manual trigger"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name WeatherAlert 'core.trigger.manual'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'core.trigger.manual'"
     timeout: 30
     expected_exit_code: 0
     weight: 1.5
@@ -67,7 +67,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow file was created in a supported authoring layout"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name WeatherAlert"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 30
     expected_exit_code: 0
     weight: 1.5

--- a/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
@@ -57,7 +57,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow file was created in a supported authoring layout"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name EmailTriage"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
     timeout: 30
     expected_exit_code: 0
     weight: 1.5
@@ -65,7 +65,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow contains the inline agent node type"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name EmailTriage 'uipath.agent.autonomous'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath.agent.autonomous'"
     timeout: 30
     expected_exit_code: 0
     weight: 2.0


### PR DESCRIPTION
For https://uipath.atlassian.net/browse/PILOT-7533

Studioweb outputs "new.flow" flow files instead of "<proj_name>.flow" file names, which are expected in tests. Therefore, studioweb stdio test checks fail even though the flow was generated. This is a test issue - the name doesn’t have to be in a particular format.

Run example (maestro-flow only) here with (unmerged) studioweb stdio and this skills branch: ~~https://dev.azure.com/uipath/coder_eval/_build/results?buildId=13343309&view=results~~
Results: TODO

Run example (maestro-flow only) here with Delegate SDK and this skills branch: ~~https://dev.azure.com/uipath/coder_eval/_build/results?buildId=13339361&view=results~~
Results: TODO