### PR TITLE
cherry-pick(release/v1.201): re-add task_timeout: 2400 to e2e_01

### DIFF
--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -13,6 +13,15 @@ tags: [uipath-human-in-the-loop, e2e, green-field, invoice, approval-gate, write
 run_limits:
   expected_turns: 19
   max_turns: 60
+  # task_timeout must be >= turn_timeout or it silently becomes the binding
+  # cap regardless of the larger per-turn budget below — nightly experiment
+  # default is task_timeout 1200 / turn_timeout 900 (tests/experiments/
+  # nightly.yaml). This test declared turn_timeout 2400 without also raising
+  # task_timeout (previously fixed in 34aa3c773, since lost) so it kept
+  # inheriting the 1200s default and dying mid-first-turn at exactly that
+  # mark, as re-confirmed on 2026-09-10 run 2026-09-10_04-18-49
+  # ("Task timed out after 1200s", iteration_count 1).
+  task_timeout: 2400
   turn_timeout: 2400
 
 initial_prompt: |

--- a/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
@@ -18,6 +18,11 @@ skip: true
 run_limits:
   expected_turns: 25
   max_turns: 60
+  # task_timeout must be >= turn_timeout or the nightly default (1200s) silently
+  # caps this regardless of the larger per-turn budget below — see e2e_01's
+  # history (34aa3c773, re-fixed 2026-09-10) for the failure mode this avoids.
+  # Currently skip: true, so dormant until the test is unblocked.
+  task_timeout: 1800
   turn_timeout: 1800
 
 initial_prompt: |


### PR DESCRIPTION
Cherry-pick of #3196 onto release/v1.201. Clean cherry-pick, no conflicts.

See #3196 for the full explanation and evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)