### PR TITLE
fix(uipath-maestro-bpmn): variables carry an elementId; script mappings use BPMN.Variables

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -280,7 +280,8 @@ registry serves a template for vs. what you author by hand:
 
 | Structure | Source |
 | --- | --- |
-| Node `uipath:*` payloads (RPA, agent, HITL, queue, business rule, API workflow, IS connector, internal message, timer, script, variables) | **Registry** `xmlTemplate` |
+| Node `uipath:*` payloads (RPA, agent, HITL, queue, business rule, API workflow, IS connector, internal message, timer, script) | **Registry** `xmlTemplate` |
+| `<uipath:variables>` declarations (each with an `elementId`) | Authored (registry gap) |
 | `<bpmn:definitions>`/`<bpmn:process>` scaffold + namespaces | Authored (registry gap) |
 | Sequence flows, `conditionExpression`, gateway `default` | Authored (registry gap) |
 | Gateways: exclusive, parallel, inclusive, event-based (complex is preserve-only) | Authored (registry gap) |

--- a/skills/uipath-maestro-bpmn/references/expression-authoring.md
+++ b/skills/uipath-maestro-bpmn/references/expression-authoring.md
@@ -13,12 +13,13 @@ them with expressions only after the variables and scopes exist.
 - Do not use bare variable names such as `=requestId` in generated runtime XML.
 - Context bindings use `=bindings.<bindingId>`.
 - Current element outputs use `result` only in output mappings for that
-  element. For new BPMN script tasks, return an object and expose its value
-  through `result.response`: use `return { response: value };` with
-  `source="=result.response"` for a scalar variable, or return a nested object
-  and use `source="=result.response.<field>"` for a field. Do not use
-  `source="=result"` with a bare scalar return in live debug/runtime BPMN; the
-  run can complete while the mapped variable reads back empty.
+  element. A script task at `uipath:scriptVersion` v2 or later returns its value
+  directly and the runtime wraps it as `result.response`. Use `return value;`
+  with `source="=result.response"` for a scalar variable, or return an object
+  and use `source="=result.response.<field>"` for one of its fields. Do not wrap
+  the return yourself — `return { response: value };` double-wraps to
+  `result.response.response` — and do not use `source="=result"`, which reads
+  the wrapper object instead of the value.
 - Multi-instance task bodies read the current item from `iterator.item`.
 - Multi-instance subprocess bodies read the current item from
   `iterator[0].item`. Use `iterator[1].item` (and so on) inside nested
@@ -87,26 +88,21 @@ Do not use assignment operators in these fields. Comparisons such as `==`,
 
 ## Scope and availability
 
-- Root variables are visible across the root process after they are declared and
-  reachable by control flow.
-- An output variable you intend to expose in runtime inspection (via
-  `debug-instance variables-all` or `instance variables`) must be root-scoped —
-  declare its `uipath:output` or `uipath:inputOutput` WITHOUT an `elementId`. A
-  variable scoped with `elementId` is bound to that element and is not surfaced
-  as a root/global runtime variable. Preserve exact variable ids: if the
-  requested variable id is `product`, declare `id="product"` and map to
-  `var="product"`, not `Product` or `Var_Product`. Current BPMN live debug may
-  expose the root output definition while still returning the value as `null`;
-  treat that as a runtime/debug API limitation, not proof that the authored
-  mapping is absent.
+- A process-level variable is readable from anywhere in the root process, and is
+  what `debug-instance variables-all` and `instance variables` surface. Declare
+  it scoped to the process — see [structural-bpmn.md](structural-bpmn.md). A
+  variable scoped to a node is bound to that node and is not surfaced as a
+  process-level runtime variable.
+- Preserve exact variable ids: if the requested variable id is `product`,
+  declare `id="product"` and map to `var="product"`, not `Product` or
+  `Var_Product`.
 - Subprocess variables stay scoped to that subprocess.
 - Output mappings should target `uipath:inputOutput` or `uipath:output`
   variables, not read-only `uipath:input` variables.
 - Entry point inputs that must later be updated need a separate mutable
   `uipath:inputOutput` variable and an explicit mapping from the entry input.
