### PR TITLE
docs: use placeholders for example values that trip content scanners

### DIFF
--- a/.claude/rules/content-quality.md
+++ b/.claude/rules/content-quality.md
@@ -27,6 +27,7 @@ This repository's primary audience is AI coding agents, not humans. Write accord
 - Show the full command with all required flags
 - Use `<PLACEHOLDER>` for user-provided values (angle brackets, UPPER_SNAKE_CASE)
 - Use a placeholder for any example value that carries the shape of a date, an identifier, or personal data — customer content-inspection gates match on shape alone and block the whole published package. Write `--expiration "<EXPIRATION_DATE>"`, never `--expiration "2027-01-15"`; write `<STREET_ADDRESS>` and `<PHONE_NUMBER>`, never a sample address or phone number; mask digit positions as `NNN-NN-NNNN`. State the required format in prose instead: ``--expiration <date>``, ISO 8601 `YYYY-MM-DD`.
+- Give each value one placeholder covering the whole value. Never glue a placeholder to a literal fragment: write `--from-date <FROM_TIMESTAMP>`, not `--from-date <FROM_DATE>T00:00:00Z`.
 - Keep product identifiers the reader needs verbatim — error codes, support-forum thread IDs in URLs, vendor documentation URLs. Those are content, not examples.
 - Specify whether a flag is required or optional
 - Show expected output when it clarifies behavior

--- a/.claude/rules/content-quality.md
+++ b/.claude/rules/content-quality.md
@@ -26,6 +26,8 @@ This repository's primary audience is AI coding agents, not humans. Write accord
 
 - Show the full command with all required flags
 - Use `<PLACEHOLDER>` for user-provided values (angle brackets, UPPER_SNAKE_CASE)
+- Use a placeholder for any example value that carries the shape of a date, an identifier, or personal data — customer content-inspection gates match on shape alone and block the whole published package. Write `--expiration "<EXPIRATION_DATE>"`, never `--expiration "2027-01-15"`; write `<STREET_ADDRESS>` and `<PHONE_NUMBER>`, never a sample address or phone number; mask digit positions as `NNN-NN-NNNN`. State the required format in prose instead: ``--expiration <date>``, ISO 8601 `YYYY-MM-DD`.
+- Keep product identifiers the reader needs verbatim — error codes, support-forum thread IDs in URLs, vendor documentation URLs. Those are content, not examples.
 - Specify whether a flag is required or optional
 - Show expected output when it clarifies behavior
 - Group related commands together

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -568,10 +568,15 @@ artifact. Literal dates are also the most common source of examples that go stal
 | `SetBookmarkContent("Phone", "+1 (555) 123-4567")` | `SetBookmarkContent("Phone", "<PHONE_NUMBER>")` |
 | `123-45-6789` | `NNN-NN-NNNN` — mask each digit position with `N` |
 | `"ffffffff-1111-2222-3333-444444444444"` | `"ffffffff-aaaa-bbbb-cccc-dddddddddddd"` — no long digit run |
+| `--from-date <FROM_DATE>T00:00:00Z` | `--from-date <FROM_TIMESTAMP>` — one placeholder per value |
 
 > The left column above deliberately spells out the literals it forbids: this file is not part of the
 > published npm package (see `files` in `package.json`), so the anti-examples never reach a customer scan.
 > Exclude `CONTRIBUTING.md` if you ever add a repository-wide content scanner.
+
+Give each value **one** placeholder covering the whole value. Gluing a placeholder to a literal fragment
+(`<FROM_DATE>T00:00:00Z`) keeps the literal in the file and reads worse than either form alone — use
+`<FROM_TIMESTAMP>` and state the expected precision in prose.
 
 State a required format in prose or in the flags table rather than demonstrating it with a literal. Write
 ``--expiration <date>``, ISO 8601 `YYYY-MM-DD` — not a made-up date that shows the format by example.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -481,6 +481,7 @@ Before submitting your PR, verify:
 ### General
 - [ ] CODEOWNERS updated with your GitHub handle
 - [ ] No secrets, tokens, or personal paths in any file
