### PR TITLE
test(uipath-maestro-bpmn): grade customer_escalation wherever the project lands

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/check_customer_escalation.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/check_customer_escalation.py
@@ -31,7 +31,10 @@ from _shared.bpmn_check import (  # noqa: E402
     require_sequence_integrity,
 )
 
-PROJECT = Path.cwd() / "CustomerEscalation"
+# PROJECT is resolved in main() from the located BPMN's parent, so the check
+# grades the process wherever the agent placed the project dir (top level or
+# nested under a Solution wrapper) — it grades the modeling, not the layout.
+PROJECT: Path = Path.cwd() / "CustomerEscalation"
 BPMN_NAME = "CustomerEscalation.bpmn"
 REQUIRED_FILES = [
     "project.uiproj",
@@ -53,11 +56,14 @@ def load_json(name: str):
 
 
 def main() -> None:
+    global PROJECT
+    path, root = parse_bpmn("CustomerEscalation")
+    PROJECT = Path(path).parent
+
     for name in REQUIRED_FILES:
         if not (PROJECT / name).is_file():
             fail(f"{name} is missing")
 
-    path, root = parse_bpmn("CustomerEscalation")
 
     process = one_or_more(root, "process")[0]
 

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/check_customer_escalation.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/check_customer_escalation.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 _d = os.path.dirname(os.path.abspath(__file__))
@@ -25,16 +26,11 @@ from _shared.bpmn_check import (  # noqa: E402
     elements,
     fail,
     one_or_more,
-    parse_bpmn,
     require_di_for_visible_elements,
     require_no_private_connector_values,
     require_sequence_integrity,
 )
 
-# PROJECT is resolved in main() from the located BPMN's parent, so the check
-# grades the process wherever the agent placed the project dir (top level or
-# nested under a Solution wrapper) — it grades the modeling, not the layout.
-PROJECT: Path = Path.cwd() / "CustomerEscalation"
 BPMN_NAME = "CustomerEscalation.bpmn"
 REQUIRED_FILES = [
     "project.uiproj",
@@ -45,25 +41,44 @@ REQUIRED_FILES = [
 ]
 
 
-def load_json(name: str):
-    p = PROJECT / name
+def load_json(project: Path, name: str):
+    p = project / name
     if not p.is_file():
-        fail(f"{name} is missing")
+        fail(f"{name} is missing beside {p}")
     try:
         return json.loads(p.read_text(encoding="utf-8"))
     except Exception as exc:  # noqa: BLE001
         fail(f"{name} is not valid JSON: {exc}")
 
 
+def resolve_project() -> Path:
+    # Grade the project wherever the agent placed it (top level or nested under a
+    # Solution wrapper), but pick the real project unambiguously: exactly one
+    # CustomerEscalation.bpmn with project.uiproj beside it. This avoids grading a
+    # stray draft copy when two same-named files exist (find_bpmn_file matches on
+    # a substring and returns the alphabetically-first).
+    candidates = [
+        p for p in Path.cwd().rglob(BPMN_NAME) if (p.parent / "project.uiproj").is_file()
+    ]
+    if len(candidates) != 1:
+        fail(
+            f"expected exactly one {BPMN_NAME} with project.uiproj beside it, "
+            f"found {[str(p) for p in candidates]}"
+        )
+    return candidates[0].parent
+
+
 def main() -> None:
-    global PROJECT
-    path, root = parse_bpmn("CustomerEscalation")
-    PROJECT = Path(path).parent
+    project = resolve_project()
+    bpmn_file = project / BPMN_NAME
+    try:
+        root = ET.parse(bpmn_file).getroot()
+    except Exception as exc:  # noqa: BLE001
+        fail(f"{bpmn_file} is not well-formed XML: {exc}")
 
     for name in REQUIRED_FILES:
-        if not (PROJECT / name).is_file():
-            fail(f"{name} is missing")
-
+        if not (project / name).is_file():
+            fail(f"{name} is missing beside {bpmn_file}")
 
     process = one_or_more(root, "process")[0]
 
@@ -104,10 +119,10 @@ def main() -> None:
 
     # Package metadata references the BPMN file.
     for name in ("entry-points.json", "operate.json", "package-descriptor.json"):
-        if BPMN_NAME not in json.dumps(load_json(name)):
+        if BPMN_NAME not in json.dumps(load_json(project, name)):
             fail(f"{name} must reference {BPMN_NAME}")
 
-    print(f"OK: {path} classifies, routes, escalates via a user task, and ships consistent package metadata")
+    print(f"OK: {bpmn_file} classifies, routes, escalates via a user task, and ships consistent package metadata")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/customer_escalation.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/customer_escalation.yaml
@@ -46,21 +46,27 @@ initial_prompt: |
   Build the complete local project end-to-end in a single pass.
 
 success_criteria:
-  - type: file_exists
+  - type: run_command
     description: "BPMN source file was created"
-    path: "CustomerEscalation/CustomerEscalation.bpmn"
+    command: "python3 -c \"from pathlib import Path; import sys; sys.exit(0 if any(Path('.').rglob('CustomerEscalation.bpmn')) else 'CustomerEscalation.bpmn missing')\""
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_exists
+  - type: run_command
     description: "Project metadata file was created"
-    path: "CustomerEscalation/project.uiproj"
+    command: "python3 -c \"from pathlib import Path; import sys; b=next(Path('.').rglob('CustomerEscalation.bpmn'), None); sys.exit(0 if b and (b.parent / 'project.uiproj').is_file() else 'project.uiproj missing beside CustomerEscalation.bpmn')\""
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: file_exists
+  - type: run_command
     description: "Package operate metadata was created"
-    path: "CustomerEscalation/operate.json"
+    command: "python3 -c \"from pathlib import Path; import sys; b=next(Path('.').rglob('CustomerEscalation.bpmn'), None); sys.exit(0 if b and (b.parent / 'operate.json').is_file() else 'operate.json missing beside CustomerEscalation.bpmn')\""
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/customer_escalation.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/customer_escalation.yaml
@@ -6,7 +6,10 @@ description: >
   combined signal through an exclusive gateway, and escalates via a human user
   task on the high-touch path while a standard path generates a ticket in a
   script task. Includes full package metadata. Authoring only, public-safe, no
-  cloud effects and no live connector.
+  cloud effects and no live connector. Project layout is deliberately ungraded:
+  the checks locate the project by the `CustomerEscalation.bpmn` + `project.uiproj`
+  pair wherever it lands, so the default `uip maestro bpmn init`
+  `<Name>Solution/<Name>/` scaffold and a bare `<Name>/` both grade the modeling.
 tags: [uipath-maestro-bpmn, e2e, "mode:build", "lifecycle:generate", "shape:multi-node", "node:decision", "node:hitl", "feature:escalation"]
 
 run_limits:


### PR DESCRIPTION
## Summary
`skill-bpmn-e2e-customer-escalation` FAILED in the `2026-09-10` nightly. It grades **process modeling**, but a brittle exact-path check failed it on **project location** before any modeling was evaluated.

## Root cause
`uip maestro bpmn init` outside a solution **auto-scaffolds `<Name>Solution/<Name>/`** by default (`references/shared/project-layout.md:16-33`). The agent used that default, producing `CustomerEscalationSolution/CustomerEscalation/CustomerEscalation.bpmn`. The three `file_exists` criteria and the check hardcoded the top-level path `CustomerEscalation/...`, so all failed on location — the check printed `FAIL: project` before checking the classifiers, gateway, user-task path, or ticket script. **The check contradicted the skill's own documented default scaffold.**

## Fix (location-robust; layout deliberately ungraded)
Decision (with @rockymadden): grade the modeling wherever the project lands, rather than pin the layout — and roll the same robustness to the ~32 sibling tasks that share this latent failure (follow-up **#3219**).

- `check_customer_escalation.py`: `resolve_project()` locates the **unique** `CustomerEscalation.bpmn` **with `project.uiproj` beside it** (fails on 0 or >1), so a stray/draft copy is never graded. Project dir threaded as a local; failure messages carry the path.
- `customer_escalation.yaml`: three exact-path `file_exists` → `rglob` `run_command` checks; the gating weight-5 check's single-candidate guard prevents any two-copy false-pass.
- `description:` states layout is deliberately ungraded.

## Verification
- **Local:** the resolver picks the correct project on wrapper, bare, and **two-copy** (bare-draft + wrapper) trees.
- **CI:** re-verifying on **claude** (34517642443) and **codex** (34517645796). Honest caveat: CI grades whatever layout the agent happens to produce that run (the first claude run used a top-level layout, so the wrapper path was exercised only by the local test above, not CI). #3219 adds a `tmp_path` unit test to make the resolver CI-enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
