### PR TITLE
docs: promote uipath-maestro-flow to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | `uipath-ixp` | In-development |
 | `uipath-maestro-bpmn` | In-development |
 | `uipath-maestro-case` | In-development |
-| `uipath-maestro-flow` | In-development |
+| `uipath-maestro-flow` | Stable |
 | `uipath-mcp-servers` | In-development |
 | `uipath-planner` | Preview |
 | `uipath-platform` | Stable |

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -146,7 +146,7 @@
       "last_synced": null
     },
     "uipath-maestro-flow": {
-      "status": "in-development",
+      "status": "stable",
       "confluence": {
         "page_id": null,
         "url": null


### PR DESCRIPTION
## What

Flips `uipath-maestro-flow` from `in-development` to `stable` in `assets/skill-status.json`, and regenerates the README status table.

- `assets/skill-status.json:149` — status → `stable`
- `README.md:121` — table row regenerated by the script, not hand-edited

## Notes

- No SKILL.md change. Status lives only in the manifest per `.claude/rules/skill-structure.md`; there is no marker in frontmatter or body to update.
- Verified:
  - `python3 scripts/check-skill-status.py --write-readme` → clean
  - `python3 scripts/check-skills-sh.py` → `OK — 27 skills grouped across 4 section(s).`
- "Flow skill" resolved to `uipath-maestro-flow` (the `.flow` owner). A local `skills/uipath-flow/` directory exists on my machine but is untracked cruft, not a skill.

## Recommendation

Approve. Single-value metadata change, generated table in sync, both validators pass.

## tl;dr

Flow skill is now Stable in the manifest, README regenerated. Nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)