### PR TITLE
test(uipath-maestro-bpmn): add variable-scope evals

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/author/variable_scopes/check_variable_scopes.py
+++ b/tests/tasks/uipath-maestro-bpmn/author/variable_scopes/check_variable_scopes.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Variable-scope check.
+
+Every `<uipath:variables>` declaration must carry an `elementId` that resolves
+to a real element, and the scope must make the variable reachable where it is
+used: the caller-supplied input keyed to the start event, and a variable read by a gateway
+keyed either to the `<bpmn:process>` id or to the node whose mapping writes it
+(the canvas emits the latter for a task output — `VariableMutationUtils.ts`).
+
+Deliberately NOT asserted: the `custom` attribute, whose effect on canvas
+re-sync is unverified.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from _shared.bpmn_check import NS, fail, parse_bpmn, text_content  # noqa: E402
+
+DECL_TAGS = ("input", "output", "inputOutput")
+
+
+def declarations(root):
+    """Every declaration child of every `<uipath:variables>` block."""
+    out = []
+    for block in root.iter("{%s}variables" % NS["uipath"]):
+        for child in block:
+            if child.tag.split("}")[1] in DECL_TAGS:
+                out.append(child)
+    return out
+
+
+def condition_text(root):
+    return " ; ".join(
+        text_content(c)
+        for c in root.iter("{%s}conditionExpression" % NS["bpmn"])
+    )
+
+
+def main() -> None:
+    path, root = parse_bpmn("TierRouting")
+
+    process = root.find("bpmn:process", NS)
+    if process is None:
+        fail(f"{path}: no <bpmn:process>")
+    process_id = process.attrib.get("id")
+
+    # The canvas resolves an elementId against the process id plus flow-element
+    # and edge ids only; a DI shape id is an orphan and gets deleted on import
+    # (migrations/s191_2-migration-utils.ts).
+    all_ids = {process_id} | {
+        e.attrib["id"] for e in process.iter()
+        if e.attrib.get("id") and e.tag.startswith("{%s}" % NS["bpmn"])
+    }
+    start_ids = {e.attrib.get("id") for e in root.iter("{%s}startEvent" % NS["bpmn"])}
+
+    decls = declarations(root)
+    if not decls:
+        fail(f"{path}: no variable declarations in <uipath:variables>")
+
+    # 1. Every declaration carries an elementId.
+    unscoped = [d.attrib.get("id") or d.attrib.get("name") for d in decls
+                if not d.attrib.get("elementId")]
+    if unscoped:
+        fail(f"{path}: declarations without an elementId: {sorted(unscoped)}. "
+             "Every <uipath:variables> child needs one.")
+    print(f"OK: all {len(decls)} declarations carry an elementId")
+
+    # 2. Every elementId resolves to an element that exists.
+    dangling = {d.attrib.get("id"): d.attrib["elementId"] for d in decls
+                if d.attrib["elementId"] not in all_ids}
+    if dangling:
+        fail(f"{path}: elementId does not match any element in the file: {dangling}")
+    print("OK: every elementId resolves to a real element")
+
+    # 3. The caller-supplied input is start-event scoped. The canvas writes a
+    #    caller argument as a root `input` keyed to the start event that accepts
+    #    it (reducers/canvasSlice.ts updateRootVariablesForInput); any other
+    #    scope is not a caller-suppliable input.
+    amount = [d for d in decls
+              if (d.attrib.get("name") or "").lower() == "amount"
+              or (d.attrib.get("id") or "").lower().endswith("amount")]
+    if not amount:
+        fail(f"{path}: no declaration for the caller-supplied amount")
+    if not any(d.attrib["elementId"] in start_ids for d in amount):
+        got = {d.attrib.get("id"): d.attrib["elementId"] for d in amount}
+        fail(f"{path}: the caller-supplied amount must be scoped to the start event "
+             f"so the caller can pass it in; got {got}")
+    print("OK: caller-supplied amount is start-event scoped")
+
+    # 4. The variable the gateway reads is reachable from that gateway: either
+    #    process-scoped (globally available), or scoped to a node whose mapping
+    #    writes it via `var=` — which is the shape the canvas itself emits for a
+    #    task output (VariableMutationUtils.ts). Both are valid; a scope that is
+    #    neither is not reachable downstream.
+    conditions = condition_text(root)
+    if not conditions:
+        fail(f"{path}: no gateway conditionExpression found")
+    # Which element writes each variable: the nearest id-bearing ancestor of
+    # each mapping `<uipath:output var="...">`.
+    parents = {child: parent for parent in process.iter() for child in parent}
+    writers = {}
+    for m in process.iter("{%s}output" % NS["uipath"]):
+        var = m.attrib.get("var")
+        if not var:
+            continue
+        node = parents.get(m)
+        while node is not None and not node.attrib.get("id"):
+            node = parents.get(node)
+        if node is not None:
+            writers[var] = node.attrib["id"]
+    # Match by `id` only. The canvas resolves a `vars.X` reference against a
+    # declaration's id (and its canonicalId, which is backfilled only for
+    # legacy obfuscated ids), never its `name` — so accepting a name match here
+    # would pass a file the canvas rejects with VARIABLE_DOES_NOT_EXIST.
+    read_by_gateway = [
+        d for d in decls
+        if d.attrib.get("id")
+        and re.search(r"\bvars\.%s\b" % re.escape(d.attrib["id"]), conditions)
+    ]
+    if not read_by_gateway:
+        referenced = sorted(set(re.findall(r"\bvars\.([A-Za-z_$][\w$]*)", conditions)))
+        declared = sorted(d.attrib.get("id") or "?" for d in decls)
+        fail(f"{path}: no declared variable id is read by a gateway condition. "
+             f"Conditions reference {referenced}; declared ids are {declared}. "
+             "References resolve by id, not by name.")
+    unreachable = {}
+    for d in read_by_gateway:
+        eid = d.attrib["elementId"]
+        vid = d.attrib.get("id")
+        if eid == process_id or writers.get(vid) == eid:
+            continue
+        unreachable[vid] = eid
+    if unreachable:
+        fail(f"{path}: a variable read by a gateway condition must be scoped to the "
+             f"process id {process_id!r}, or to the node whose mapping writes it; "
+             f"got {unreachable}")
+    print(f"OK: gateway-read variable(s) reachable from the gateway "
+          f"({ {d.attrib.get('id'): d.attrib['elementId'] for d in read_by_gateway} })")
+
+    print("PASS: all variable-scope checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/author/variable_scopes/variable_scopes.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/variable_scopes/variable_scopes.yaml
@@ -1,0 +1,45 @@
+task_id: skill-bpmn-author-variable-scopes
+description: >
+  Authoring eval for variable scoping: every `<uipath:variables>` declaration
+  must carry an `elementId` that resolves to a real element, keyed to the
+  element that owns the variable — the start event for a caller-supplied input
+  (so it reaches the generated entry point's input schema), the process id for
+  a working variable read by a gateway. The prompt never mentions `elementId`,
+  so the task fails if the skill stops teaching the contract.
+tags: [uipath-maestro-bpmn, smoke, "mode:build", lifecycle:generate, shape:multi-node, node:gateway, node:script]
+
+run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
+  expected_turns: 16
+  max_turns: 60
+
+initial_prompt: |
+  Create a local BPMN project named "TierRouting" for this process:
+  - The caller supplies an order `amount` when starting the process.
+  - A `bpmn:scriptTask` derives a `tier` of `high` (`amount >= 1000`) or `low`.
+  - An exclusive gateway routes on the tier to one of two end events.
+
+  Requirements:
+  - Use synthetic placeholder resource names only. Do not include tenant URLs,
+    folder keys, connection IDs, or user names.
+  - Do not upload, publish, deploy, debug, or run the process.
+
+  The caller must be able to supply the amount when starting the process.
+
+success_criteria:
+  - type: run_command
+    description: "BPMN source was created"
+    command: "python3 -c \"from pathlib import Path; import sys; sys.exit(0 if any(Path('.').rglob('TierRouting.bpmn')) else 'TierRouting.bpmn missing')\""
+    timeout: 30
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Every variable declaration is scoped to the element that owns it"
+    command: "python3 $TASK_DIR/check_variable_scopes.py"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/author/variable_scopes_nested/check_variable_scopes_nested.py
+++ b/tests/tasks/uipath-maestro-bpmn/author/variable_scopes_nested/check_variable_scopes_nested.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Variable-scope check for nested and multi-entry scoping.
+
+Covers the scopes the single-entry check cannot reach:
+  - two start events, each owning its own caller-supplied input, with no input
+    leaking onto the other entry point
+  - a variable owned by a subprocess, declared in the subprocess's own
+    `<uipath:variables>` block and keyed to an element inside that subprocess
+  - a public output keyed to a root end event
+
+Every assertion reads the authored `.bpmn`. Generated metadata
+(`entry-points.json`) is deliberately not asserted: the CLI packager produces
+it, so grading it would couple this test to another component's behaviour
+instead of to the canvas contract.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from _shared.bpmn_check import NS, fail, parse_bpmn  # noqa: E402
+
+DECL_TAGS = ("input", "output", "inputOutput")
+
+
+def decls_of(owner):
+    """Declaration children of the owner's own `<uipath:variables>` block."""
+    out = []
+    for ext in owner.findall("bpmn:extensionElements", NS):
+        for block in ext.findall("uipath:variables", NS):
+            for child in block:
+                if child.tag.split("}")[1] in DECL_TAGS:
+                    out.append(child)
+    return out
+
+
+def ident(d):
+    return d.attrib.get("id") or d.attrib.get("name") or "<unnamed>"
+
+
+def main() -> None:
+    path, root = parse_bpmn("OrderEnrich")
+
+    process = root.find("bpmn:process", NS)
+    if process is None:
+        fail(f"{path}: no <bpmn:process>")
+    process_id = process.attrib.get("id")
+
+    # Canvas resolves elementId against the process id plus BPMN element ids;
+    # DI shape ids are orphans (migrations/s191_2-migration-utils.ts).
+    all_ids = {process_id} | {
+        e.attrib["id"] for e in process.iter()
+        if e.attrib.get("id") and e.tag.startswith("{%s}" % NS["bpmn"])
+    }
+    subprocesses = list(process.iter("{%s}subProcess" % NS["bpmn"]))
+    root_starts = [e for e in process.findall("bpmn:startEvent", NS)]
+    root_ends = {e.attrib.get("id") for e in process.findall("bpmn:endEvent", NS)}
+
+    root_decls = decls_of(process)
+    sub_decls = {s.attrib.get("id"): decls_of(s) for s in subprocesses}
+    every = root_decls + [d for ds in sub_decls.values() for d in ds]
+    if not every:
+        fail(f"{path}: no variable declarations found")
+
+    # 1. Every declaration, at every level, carries an elementId.
+    unscoped = [ident(d) for d in every if not d.attrib.get("elementId")]
+    if unscoped:
+        fail(f"{path}: declarations without an elementId: {sorted(unscoped)}")
+    print(f"OK: all {len(every)} declarations carry an elementId")
+
+    # 2. Every elementId resolves.
+    dangling = {ident(d): d.attrib["elementId"] for d in every
+                if d.attrib["elementId"] not in all_ids}
+    if dangling:
+        fail(f"{path}: elementId does not match any element in the file: {dangling}")
+    print("OK: every elementId resolves to a real element")
+
+    # 3. Each root start event owns exactly one caller-supplied input, and no
+    #    two start events share one. The canvas writes a caller argument as a
+    #    root `input` keyed to the start event that accepts it
+    #    (reducers/canvasSlice.ts updateRootVariablesForInput), so a second
+    #    start's argument keyed to the first start belongs to the wrong caller.
+    if len(root_starts) < 2:
+        fail(f"{path}: expected two root start events, found {len(root_starts)}")
+    start_ids = {e.attrib.get("id") for e in root_starts}
+    inputs = [d for d in root_decls if d.tag.split("}")[1] == "input"]
+    stray = {ident(d): d.attrib["elementId"] for d in inputs
+             if d.attrib["elementId"] not in start_ids}
+    if stray:
+        fail(f"{path}: a caller-supplied input must be scoped to the start event that "
+             f"accepts it; got {stray}")
+    by_start = {}
+    for d in inputs:
+        by_start.setdefault(d.attrib["elementId"], set()).add(d.attrib.get("name"))
+    missing = start_ids - set(by_start)
+    if missing:
+        fail(f"{path}: start event(s) {sorted(missing)} accept no caller-supplied "
+             "input — each start event owns the argument its caller passes in")
+    for sid, names in by_start.items():
+        if len(names) != 1:
+            fail(f"{path}: start event {sid!r} owns {sorted(names)}; each start event "
+                 "accepts exactly one caller-supplied input in this process")
+    shared = [n for n in {n for ns in by_start.values() for n in ns}
+              if sum(1 for ns in by_start.values() if n in ns) > 1]
+    if shared:
+        fail(f"{path}: input name(s) {sorted(shared)} are claimed by more than one "
+             "start event; each caller input belongs to exactly one entry point")
+    print("OK: each start event owns exactly its own caller input "
+          f"({ {k: sorted(v) for k, v in by_start.items()} })")
+
+    # 4. A subprocess owns a variable, declared in its own block and keyed
+    #    within that subprocess — either the subprocess itself or a node inside
+    #    it. Both are accepted deliberately: the canvas keys such a variable to
+    #    the writing node (VariableMutationUtils.ts) and reserves the
+    #    self-keyed form for user-created custom variables, but a non-custom
+    #    self-keyed declaration is *relocated* to the root block on import
+    #    (migrations/s191_2-migration-utils.ts), not rejected. Grading that
+    #    difference would fail a file the platform accepts. What is settled, and
+    #    what this asserts, is that the scope must be inside the subprocess:
+    #    keyed to a root element it is not the subprocess's variable at all.
+    #    Subprocess blocks hold `inputOutput` only (s180-migrations.ts).
+    if not subprocesses:
+        fail(f"{path}: no <bpmn:subProcess> found")
+    with_own = {sid: ds for sid, ds in sub_decls.items() if ds}
+    if not with_own:
+        fail(f"{path}: no subprocess declares its own variable — a variable owned by "
+             "the subprocess belongs in that subprocess's <uipath:variables> block")
+    for sub in subprocesses:
+        sid = sub.attrib.get("id")
+        ds = sub_decls.get(sid) or []
+        if not ds:
+            continue
+        inner_ids = {e.attrib["id"] for e in sub.iter() if e.attrib.get("id")}
+        bad_tag = [ident(d) for d in ds if d.tag.split("}")[1] != "inputOutput"]
+        if bad_tag:
+            fail(f"{path}: subprocess {sid!r} may only declare <uipath:inputOutput>; "
+                 f"got other tags for {sorted(bad_tag)}")
+        wrong = {ident(d): d.attrib["elementId"] for d in ds
+                 if d.attrib["elementId"] not in inner_ids}
+        if wrong:
+            fail(f"{path}: a variable owned by subprocess {sid!r} must be scoped "
+                 f"within that subprocess — {sid!r} itself, or a node inside it; "
+                 f"got {wrong}")
+    print(f"OK: subprocess-owned variable(s) declared and scoped inside "
+          f"({sorted(with_own)})")
+
+    # 5. The public output is keyed to a root end event. The canvas writes root
+    #    `outputs` only through the end-event pair reducer (canvasSlice.ts
+    #    updateRootVariablesForOutput), and migration 13 forces basic end-event
+    #    outputs into that shape (migrations/s191_2-migration-utils.ts).
+    outputs = [d for d in root_decls if d.tag.split("}")[1] == "output"]
+    if not outputs:
+        fail(f"{path}: no <uipath:output> declaration — the process must publish a result")
+    bad = {ident(d): d.attrib["elementId"] for d in outputs
+           if d.attrib["elementId"] not in root_ends}
+    if bad:
+        fail(f"{path}: a published output must be scoped to a root end event "
+             f"{sorted(root_ends)}; got {bad}")
+    print("OK: published output(s) scoped to a root end event "
+          f"({sorted(ident(d) for d in outputs)})")
+
+    print(f"PASS: nested and multi-entry variable scopes correct (process {process_id!r})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/author/variable_scopes_nested/variable_scopes_nested.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/variable_scopes_nested/variable_scopes_nested.yaml
@@ -1,0 +1,49 @@
+task_id: skill-bpmn-author-variable-scopes-nested
+description: >
+  Authoring eval for the variable scopes the single-entry case cannot reach: two
+  start events each owning their own caller-supplied input (with no input
+  leaking onto the other entry point), a variable owned by a subprocess and
+  declared in that subprocess's own `<uipath:variables>` block, and a published
+  output keyed to a root end event. The prompt never mentions `elementId` or
+  scoping, so the task fails if the skill stops teaching the contract.
+tags: [uipath-maestro-bpmn, smoke, "mode:build", lifecycle:generate, shape:multi-node, node:script, node:subprocess]
+
+run_limits:
+  task_timeout: 2400
+  turn_timeout: 1800
+  expected_turns: 22
+  max_turns: 80
+
+initial_prompt: |
+  Create a local BPMN project named "OrderEnrich" for this process:
+  - It can be started two ways: a manual start where the caller supplies an
+    `orderId`, and a separate API start where the caller supplies a `reference`.
+  - Both starts lead into a subprocess named "Enrich" that derives an enriched
+    value from the order id. That enriched value belongs to the subprocess — it
+    is not used outside it.
+  - The process finishes at a single end event that publishes a `result` the
+    caller can read back.
+
+  Requirements:
+  - Use synthetic placeholder resource names only. Do not include tenant URLs,
+    folder keys, connection IDs, or user names.
+  - Do not upload, publish, deploy, debug, or run the process.
+
+  Each start event must accept only the argument its own caller supplies.
+
+success_criteria:
+  - type: run_command
+    description: "BPMN source was created"
+    command: "python3 -c \"from pathlib import Path; import sys; sys.exit(0 if any(Path('.').rglob('OrderEnrich.bpmn')) else 'OrderEnrich.bpmn missing')\""
+    timeout: 30
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Nested, multi-entry and published-output variable scopes are correct"
+    command: "python3 $TASK_DIR/check_variable_scopes_nested.py"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Problem

**No test in this suite reads `elementId`** — 79 BPMN tasks, and not one check script looks at the attribute that decides whether a variable exists at all. They parse declarations by `id`, `name` and `type` only.

That is why a wrong variable-scoping rule shipped and survived seven weeks of green CI. The rule was wrong, the fixtures demonstrated the wrong shape, the one live test that touched it had been weakened to pass on a `null` — and nothing anywhere would go red.

---

**Stack 4/4** — base `fix/bpmn-live-debug-assert-value` (#3213). Bottom of the stack: #3211 → #3212 → #3213 → this.

Nothing in this suite read `elementId`, which is why a wrong scoping rule survived seven weeks of green CI. Two tasks close that gap, graded on the authored `.bpmn`.

- **`author/variable_scopes`** — one entry point: every declaration carries an `elementId`; each resolves to an element that exists; the caller-supplied input is start-event scoped; the variable a gateway reads is reachable from it.
- **`author/variable_scopes_nested`** — the scopes the single-entry case cannot reach: two start events each owning exactly their own caller input, a subprocess-owned variable declared in that subprocess's own block and keyed within it, and a published output keyed to a root end event.

### Design notes

- **Neither prompt contains the word `elementId`.** If it did, the task would measure instruction-following rather than the skill — which is exactly how `live_debug_e2e` stayed green while the skill taught the wrong shape.
- Every assertion reads the `.bpmn`. Generated metadata (`entry-points.json`) is deliberately **not** asserted: the CLI packager produces it, so grading it would couple these tests to another component instead of to the canvas contract.
- Three dimensions are deliberately left ungraded — node-keyed vs process-keyed task-output targets, the `custom` attribute, and self-keyed vs node-keyed subprocess variables. The canvas writes one form and merely *relocates* the other on import (migration 13) rather than rejecting it, so grading the difference would fail a file the platform accepts.
- **Both** tasks are tagged `smoke` so they actually gate PRs. `smoke-skills.yml` selects on `grep -qE '^tags:.*\bsmoke\b'`, so an `integration` tag would leave these scopes to nightly only — the same shape of gap as the one this stack exists to close. 12 of the 14 existing BPMN smoke tasks are `mode:build` + `lifecycle:generate` authoring tasks, and both of these are lighter than the rest, invoking no `uip` command at all.

### Verification

Local runs under `experiments/default.yaml` (tempdir, agent `claude-code`):

```
skill-bpmn-author-variable-scopes         SUCCESS  2/2  score 1.000  163s
skill-bpmn-author-variable-scopes-nested  SUCCESS  2/2  score 1.000  348s
```

The nested task **failed at 0.250 on its first run**, and the failure was mine rather than the agent's: the check demanded `custom="true"` on a self-keyed subprocess variable, a shape the skill does not teach and the platform does not require. Gold-and-mutation testing could not surface that, since I wrote both the gold and the mutations — only an agent reading the real skill could. The assertion now grades what is settled, and the mutation set still catches all six real defects.

### Review follow-ups

- `check_variable_scopes.py` now matches `vars.X` by declaration **id** only. The name fallback would have passed a file the canvas rejects — the same defect #3212 fixed in `OrderRouting.bpmn`.
- `variable_scopes_nested` retagged from `integration` to `smoke`; as `integration` it never ran on a PR, leaving the three scopes only it covers ungated.

Both agents authored correctly scoped files without being told the rule: `elementId="Event_start"` on the caller input, `elementId="Process_1"` on the process-level variable, `BPMN.Variables` on the script mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
