### PR TITLE
docs: promote uipath-coded-apps to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | `uipath-api-workflow` | In-development |
 | `uipath-automation-discovery` | Preview |
 | `uipath-automationhub` | In-development |
-| `uipath-coded-apps` | Preview |
+| `uipath-coded-apps` | Stable |
 | `uipath-connector-builder` | In-development |
 | `uipath-feedback` | Stable |
 | `uipath-functions` | Preview |

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -66,7 +66,7 @@
       "last_synced": null
     },
     "uipath-coded-apps": {
-      "status": "preview",
+      "status": "stable",
       "confluence": {
         "page_id": null,
         "url": null


### PR DESCRIPTION
## What

Mirrors #3205 for Coded Apps: flips `uipath-coded-apps` from `preview` to `stable` in `assets/skill-status.json`, and regenerates the README status table.

- `assets/skill-status.json:69` — status → `stable`
- `README.md:111` — table row regenerated by the script, not hand-edited

## Notes

- No SKILL.md change. Status lives only in the manifest per `.claude/rules/skill-structure.md`; there is no marker in frontmatter or body to update.
- Verified:
  - `python3 scripts/check-skill-status.py --write-readme` → clean
  - `python3 scripts/check-skills-sh.py` → `OK — 27 skills grouped across 4 section(s).`

## tl;dr

Coded Apps skill is now Stable in the manifest, README regenerated. Nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)