-- Trigger-bound values are commonly represented as `uipath:inputOutput`
-  variables scoped with `elementId` so the trigger can write them during
-  execution.
+- Trigger-bound values are `uipath:inputOutput` variables scoped to the trigger
+  node, so the trigger can write them during execution.
 
 ## Common mistakes
 

--- a/skills/uipath-maestro-bpmn/references/registry-workflow.md
+++ b/skills/uipath-maestro-bpmn/references/registry-workflow.md
@@ -188,8 +188,8 @@ auth, schema, or enrichment decision is missing).
 
 1. Build the document scaffold and process (see
    [structural-bpmn.md](structural-bpmn.md)).
-2. Declare root variables (`BPMN.Variables` template) and the
-   `<uipath:bindings>` block.
+2. Declare the process's variables (`<uipath:variables>`, each with an
+   `elementId`) and the `<uipath:bindings>` block.
 3. For each node, paste its `registry get` `xmlTemplate`, fill placeholders, and
    wire `{incomingEdge}`/`{outgoingEdge}` to your sequence flows.
 4. Author the structural BPMN the registry does not emit: sequence flows,

--- a/skills/uipath-maestro-bpmn/references/structural-bpmn.md
+++ b/skills/uipath-maestro-bpmn/references/structural-bpmn.md
@@ -124,20 +124,25 @@ example BPMN files** — it is the main reason authoring runs out of time.
 </bpmn:definitions>
 ```
 
-## Variables (`BPMN.Variables`)
+## Variables
 
-Declare root variables with the `BPMN.Variables` registry template attached to
-the process via `extensionElements`, or use the canvas `<uipath:variables>`
-block directly. Every declaration needs a stable, unique `id`, a non-empty
-user-facing `name`, and its documented `type`; do not use the name as a
-substitute for the id. Expressions reference the id as `vars.<id>`. Public or
-node-scoped declarations also carry the owning node's `elementId`. Variable
-schema bodies are JSON text or CDATA.
+Declare variables in the process's own `<uipath:variables>` block. Every
+declaration needs a stable, unique `id`, a non-empty user-facing `name`, and its
+documented `type`; do not use the name as a substitute for the id. Expressions
+reference the id as `vars.<id>`. Variable schema bodies are JSON text or CDATA.
+
+Every declaration also carries an `elementId` naming the element that owns it:
+the `<bpmn:process>` id for a process-level variable, the start event id for a
+caller-supplied input, the end event id for a published output, the owning node's
+id for a node-scoped variable. A subprocess-level variable is keyed inside its
+own subprocess: the subprocess id, or the node in it that writes the value —
+both import cleanly. Without an `elementId` the declaration does not exist to
+the canvas, and every `vars.<id>` reference to it fails on import.
 
 ```xml
 <uipath:variables version="v1">
   <uipath:input id="input_ExpenseId" name="expenseId" type="string" elementId="Start_1" />
