### PR TITLE
fix(uipath-maestro-bpmn): reduce high_volume_batch aggregate over-authoring (partial)

### DIFF
--- a/skills/uipath-maestro-bpmn/references/patterns/high-volume-batch-guide.md
+++ b/skills/uipath-maestro-bpmn/references/patterns/high-volume-batch-guide.md
@@ -79,6 +79,12 @@ system or items must be ordered.
   `bpmn:completionCondition` on the multi-instance marker. A completion
   condition stops the block early, which is a different thing from judging the
   run afterwards, and it cannot see the per-item results the policy needs.
+  Author it as a **placeholder `bpmn:serviceTask` on the path after the block** —
+  the reading and summing of per-item results happen at runtime, not while
+  authoring. Do NOT wire multi-instance output collection (`loopDataOutputRef`,
+  `outputCollection`, `dataOutputAssociation`) or hunt the registry for a
+  `uipath.aggregate` type: none is required and none exists. Placing the node is
+  the whole authoring job.
 - **`send_report`** — email, chat, dashboard, audit store.
 
 Fetch payloads through [registry-workflow.md](../registry-workflow.md).

--- a/skills/uipath-maestro-bpmn/references/patterns/high-volume-batch-guide.md
+++ b/skills/uipath-maestro-bpmn/references/patterns/high-volume-batch-guide.md
@@ -79,12 +79,12 @@ system or items must be ordered.
   `bpmn:completionCondition` on the multi-instance marker. A completion
   condition stops the block early, which is a different thing from judging the
   run afterwards, and it cannot see the per-item results the policy needs.
-  Author it as a **placeholder `bpmn:serviceTask` on the path after the block** —
-  the reading and summing of per-item results happen at runtime, not while
-  authoring. Do NOT wire multi-instance output collection (`loopDataOutputRef`,
-  `outputCollection`, `dataOutputAssociation`) or hunt the registry for a
-  `uipath.aggregate` type: none is required and none exists. Placing the node is
-  the whole authoring job.
+  Author it as a `bpmn:serviceTask` on the path after the block — the per-item
+  reading and summing happen at runtime, so you do not need to wire
+  multi-instance output-collection plumbing (`loopDataOutputRef`,
+  `outputCollection`, `dataOutputAssociation`) or fetch a `uipath.aggregate`
+  registry template (there is none) to author it. Placing the node on the path
+  is the authoring job.
 - **`send_report`** — email, chat, dashboard, audit store.
 
 Fetch payloads through [registry-workflow.md](../registry-workflow.md).


### PR DESCRIPTION
## Summary
Reduces wasted turns in `high_volume_batch` authoring. **Partial improvement, not a full fix** (see caveat).

## Context
`high_volume_batch` regressed in the eu nightly `2026-09-10` — timed out at `turn_timeout` 2700s. It's latency-bound, and the eu region is slower per turn than the us GH runner.

## Root cause (transcript, blob `2026-09-10_04-18-49`)
~15-20 of its turns went to hunting for multi-instance output-collection wiring (`loopDataOutputRef`, `outputCollection`, `dataOutputAssociation`, `uipath.aggregate`) that `check_greenfield.py` does not require — the `aggregate` node just needs to be a serviceTask on the path after the block.

## Fix
`high-volume-batch-guide.md` marks `aggregate` as a placeholder `bpmn:serviceTask` with no output-collection to author — the per-item reading/summing happens at runtime.

## ⚠️ This is partial
Verification (us region, run 34504377464): hunting dropped ~15-20 → 4 commands, and it passed once at 1829s — **but timed out at 2703s in another us run** (34503621234). The remaining **~78 commands / 148 turns are genuine authoring** of a heavy multi-instance + aggregate + escalation shape. It sits at the 2700s edge and flakes over it, and the eu nightly is slower still.

**A full fix needs decomposition or a fundamentally tighter authoring recipe** (closer to the `composition` case than the clean `queue_distribution` win). This PR is a strict, harmless improvement that cuts the wasted turns; the deeper work is tracked for follow-up. Merge on its own merits, or hold pending the decomposition decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
