### PR TITLE
chore(release): bump plugin version to 1.201.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uipath",
       "source": "./",
       "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath workflows, UI automation, UI testing and UiPath troubleshoot",
-      "version": "1.201.0",
+      "version": "1.201.1",
       "author": {
         "name": "UiPath"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath",
-  "version": "1.201.0",
+  "version": "1.201.1",
   "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath RPA workflows, UI automation, UI testing, Python coded agents and UiPath troubleshoot",
   "author": {
     "name": "UiPath"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath",
-  "version": "1.201.0",
+  "version": "1.201.1",
   "description": "UiPath skills for building, validating, deploying, and operating automations and agents from Codex.",
   "author": {
     "name": "UiPath"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uipath",
   "displayName": "UiPath",
-  "version": "1.201.0",
+  "version": "1.201.1",
   "description": "UiPath plugin for Cursor — skills for building, running, testing, and deploying UiPath automations, agents, coded apps, and platform operations.",
   "author": {
     "name": "UiPath",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/skills",
-  "version": "1.201.0",
+  "version": "1.201.1",
   "description": "UiPath agent skills for Claude Code, Codex, Cursor, Copilot, Gemini and OpenCode — RPA, UI automation, UI testing, coded agents/apps/workflows, and troubleshooting. Distributed as the UiPath Claude Code plugin.",
   "author": {
     "name": "UiPath"

--- a/version-manifest.json
+++ b/version-manifest.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 2,
-  "skillsVersion": "1.201.0",
+  "skillsVersion": "1.201.1",
   "targetCli": "^1.201.0"
 }


### PR DESCRIPTION
## What

Bumps the plugin/skills package version from `1.201.0` to `1.201.1` on the 1.201 release line.

`package.json` is the single source of truth; the five derived manifests were synced with `npm run version:sync` (not hand-edited):

| File | Field | 1.201.0 → 1.201.1 |
|------|-------|--------------------|
| `package.json` | `version` | ✅ (authoritative) |
| `version-manifest.json` | `skillsVersion` | ✅ |
| `.claude-plugin/plugin.json` | `version` | ✅ |
| `.claude-plugin/marketplace.json` | `plugins[0].version` | ✅ |
| `.codex-plugin/plugin.json` | `version` | ✅ |
| `.cursor-plugin/plugin.json` | `version` | ✅ |

## Deliberately unchanged

- `version-manifest.json` `targetCli` stays `^1.201.0` — `scripts/sync-version.mjs` derives it as the matching `@uipath/cli` **minor** line (`^MAJOR.MINOR.0`), so a patch bump does not move it. `^1.201.0` already admits CLI 1.201.1.
- `assets/uip-catalog-snapshot.json` `cli_version: "1.201.0-dev.8319"` and the `1.201.0` mentions in `skills/uipath-admin/references/authorization/permission-catalog.md` and `skills/uipath-automationhub/references/cli-commands.md` refer to the **`uip` CLI** version, not the plugin version.

## Verification

`npm run version:check` → `✓ All manifests in sync (package 1.201.1, plugin 1.201.1, targetCli ^1.201.0).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)