-  <uipath:inputOutput id="Var_Decision" name="decision" type="string" />
+  <uipath:inputOutput id="Var_Decision" name="decision" type="string" elementId="Process_1" />
   <uipath:output id="output_Decision" name="decision" type="string" elementId="End_1" />
 </uipath:variables>
 ```
@@ -159,7 +164,8 @@ Sub-process-scoped variables go in that sub-process's own `<uipath:variables>`.
 
 `bpmn:scriptTask scriptFormat="JavaScript"` runs under **Jint**, not Node.js or
 a browser. The mapping payload comes from the `BPMN.ScriptTask` registry
-template, but the runtime contract is fixed:
+template, but the runtime contract is fixed — including one correction to that
+template, in the first rule below:
 
 - Only these helpers exist: `uipath.aggregate`, `uipath._aggregate`,
   `uipath._pipe`, and a no-op `console`. No npm packages, filesystem, network,
@@ -177,23 +183,30 @@ template, but the runtime contract is fixed:
   never retrofit these attributes onto an untouched node's mapping — a
   pre-existing `<uipath:input name="args">` outside the edit's target stays
   byte-identical.
-- Map the returned object's property back through `source="=result.response"`
-  (the conventional scalar property) or `source="=result.response.<field>"`
-  (another object field); `var` points at a declared variable id (do not put the
-  target id in `name`).
-- When the output mapping uses `source="=result.response"`, return an object
-  with a `response` property, such as `return { response: 6 * 7 };`. Do not
-  return the bare primitive `42` for that mapping shape; there is no
-  `response` property to bind, so the runtime variable stays empty.
-- Do not use `source="=result"` with a bare scalar return in live debug/runtime
-  BPMN. Studio Web can report `FinalStatus: Completed` while the target root
-  variable still reads back as `{}` or `null` from
-  `debug-instance variables-all`.
-- For live debug/runtime runs, never use `source="=this.result"` or
-  `<uipath:type value="BPMN.Variables" ...>` on a script task output mapping.
-  That older structural-test shape can pass local validation but leaves root
-  variables `null` or faults in Studio Web. Use the `BPMN.ScriptTask` mapping
-  with `source="=result.response"`.
+- **The mapping's type child is `<uipath:type value="BPMN.Variables"
+  version="v1" />`, not `BPMN.ScriptTask`.** The registry's `BPMN.ScriptTask`
+  `xmlTemplate` emits the latter, and this is the first of two corrections that
+  template needs: any `uipath:type` other than `BPMN.Variables` overwrites the parser's
+  `Scp.Script` extension type, so the runtime never dispatches the script. The
+  element still completes, the output mapping resolves against an empty result,
+  and the target variable reads back `null`. Verified live: two files differing
+  only in this attribute returned `product: 42` (`BPMN.Variables`) and
+  `product: null` (`BPMN.ScriptTask`).
+- Map the return through `source="=result.response"` for a scalar, or
+  `source="=result.response.<field>"` for a field of a returned object; `var`
+  points at a declared variable id (do not put the target id in `name`).
+- **The template ships no `<uipath:scriptVersion>`, and that is the second
+  correction.** A missing element parses as `v1`
+  (`UiPath.PO.BpmnParser/Extensions/Xml/ScriptReader.cs`), and at v1 the runtime
+  demands an object return and throws `ScriptTaskInvocationResultError`
+  otherwise. So a template pasted with only the type child corrected, plus the
+  bare return below, faults at run time. Add
+  `<uipath:scriptVersion value="v3" />` as a sibling of `uipath:mapping`.
+- Return the value directly — `return 6 * 7;`. At `scriptVersion` v2 or later the
+  runtime wraps the return under `response` itself, so returning
+  `{ response: value }` yields `result.response.response`. Do not use
+  `source="=result"` or `source="=this.result"`, which read the wrapper object
+  rather than the value.
 - Do not mutate `Globals.*`, `vars.*`, or process variables inside the script
   body. The supported path is: return a value from the script, then use a
   `uipath:output` mapping to write it to the declared variable. Direct mutation
@@ -204,14 +217,14 @@ template, but the runtime contract is fixed:
   <bpmn:extensionElements>
     <uipath:scriptVersion value="v3" />
     <uipath:mapping version="v1">
-      <uipath:type value="BPMN.ScriptTask" version="v1" />
+      <uipath:type value="BPMN.Variables" version="v1" />
       <uipath:input name="args" type="json" target="bodyField"><![CDATA[{"amount":"=vars.Var_Amount","daysOverdue":"=vars.Var_DaysOverdue"}]]></uipath:input>
       <uipath:output name="riskScore" type="number" var="Var_RiskScore" source="=result.response" />
     </uipath:mapping>
   </bpmn:extensionElements>
   <bpmn:script><![CDATA[
 var score = amount * 0.01 + daysOverdue * 2;
-return { response: score };
+return score;
 ]]></bpmn:script>
 </bpmn:scriptTask>
 ```