+- [ ] Command examples and sample output use `<UPPER_SNAKE_CASE>` placeholders — no literal dates, street addresses, phone numbers, or identifier-shaped digit runs ([Style Guide](#cli-commands))
 - [ ] No auto-generated or binary files committed (check `.gitignore`)
 - [ ] Markdown is well-formed (no broken links, proper heading hierarchy)
 
@@ -549,6 +550,38 @@ current set, the rationale, and how to change it: [docs/REQUIRED-CHECKS.md](docs
 - Use `--output json` when the output needs to be parsed
 - Use placeholders in angle brackets for user-provided values: `<PROJECT_DIR>`, `<FILE_PATH>`
 - Show expected output format when it helps understanding
+
+#### Use placeholders for example values, not literals
+
+Command examples, sample payloads, and sample output MUST use `<UPPER_SNAKE_CASE>` placeholders wherever
+a literal would carry the shape of a date, an identifier, or personal data. Two reasons, and the first is
+the one that blocks releases: customers run content-inspection gates over the published package, and those
+gates match on shape alone — an example does not have to contain real data to fail one and block the whole
+artifact. Literal dates are also the most common source of examples that go stale.
+
+| Do not write | Write instead |
+|---|---|
+| `--expiration "2027-01-15"` | `--expiration "<EXPIRATION_DATE>"` |
+| `--from-date 2026-01-01 --to-date 2026-01-31` | `--from-date <FROM_DATE> --to-date <TO_DATE>` |
+| `audit_2026-01-01_2026-01-31_<generatedAt>` | `audit_<from>_<to>_<generatedAt>` |
+| `SetBookmarkContent("Address", "123 Main Street")` | `SetBookmarkContent("Address", "<STREET_ADDRESS>")` |
+| `SetBookmarkContent("Phone", "+1 (555) 123-4567")` | `SetBookmarkContent("Phone", "<PHONE_NUMBER>")` |
+| `123-45-6789` | `NNN-NN-NNNN` — mask each digit position with `N` |
+| `"ffffffff-1111-2222-3333-444444444444"` | `"ffffffff-aaaa-bbbb-cccc-dddddddddddd"` — no long digit run |
+
+> The left column above deliberately spells out the literals it forbids: this file is not part of the
+> published npm package (see `files` in `package.json`), so the anti-examples never reach a customer scan.
+> Exclude `CONTRIBUTING.md` if you ever add a repository-wide content scanner.
+
+State a required format in prose or in the flags table rather than demonstrating it with a literal. Write
+``--expiration <date>``, ISO 8601 `YYYY-MM-DD` — not a made-up date that shows the format by example.
+
+Two narrow exceptions:
+
+- **Product identifiers the reader needs verbatim** — error codes, support-forum thread IDs inside URLs,
+  vendor documentation URLs. These are the content itself, not an example of it. Keep them.
+- **Regex reference tables**, where the example column has to match the pattern it documents. Mask the
+  digits (`NNN-NN-NNNN`) instead of deleting the row, and note the masking convention under the table.
 
 ### Naming Conventions Summary
 

--- a/skills/uipath-admin/references/audit-commands.md
+++ b/skills/uipath-admin/references/audit-commands.md
@@ -51,13 +51,13 @@ List visible audit event sources. Pass inner `id` GUIDs from `eventTargets[]` an
 Run queries with filters and cursor pagination:
 
 ```bash
-uip admin audit tenant events --from-date 2026-04-22T00:00:00Z --to-date 2026-04-29T00:00:00Z --limit 50 --output json
+uip admin audit tenant events --from-date <FROM_DATE>T00:00:00Z --to-date <TO_DATE>T00:00:00Z --limit 50 --output json
 ```
 
 | Flag | Required | Description |
 |---|---|---|
 | `--from-date <iso>` | no | ISO 8601 start; inclusive. Recommended for non-trivial queries. |
-| `--to-date <iso>` | no | ISO 8601 end; inclusive of the exact instant. Pass the next day’s start (for example `2026-02-01`) or `T23:59:59.999Z` to capture a full final day. Applies only to `events`; `export` bounds are whole-day inclusive, so the next-day trick over-exports. See [workflow-guide gotchas](./audit-workflow-guide.md#common-gotchas). |
+| `--to-date <iso>` | no | ISO 8601 end; inclusive of the exact instant. Pass the next day’s start or `T23:59:59.999Z` to capture a full final day. Applies only to `events`; `export` bounds are whole-day inclusive, so the next-day trick over-exports. See [workflow-guide gotchas](./audit-workflow-guide.md#common-gotchas). |
 | `--source <guid...>` | no | Repeatable event-source filter; discover IDs with `sources`. |
 | `--target <guid...>` | no | Repeatable event-target filter. |
 | `--type <guid...>` | no | Repeatable event-type filter. |
@@ -77,7 +77,7 @@ uip admin audit tenant events --from-date 2026-04-22T00:00:00Z --to-date 2026-04
   "auditEvents": [
     {
       "id": "...",
-      "createdOn": "2026-04-29T17:46:07.123Z",
+      "createdOn": "...",
       "organizationId": "...",
       "organizationName": "...",
       "tenantId": "...",
@@ -110,14 +110,14 @@ Run the long-term audit store export for `[--from-date, --to-date]` as inclusive
 
 ```bash
 uip admin audit tenant export \
-  --from-date 2026-01-01 \
-  --to-date 2026-01-31 \
+  --from-date <FROM_DATE> \
+  --to-date <TO_DATE> \
   --output-path ./audit-exports \
   --output json
 
 uip admin audit tenant export \
-  --from-date 2026-01-01 \
-  --to-date 2026-01-31 \
+  --from-date <FROM_DATE> \
+  --to-date <TO_DATE> \
   --file-format csv \
   --output-path ./audit-exports \
   --output json
@@ -130,7 +130,7 @@ uip admin audit tenant export \
   --output json
 ```
 
-Pass a directory, never a filename or extension. Each run creates `audit_<from>_<to>_<generated-at>`: a folder of day-wise JSON files by default or one merged CSV. JSON output is `./audit-exports/audit_2026-01-01_2026-01-31_<generatedAt>/`; CSV output is `./audit-exports/audit_2026-01-01_2026-01-31_<generatedAt>.csv`. The generated-at value is to the second; repeated exports do not collide.
+Pass a directory, never a filename or extension. Each run creates `audit_<from>_<to>_<generated-at>`: a folder of day-wise JSON files by default or one merged CSV. JSON output is `./audit-exports/audit_<from>_<to>_<generatedAt>/`; CSV output is `./audit-exports/audit_<from>_<to>_<generatedAt>.csv`. The generated-at value is to the second; repeated exports do not collide.
 
 This is the organization/tenant audit event store (LTS-schema columns such as `Identifier`, `DateCreatedUtc`, `ActorId`, `Action`, `Source`, `Category`) for compliance dumps, login history, and cross-platform “who did what where.” It is not `uip or audit-logs list --export` (the uipath-platform skill), which exports one Orchestrator tenant’s operational actions with `Component,User,Action,Operation,Time` columns. An org/tenant audit-event or compliance export with a date window and `--output-path`, whether JSON files or spreadsheet/Excel CSV, belongs here.
 
@@ -150,13 +150,13 @@ This is the organization/tenant audit event store (LTS-schema columns such as `I
 
 ```json
 {
-  "Path": "C:\\absolute\\path\\to\\audit-exports\\audit_2026-01-01_2026-01-31_20260617T112630",
+  "Path": "C:\\absolute\\path\\to\\audit-exports\\audit_<from>_<to>_<generatedAt>",
   "Format": "json",
   "Files": 27,
   "Bytes": 1841,
   "Days": 31,
   "NonEmptyDays": 27,
-  "GeneratedAt": "2026-06-17T11:26:30.000Z"
+  "GeneratedAt": "<GENERATED_AT>"
 }
 ```
 
@@ -188,7 +188,7 @@ These program-level `uip` flags appear on every command:
 ```json
 {
   "Result": "Failure",
-  "Message": "Audit export failed for 2026-04-02 (HTTP 504): Gateway Timeout",
+  "Message": "Audit export failed for <DATE> (HTTP 504): Gateway Timeout",
   "Instructions": "Ensure you are logged in with 'uip login' and have access to the audit service."
 }
 ```

--- a/skills/uipath-admin/references/audit-commands.md
+++ b/skills/uipath-admin/references/audit-commands.md
@@ -51,7 +51,7 @@ List visible audit event sources. Pass inner `id` GUIDs from `eventTargets[]` an
 Run queries with filters and cursor pagination:
 
 ```bash
-uip admin audit tenant events --from-date <FROM_DATE>T00:00:00Z --to-date <TO_DATE>T00:00:00Z --limit 50 --output json
+uip admin audit tenant events --from-date <FROM_TIMESTAMP> --to-date <TO_TIMESTAMP> --limit 50 --output json
 ```
 
 | Flag | Required | Description |

--- a/skills/uipath-admin/references/audit-workflow-guide.md
+++ b/skills/uipath-admin/references/audit-workflow-guide.md
@@ -59,8 +59,8 @@ uip admin audit tenant events \
   --source <ORCHESTRATOR_SOURCE_GUID> \
   --target <FOLDERS_TARGET_GUID> \
   --type   <DELETE_FOLDER_TYPE_GUID> \
-  --from-date   2026-05-11T00:00:00Z \
-  --to-date     2026-05-18T00:00:00Z \
+  --from-date   <FROM_DATE>T00:00:00Z \
+  --to-date     <TO_DATE>T00:00:00Z \
   --limit  50 \
   --output json
 ```
@@ -120,8 +120,8 @@ Run:
 uip admin audit org events \
   --user-id   <USER_GUID> \
   --type      <USER_LOGIN_TYPE_GUID> \
-  --from-date 2026-04-01T00:00:00Z \
-  --to-date   2026-04-29T23:59:59Z \
+  --from-date <FROM_DATE>T00:00:00Z \
+  --to-date   <TO_DATE>T23:59:59Z \
   --limit     200 \
   --output    json
 ```
@@ -133,8 +133,8 @@ uip admin audit org events \
   --user-id   <USER_GUID> \
   --type      <USER_LOGIN_TYPE_GUID> \
   --status    Failure \
-  --from-date 2026-04-01T00:00:00Z \
-  --to-date   2026-04-29T23:59:59Z \
+  --from-date <FROM_DATE>T00:00:00Z \
+  --to-date   <TO_DATE>T23:59:59Z \
   --output    json
 ```
 
@@ -165,23 +165,23 @@ Run the applicable command:
 ```bash
 # Tenant scope — most events (default json: a uniquely-named folder of day-wise JSON files under the base dir)
 uip admin audit tenant export \
-  --from-date 2026-01-01 \
-  --to-date   2026-01-31 \
+  --from-date <FROM_DATE> \
+  --to-date   <TO_DATE> \
   --output-path ./audit-exports \
   --output json
 
 # Tenant scope as a single merged CSV (flat, Excel-friendly)
 uip admin audit tenant export \
-  --from-date 2026-01-01 \
-  --to-date   2026-01-31 \
+  --from-date <FROM_DATE> \
+  --to-date   <TO_DATE> \
   --file-format csv \
   --output-path ./audit-exports \
   --output json
 
 # Org scope — admin events (memberships, license, tenant lifecycle)
 uip admin audit org export \
-  --from-date 2026-01-01 \
-  --to-date   2026-01-31 \
+  --from-date <FROM_DATE> \
+  --to-date   <TO_DATE> \
   --output-path ./audit-exports \
   --output json
 ```
@@ -200,10 +200,10 @@ Typical layout:
 
 ```text
 audit-exports/
-└── audit_2026-01-01_2026-01-31_20260617T112630/
-    ├── 2026-01-01.json
+└── audit_<from>_<to>_<generatedAt>/
+    ├── <FROM_DATE>.json
     ├── ...
-    └── 2026-01-31.json
+    └── <TO_DATE>.json
 ```
 
 Each file is a JSON array with LTS-schema keys (`Identifier`, `DateCreatedUtc`, `OrganizationId`, `ActorId`, `User`, `Action`, …), unlike the camelCase live `events` response. Tell downstream users about this difference.
@@ -233,8 +233,8 @@ Run both scopes over a bounded recent window without filters, then summarize eve
 Run:
 
 ```bash
-uip admin audit org    events --from-date 2026-04-22 --to-date 2026-04-29 --limit 100 --output json > /tmp/org-events.json
-uip admin audit tenant events --from-date 2026-04-22 --to-date 2026-04-29 --limit 100 --output json > /tmp/tenant-events.json
+uip admin audit org    events --from-date <FROM_DATE> --to-date <TO_DATE> --limit 100 --output json > /tmp/org-events.json
+uip admin audit tenant events --from-date <FROM_DATE> --to-date <TO_DATE> --limit 100 --output json > /tmp/tenant-events.json
 ```
 
 ### Step 2 — Group by event type
@@ -265,8 +265,8 @@ If multiple signals appear, run the investigations in sequence and stitch the re
 
 - **Tenant context:** `tenant` commands fail without an active tenant. Re-run `uip login` with a tenant or pass `--tenant-id <guid>` on every call.
 - **Pagination:** `next` means newer and is often null; `previous` means older. The CLI follows `previous` automatically for `--limit > 200`; do not reimplement it.
-- **Events dates:** date-only ISO strings mean UTC midnight. `--from-date 2026-01-01` means `2026-01-01T00:00:00Z`. To include the full final day, use `--to-date 2026-02-01` as an exclusive next day or `--to-date 2026-01-31T23:59:59.999Z`.
-- **Export dates:** bounds are inclusive whole UTC days. January is `--from-date 2026-01-01 --to-date 2026-01-31`; a single day uses the same date for both. Do not use the events next-day convention for exports.
+- **Events dates:** date-only ISO strings mean UTC midnight. `--from-date <FROM_DATE>` means `<FROM_DATE>T00:00:00Z`. To include the full final day, pass the day *after* the window as an exclusive `--to-date`, or append `T23:59:59.999Z` to the final day.
+- **Export dates:** bounds are inclusive whole UTC days. A whole month is its first and last day; a single day uses the same date for both. Do not use the events next-day convention for exports.
 - **Export lag:** the long-term store typically lags live `events` by up to 24–48 hours. Recent trailing days may be empty; offer to rerun later or end the window 2 days earlier when completeness matters.
 - **Relative dates:** resolve them with `date -u +%F`, `date -u -d 'yesterday' +%F`, or macOS/BSD `date -u -v-1d +%F`, and echo the window.
 - **Export schema:** default `json` writes one `<YYYY-MM-DD>.json` per UTC day in a generated folder; `--file-format csv` writes one merged CSV with the same LTS-schema field names. Both differ from live camelCase `events`; do not feed exports to a live-shape parser.

--- a/skills/uipath-admin/references/audit-workflow-guide.md
+++ b/skills/uipath-admin/references/audit-workflow-guide.md
@@ -59,8 +59,8 @@ uip admin audit tenant events \
   --source <ORCHESTRATOR_SOURCE_GUID> \
   --target <FOLDERS_TARGET_GUID> \
   --type   <DELETE_FOLDER_TYPE_GUID> \
-  --from-date   <FROM_DATE>T00:00:00Z \
-  --to-date     <TO_DATE>T00:00:00Z \
+  --from-date   <FROM_TIMESTAMP> \
+  --to-date     <TO_TIMESTAMP> \
   --limit  50 \
   --output json
 ```
@@ -120,11 +120,13 @@ Run:
 uip admin audit org events \
   --user-id   <USER_GUID> \
   --type      <USER_LOGIN_TYPE_GUID> \
-  --from-date <FROM_DATE>T00:00:00Z \
-  --to-date   <TO_DATE>T23:59:59Z \
+  --from-date <FROM_TIMESTAMP> \
+  --to-date   <TO_TIMESTAMP> \
   --limit     200 \
   --output    json
 ```
+
+Pass full ISO instants here: a date-only `--to-date` stops at midnight and drops the final day’s logins.
 
 For failed logins, run:
 
@@ -133,8 +135,8 @@ uip admin audit org events \
   --user-id   <USER_GUID> \
   --type      <USER_LOGIN_TYPE_GUID> \
   --status    Failure \
-  --from-date <FROM_DATE>T00:00:00Z \
-  --to-date   <TO_DATE>T23:59:59Z \
+  --from-date <FROM_TIMESTAMP> \
+  --to-date   <TO_TIMESTAMP> \
   --output    json
 ```
 
@@ -265,7 +267,7 @@ If multiple signals appear, run the investigations in sequence and stitch the re
 
 - **Tenant context:** `tenant` commands fail without an active tenant. Re-run `uip login` with a tenant or pass `--tenant-id <guid>` on every call.
 - **Pagination:** `next` means newer and is often null; `previous` means older. The CLI follows `previous` automatically for `--limit > 200`; do not reimplement it.
-- **Events dates:** date-only ISO strings mean UTC midnight. `--from-date <FROM_DATE>` means `<FROM_DATE>T00:00:00Z`. To include the full final day, pass the day *after* the window as an exclusive `--to-date`, or append `T23:59:59.999Z` to the final day.
+- **Events dates:** a date-only ISO string means UTC midnight — `--from-date` given a bare `YYYY-MM-DD` resolves to `T00:00:00Z` on that day. To include the full final day, pass the day *after* the window as an exclusive `--to-date`, or give `--to-date` a full instant ending `T23:59:59.999Z`.
 - **Export dates:** bounds are inclusive whole UTC days. A whole month is its first and last day; a single day uses the same date for both. Do not use the events next-day convention for exports.
 - **Export lag:** the long-term store typically lags live `events` by up to 24–48 hours. Recent trailing days may be empty; offer to rerun later or end the window 2 days earlier when completeness matters.
 - **Relative dates:** resolve them with `date -u +%F`, `date -u -d 'yesterday' +%F`, or macOS/BSD `date -u -v-1d +%F`, and echo the window.

--- a/skills/uipath-admin/references/external-app-management.md
+++ b/skills/uipath-admin/references/external-app-management.md
@@ -55,7 +55,7 @@ Any app with `--user-scope` requires `--redirect-uri` for authorization-code flo
 
 Run the following to generate a secret; its value is shown only once:
 ```bash
-uip admin external-apps generate-secret <CLIENT_ID> --description "Rotated secret" --expiration "2027-06-01" --output json
+uip admin external-apps generate-secret <CLIENT_ID> --description "Rotated secret" --expiration "<EXPIRATION_DATE>" --output json
 ```
 
 Confirm with the user first, then run the following to delete a secret; only the secret ID is required:

--- a/skills/uipath-admin/references/pat-management.md
+++ b/skills/uipath-admin/references/pat-management.md
@@ -19,7 +19,7 @@ PATs provide scoped API authentication for users when user-context authenticatio
    ```bash
    uip admin pat create \
      --description "CI/CD pipeline token" \
-     --expiration "2027-01-15" \
+     --expiration "<EXPIRATION_DATE>" \
      --scope "OR.Folders.Read,OR.Jobs.Read" \
      --output json
    ```
@@ -44,7 +44,7 @@ uip admin pat revoke <TOKEN_ID> --output json
 Run the following with a new expiration. The new token value is returned only once:
 
 ```bash
-uip admin pat regenerate <TOKEN_ID> --expiration "2028-01-15" --output json
+uip admin pat regenerate <TOKEN_ID> --expiration "<EXPIRATION_DATE>" --output json
 ```
 
 ## Error Handling

--- a/skills/uipath-rpa/references/activity-docs/UiPath.AzureWVD.Activities/1.5/coded/examples.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.AzureWVD.Activities/1.5/coded/examples.md
@@ -273,7 +273,7 @@ namespace MyProject
             string[] userIds = new[]
             {
                 "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",  // Azure AD object ID
-                "ffffffff-1111-2222-3333-444444444444"
+                "ffffffff-aaaa-bbbb-cccc-dddddddddddd"
             };
             await roleService.AssignObjectsToApplicationGroup(appGroup, userIds);
             Log("Users assigned to application group.");

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.5/coded/examples.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.5/coded/examples.md
@@ -100,10 +100,10 @@ namespace MyProject
             using var doc = word.UseWordDocument("form.docx");
 
             // Fill bookmarks with data
-            doc.SetBookmarkContent("CompanyName", "Acme Corporation");
-            doc.SetBookmarkContent("Address", "123 Main Street, Suite 100");
-            doc.SetBookmarkContent("ContactName", "John Smith");
-            doc.SetBookmarkContent("Phone", "+1 (555) 123-4567");
+            doc.SetBookmarkContent("CompanyName", "<COMPANY_NAME>");
+            doc.SetBookmarkContent("Address", "<STREET_ADDRESS>");
+            doc.SetBookmarkContent("ContactName", "<CONTACT_NAME>");
+            doc.SetBookmarkContent("Phone", "<PHONE_NUMBER>");
             doc.SetBookmarkContent("Date", DateTime.Now.ToString("yyyy-MM-dd"));
 
             Log("Bookmarks populated successfully.");

--- a/skills/uipath-rpa/references/legacy/data-manipulation-guide.md
+++ b/skills/uipath-rpa/references/legacy/data-manipulation-guide.md
@@ -15,15 +15,17 @@ Use `System.Text.RegularExpressions.Regex` for pattern matching and extraction. 
 | Pattern | RegEx | Match Examples |
 |---|---|---|
 | Email | `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}` | `user@example.com` |
-| Phone (US) | `\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}` | `(555) 123-4567`, `555.123.4567` |
-| Date (MM/DD/YYYY) | `\d{2}/\d{2}/\d{4}` | `01/15/2025` |
-| Date (YYYY-MM-DD) | `\d{4}-\d{2}-\d{2}` | `2025-01-15` |
+| Phone (US) | `\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}` | `(NNN) NNN-NNNN`, `NNN.NNN.NNNN` |
+| Date (MM/DD/YYYY) | `\d{2}/\d{2}/\d{4}` | `MM/DD/YYYY` |
+| Date (YYYY-MM-DD) | `\d{4}-\d{2}-\d{2}` | `YYYY-MM-DD` |
 | Currency (USD) | `\$[\d,]+\.?\d{0,2}` | `$1,234.56`, `$50` |
 | Invoice Number | `INV-\d{4,10}` | `INV-12345`, `INV-0001234567` |
 | ZIP Code (US) | `\d{5}(-\d{4})?` | `90210`, `90210-1234` |
-| SSN | `\d{3}-\d{2}-\d{4}` | `123-45-6789` |
+| SSN | `\d{3}-\d{2}-\d{4}` | `NNN-NN-NNNN` |
 | IP Address | `\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}` | `192.168.1.1` |
 | Decimal Number | `-?\d+\.?\d*` | `123.45`, `-67`, `0.5` |
+
+> `N` marks a digit position. Examples for personally identifiable patterns are masked, not literal values.
 
 ### VB.NET Usage
 
@@ -376,7 +378,7 @@ CDbl("1,234.56")   ' Works on US locale, fails on German locale (1.234,56)
 Double.Parse("1,234.56", System.Globalization.CultureInfo.InvariantCulture)
 
 ' SAFE: explicit date format
-DateTime.ParseExact("01/15/2025", "MM/dd/yyyy", System.Globalization.CultureInfo.InvariantCulture)
+DateTime.ParseExact(dateText, "MM/dd/yyyy", System.Globalization.CultureInfo.InvariantCulture)
 ```
 
 ### Common Conversion Traps

--- a/skills/uipath-rpa/references/legacy/testing-guide.md
+++ b/skills/uipath-rpa/references/legacy/testing-guide.md
@@ -111,7 +111,7 @@ Sequence "Test_ValidateInput_MultipleScenarios"
 | `"INV-12345"` | True | Valid invoice number |
 | `""` | False | Empty string |
 | `"INV"` | False | Incomplete format |
-| `"INV-99999999999"` | False | Number too long |
+| `"INV-"` + 11 digits | False | Number too long |
 | `"inv-12345"` | True | Lowercase (should be case-insensitive) |
 
 ### Data Sources


### PR DESCRIPTION
## Summary

- Replace literal dates, addresses, phone numbers, and identifier-shaped digit runs in **10 documentation files** with the repo's existing `<UPPER_SNAKE_CASE>` placeholder convention
- Unblocks a customer whose content-inspection gate rejected the published package on 21 findings — all false positives on example text, but a shape-based gate blocks the artifact either way
- Add the rule to `CONTRIBUTING.md` § CLI Commands and `.claude/rules/content-quality.md` so new examples don't reintroduce it

No credential, live PII, or cardholder data exists in the repo. An independent sweep over all tracked files (AWS key IDs, private keys, `gh*_`/`xox*`/`sk_live` tokens, JWTs, npm/PyPI tokens, Luhn-valid PANs) returned zero hits. This PR removes *shapes*, not secrets.

## Changes

### `uipath-admin`

- `pat-management.md`, `external-app-management.md` — `--expiration "2027-01-15"` → `--expiration "<EXPIRATION_DATE>"`
- `audit-commands.md`, `audit-workflow-guide.md` — export windows → `<FROM_DATE>` / `<TO_DATE>`; generated names → `audit_<from>_<to>_<generatedAt>`, the placeholder both files already used in prose

> Both audit references are now free of **every** literal calendar date, not just the lines the customer's scan reported. The detector fired on an unpredictable subset — `2026-01-01` yes, `2026-04-22` no — so a partial fix would fail the next scan.

### `uipath-rpa`

- `UiPath.Word.Activities/…/examples.md` — mail-merge sample data → `<COMPANY_NAME>` / `<STREET_ADDRESS>` / `<CONTACT_NAME>` / `<PHONE_NUMBER>`
- `UiPath.AzureWVD.Activities/…/examples.md` — placeholder GUID loses its digit runs: `ffffffff-1111-2222-3333-444444444444` → `ffffffff-aaaa-bbbb-cccc-dddddddddddd`, matching the letter-based GUID on the line above it
- `legacy/data-manipulation-guide.md` — regex table masks digit positions (`NNN-NN-NNNN`, `MM/DD/YYYY`) with a note explaining `N`; `ParseExact` takes a `dateText` variable instead of a literal
- `legacy/testing-guide.md` — the "number too long" row describes its length instead of spelling out 11 digits

## Left unchanged, deliberately

Four findings are product data the playbooks exist to convey, not examples. Editing them would break the page:

- Orchestrator error code `170002` (`uipath-troubleshoot`) — the identifier being diagnosed
- Two `forum.uipath.com` thread IDs inside URLs — the ID *is* the link
- A Databricks documentation URL in `vendor-docs-registry.json` — matched a 40-char AWS-secret shape rule

These need an allowlist on the scanning side. The cleanest ask is excluding documentation-only artifacts from cardholder-data scanning: the package is Markdown and JSON reference material with no runtime data path.

## Testing

- `npm run skills:validate` — OK, default 27 skills / 1765 files; studioweb 27 / 1765 / 264 replacements
- `npm run skills:check-links` — 6723 relative links, all resolve
- `npm run skills:build` — both trees build clean
- `python scripts/check-skill-status.py` — OK, 27 skills, manifest valid
- `python scripts/check-skills-sh.py` — OK, 27 skills across 4 sections
- Re-scanned all 10 files with the shape detectors that produced the original findings: **0 remaining matches**

No skill folder added, renamed, or removed, so `assets/skill-status.json` and `skills.sh.json` need no edit. No flavor overrides or `skill-flavor` markers touch any edited file.

## Reviewer notes

> `CONTRIBUTING.md` deliberately spells out the literals it forbids, in the "Do not write" column. That file is not in `files` in `package.json`, so the anti-examples never reach a customer scan — there's an inline note saying so, and to exclude it if we ever add a repository-wide content scanner.

Worth considering as a follow-up: none of the 22 workflows scans content today, so nothing stops the next literal date from landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