--- a/tests/scripts/test_bpmn_project_scaffold_contract.py
+++ b/tests/scripts/test_bpmn_project_scaffold_contract.py
@@ -96,7 +96,10 @@ def test_minimal_example_has_complete_di_coverage() -> None:
 
 def test_variable_and_migration_examples_use_serializer_attributes() -> None:
     text = REFERENCE.read_text(encoding="utf-8")
-    variables_section = text.split("## Variables (`BPMN.Variables`)", maxsplit=1)[1]
+    # Match the heading, not its parenthetical: the section has been titled both
+    # "## Variables" and "## Variables (`BPMN.Variables`)".
+    _, marker, variables_section = text.partition("\n## Variables")
+    assert marker, "structural-bpmn.md is missing its Variables section"
     variables_section = variables_section.split("\n## ", 1)[0]
     match = re.search(r"```xml\n(?P<xml>.*?)\n```", variables_section, re.DOTALL)
     assert match, "structural-bpmn.md is missing its variable declaration example"
@@ -113,6 +116,12 @@ def test_variable_and_migration_examples_use_serializer_attributes() -> None:
     assert all(item.attrib.get("id") for item in declarations)
     assert all(item.attrib.get("name") for item in declarations)
     assert all(item.attrib.get("type") for item in declarations)
+    # Every declaration carries an elementId naming the element that owns it. A
+    # declaration without one is not a variable to the canvas, so each
+    # `vars.<id>` reference to it fails on import.
+    assert all(item.attrib.get("elementId") for item in declarations), [
+        item.attrib for item in declarations
+    ]
 
     # Pin the contract, not a version number: the attribute is `version` and its
     # value is an integer (the reader does Number.parseInt, so "11.5" -> 11).
@@ -120,3 +129,62 @@ def test_variable_and_migration_examples_use_serializer_attributes() -> None:
         r'<uipath:migrationVersion version="\d+"\s*/>', variables_section
     ), variables_section
     assert "<uipath:migrationVersion value=" not in variables_section
+
+
+def test_script_task_examples_dispatch_and_return_bare() -> None:
+    """The half of the variable contract that fails silently.
+
+    A mapping `uipath:type` other than `BPMN.Variables` overwrites the parser's
+    `Scp.Script` extension type, so the runtime never dispatches the script:
+    the element completes, the output mapping resolves against an empty result,
+    and the target variable reads back `null`. Nothing surfaces it — which is
+    how the wrong value shipped in this reference for seven weeks.
+
+    Paired with the return shape, because the two only work together: at
+    `scriptVersion` v2+ the runtime wraps the return under `response`
+    (`ScriptActivities.cs`), so a script that wraps it again double-wraps.
+    """
+    text = REFERENCE.read_text(encoding="utf-8")
+    fragments = re.findall(
+        r"```xml\n(?P<xml>(?:(?!```).)*?<bpmn:scriptTask.*?)\n```", text, re.DOTALL
+    )
+    assert fragments, "structural-bpmn.md is missing its script-task example"
+
+    for xml in fragments:
+        wrapper = ET.fromstring(
+            '<root xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"'
+            ' xmlns:uipath="http://uipath.org/schema/bpmn"'
+            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+            f"{xml}"
+            "</root>"
+        )
+        for task in wrapper.iter("{%s}scriptTask" % NS["bpmn"]):
+            types = [
+                el.attrib.get("value")
+                for mapping in task.iter("{%s}mapping" % NS["uipath"])
+                for el in mapping.findall("uipath:type", NS)
+            ]
+            assert types, f"script task {task.attrib.get('id')} declares no uipath:type"
+            assert all(value == "BPMN.Variables" for value in types), (
+                f"script task {task.attrib.get('id')} maps through {types}; anything "
+                "other than BPMN.Variables overwrites Scp.Script and the script "
+                "never runs"
+            )
+            # The template omits scriptVersion, which parses as v1 and rejects a
+            # bare return, so the example must carry it explicitly.
+            versions = [
+                el.attrib.get("value")
+                for el in task.iter("{%s}scriptVersion" % NS["uipath"])
+            ]
+            assert versions and all(v and v != "v1" for v in versions), (
+                f"script task {task.attrib.get('id')} needs an explicit "
+                f"uipath:scriptVersion of v2 or later; got {versions}"
+            )
+            body = "".join(
+                el.text or "" for el in task.iter("{%s}script" % NS["bpmn"])
+            )
+            assert not re.search(r"\breturn\s*\{\s*response\b", body), (
+                f"script task {task.attrib.get('id')} wraps its return in "
+                "`response`; the v2+ runtime already does, so this double-wraps "
+                "to result.response.response"
+            )


### PR DESCRIPTION
## Problem

The skill taught two variable rules backwards, so **every BPMN an agent authored from it was broken in Studio Web.**

**Root variables.** The skill said a process-level declaration carries no `elementId`. The canvas requires one — an `elementId` *is* how scope is expressed:

```xml
<!-- what the skill taught: not a variable at all to the canvas -->
<uipath:inputOutput id="Var_Tier" name="tier" type="string" />

<!-- what the canvas requires -->
<uipath:inputOutput id="Var_Tier" name="tier" type="string" elementId="Process_1" />
```

Every `vars.Var_Tier` reference to the first form fails on import with `VARIABLE_DOES_NOT_EXIST`. One reported file showed 28 of them.

**Script mappings.** The skill said to use `<uipath:type value="BPMN.ScriptTask">` and *explicitly forbade* `BPMN.Variables`. It is the reverse: any type other than `BPMN.Variables` stops the runtime dispatching the script. The element still completes and validation stays clean, so nothing looks wrong — the variable just reads `null`.

Both rules were inferred from a symptom rather than checked against the canvas, and the examples around them reinforced the mistake.

---

**Stack 1/4** — base `main`. Followed by #fixtures → #assert-value → #evals.

Two authoring rules in this skill were inverted, and each made every BPMN an agent authored from it fail in Studio Web. Both were inferred from a symptom rather than checked against the canvas or the engine, then reinforced by the examples around them.

### 1. Process-level variables

The skill implied a root declaration carries no `elementId` ("public or node-scoped declarations *also* carry the owning node's elementId"), and its example declared `Var_Decision` without one.

The canvas keys scope by `elementId`. Its existence check filters on any non-empty value (PO.Frontend `VariableValidationUtils.ts:163`, `origin/develop`), so a declaration without one is not a variable at all, and every `vars.<id>` reference to it raises `VARIABLE_DOES_NOT_EXIST` on import.

Field evidence: 4 of 5 exported diagrams carried elementId-less root variables — 56 declarations. The one file that worked had all 9 keyed to its process id.

**Verified in Studio Web.** The reported `0909-claude-SiteCoordination.bpmn` showed 28 errors. With `elementId="<process id>"` added to its ten root variables and nothing else changed, the canvas validation panel reads `Validation issues (0)` / "No issues found".

### 2. Script-task mappings

The skill told agents to use `<uipath:type value="BPMN.ScriptTask">` and **explicitly forbade** `BPMN.Variables`. It is the reverse: any type other than `BPMN.Variables` overwrites the parser's `Scp.Script` extension type, so the runtime never dispatches the script. The element still completes, the output mapping resolves against an empty result, and the target variable reads back `null`.

**Verified live** on alpha: two files differing only in that attribute returned `product: 42` (`BPMN.Variables`) and `product: null` (`BPMN.ScriptTask`). Engine test fixtures agree — 242 `BPMN.Variables`, zero `BPMN.ScriptTask`.

The registry's `BPMN.ScriptTask` `xmlTemplate` emits the wrong type child, so this is documented as the one place to correct the template. Its own `extensionTagNotes` already say script tasks route the same way as `BPMN.Variables` — **the template contradicts its own note, which is worth fixing upstream.**

### Also

The return contract was inverted too: at `scriptVersion` v2+ the runtime wraps the return under `response` itself (`ScriptActivities.cs:211-216`), so `return { response: v }` double-wraps to `result.response.response`. Return the value directly and map `source="=result.response"`.

Every citation was re-checked against PO.Frontend `origin/develop` rather than a stale checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
