### PR TITLE
fix(uipath-automationhub): install the ah tool when the preflight finds it missing

### DIFF
--- a/skills/uipath-automationhub/SKILL.md
+++ b/skills/uipath-automationhub/SKILL.md
@@ -11,10 +11,11 @@ Work with business processes in UiPath Automation Hub (AH) through the AH Open A
 
 ## Step 0: Preflight — pick the transport once
 
-Run `uip ah --help` once per session:
+Run `uip ah --help` once per session.
 
 - **Succeeds** → use the **CLI flows**. Read [`references/cli-commands.md`](references/cli-commands.md) (command catalog + auth), then the matching `*-cli-guide.md` flow. Auth is handled by `uip` itself — never touch a token.
-- **Fails with `unknown command 'ah'`** (CLI predates the AH surface) → use the **raw Open API flows**. Read [`references/api-endpoints.md`](references/api-endpoints.md) (auth model, gateway URL, exact headers — and the header to never send), then the matching flow.
+- **Fails with `unknown command 'ah'`** → the `ah` tool isn't installed. `uip` is a dispatcher: each verb is its own package, and the AH package ships separately from the CLI, so a host can bundle `uip` without it. Run `uip tools install ah` **once**, then re-run `uip ah --help`. If it now succeeds, take the CLI flows.
+- **Still failing** (install refused, no registry access, any other error) → use the **raw Open API flows**. Read [`references/api-endpoints.md`](references/api-endpoints.md) (auth model, gateway URL, exact headers — and the header to never send), then the matching flow. Do not retry the install.
 
 Never mix the two transports in one run. The domain contract — required fields, wrapping rules, document types — is identical either way and lives in `api-endpoints.md`.
 

--- a/skills/uipath-automationhub/references/cli-commands.md
+++ b/skills/uipath-automationhub/references/cli-commands.md
@@ -1,6 +1,6 @@
 # Automation Hub via the `uip ah` CLI — Command Catalog
 
-> **Preflight (run once per session):** `uip ah --help`. If it errors with `unknown command 'ah'`, the installed CLI predates the Automation Hub surface — tell the user to update `uip` (or follow the raw-API flows in [`api-endpoints.md`](api-endpoints.md) instead). Never mix the two paths in one run.
+> **Preflight (run once per session):** `uip ah --help`. On `unknown command 'ah'` the AH tool simply isn't installed — `uip` is a dispatcher and each verb ships as its own package — so run `uip tools install ah` once and re-check. If it still fails, follow the raw-API flows in [`api-endpoints.md`](api-endpoints.md) instead. Never mix the two paths in one run.
 
 The CLI wraps the same Open API endpoints as [`api-endpoints.md`](api-endpoints.md) — every domain fact there (required fields, wrapping rules, document-type ids, tenant-required questions) still applies. What the CLI adds: auth is handled for you, every response is one uniform JSON envelope, and windowing/projection quirks are absorbed.
 
@@ -54,4 +54,6 @@ Failure: `Result` is `Failure`/`ValidationError` with a `Message` and usually an
 | `uip ah automations get <id> [--all-fields]` | one process record | default projection has `Id`/`Name`/`Phase`/`Tags`; `--all-fields` for the raw record (needed for `process_slug`) |
 | `uip ah components list --automation-id <id>` | linked components (optional, get flow) | same record shape as the tenant-wide catalogue |
 
-**Version note:** the `ah` surface first appears in `uip` **1.201.0** (as of 2026-08-21 no public release ships it — the latest release is 1.199.0; the Step-0 preflight routes older installs to the raw-API flows). `documents create --file` and `automations create --idea-flow-id` additionally come from CLI PR #3720 — if either flag is rejected as unknown, the installed `uip` has the `ah` surface but predates those flags: tell the user to upgrade `uip` and **stop**. Never switch to the raw-API path mid-run — the transport was already selected at preflight.
+**Packaging note:** `ah` is **not part of the CLI binary** — `uip` is a dispatcher and every verb is its own npm package (`@uipath/automation-hub-tool`), which `@uipath/cli` does not depend on. A host can therefore ship a perfectly current `uip` with no `ah`, and the CLI version tells you nothing about whether it is there; only `uip ah --help` does. That is what `uip tools install ah` in the preflight is for. The tool must be on the CLI's own version line (`uip tools install` handles this), and the `ah` surface first exists at **1.201.0**.
+
+`documents create --file` and `automations create --idea-flow-id` come from CLI PR #3720 — if either flag is rejected as unknown, the installed tool has the `ah` surface but predates those flags: tell the user to upgrade and **stop**. Never switch to the raw-API path mid-run — the transport was already selected at preflight.

--- a/tests/tasks/uipath-automationhub/smoke_missing_ah_tool.yaml
+++ b/tests/tasks/uipath-automationhub/smoke_missing_ah_tool.yaml
@@ -1,0 +1,86 @@
+task_id: skill-ah-missing-tool-install-smoke
+description: >
+  Regression guard for RPANAV-19070: when `uip ah` answers
+  `unknown command 'ah'`, the skill must recover by INSTALLING the Automation
+  Hub tool, not by treating the missing verb as a CLI-version problem or as
+  terminal. `uip` is a dispatcher — every verb ships as its own npm package and
+  `@uipath/cli` does not depend on `@uipath/automation-hub-tool`, so a host can
+  bundle a perfectly current `uip` with no `ah` and the CLI version tells you
+  nothing. A shipped UiPath Delegate did exactly that, which is what sent the
+  Automation Hub publish down its fallback path. Grades the recovery DECISION.
+tags: [uipath-automationhub, smoke, mode:diagnose]
+
+run_limits:
+  expected_turns: 6
+
+initial_prompt: |
+  You are about to publish an approved business process to UiPath Automation
+  Hub with the `uipath-automationhub` skill.
+
+  Take this as given about the runtime — do NOT run commands to verify it, and
+  do NOT make any network call:
+
+    - `uip` is installed and current, but `uip ah --help` answers
+      `error: unknown command 'ah'`.
+
+  Answer in text only:
+
+    1. Why does `uip ah` not exist here, given the CLI itself is current?
+    2. What exact command do you run to fix it, and what do you do next?
+    3. If that command cannot succeed, what do you do — and what do you tell
+       the user?
+
+  Do NOT run any commands. Do NOT ask for confirmation — this is an automated
+  test.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-automationhub skill"
+    skill_name: "uipath-automationhub"
+    expected_skill: "uipath-automationhub"
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent names the install command and the re-check, rather than a CLI upgrade"
+    include_agent_output: true
+    prompt: |
+      The runtime has a current `uip` whose `ah` verb is missing.
+
+      Score 1.0 if the agent says to INSTALL the Automation Hub tool — naming
+      `uip tools install ah` (or clearly describing installing the `ah` /
+      `automation-hub-tool` package) — AND re-running `uip ah --help`
+      afterwards to decide the transport.
+      Score 0.5 if it identifies the tool as a separately-installed package but
+      names neither the install command nor the re-check.
+      Score 0.0 if it says to upgrade or reinstall `uip` / the CLI to a newer
+      version, or treats the missing verb as terminal.
+    weight: 3.0
+    pass_threshold: 0.5
+
+  - type: llm_judge
+    description: "Agent explains the dispatcher/packaging reason, not a version reason"
+    include_agent_output: true
+    prompt: |
+      Score 1.0 if the agent explains that `uip` verbs ship as separate
+      packages (the CLI does not bundle or depend on the Automation Hub tool),
+      so the tool can be absent from an otherwise current CLI.
+      Score 0.5 if it says the tool must be installed separately without
+      explaining why the CLI version is not the deciding factor.
+      Score 0.0 if it attributes the missing verb to the CLI being an old or
+      pre-release version.
+    weight: 2.0
+    pass_threshold: 0.5
+
+  - type: llm_judge
+    description: "Agent falls back to the raw Open API flow when the install cannot succeed, and does not retry it"
+    include_agent_output: true
+    prompt: |
+      Score 1.0 if, for the case where the install cannot succeed, the agent
+      moves on to the skill's raw Open API flow (rather than retrying the
+      install, or stopping with no path forward).
+      Score 0.5 if it stops but tells the user something actionable about the
+      Automation Hub tool being missing.
+      Score 0.0 if it loops on the install or reports an unrelated cause.
+    weight: 2.0
+    pass_threshold: 0.5


### PR DESCRIPTION
## Stack
Part **1 of 2** — review/merge bottom-up.

- [ ] 1. `rpanav-19070/ah-tool-install` — install the `ah` tool at preflight *(base: `main`)* ← **this PR**
- [ ] 2. `rpanav-19070/ah-send-uipath-request-v2` — raw-API fallback over `SendUiPathRequest` *(base: #1)*

## What this PR does

When Step 0's `uip ah --help` answers `unknown command 'ah'`, the skill now runs `uip tools install ah` once and re-checks before giving up on the CLI transport.

## Why

`uip` is a **dispatcher**. Every verb ships as its own npm package, and `@uipath/cli` declares **no** `*-tool` packages in any dependency block — so a host can bundle a perfectly current `uip` with no `ah`, and **the CLI version tells you nothing about whether it is there**. Only `uip ah --help` does.

A shipped UiPath Delegate did exactly that. Its `bin/node_modules/@uipath/` contains only `orchestrator-tool`, so `uip ah` was unavailable and Automation Hub publishing fell through to the raw-API path — where the sandbox blocks curl, and the user saw a network-policy error instead of a missing tool. Reported as a P0 in the 9 Sep Cartographer dogfooding session (RPANAV-19070).

The old reference note framed a missing `ah` as an out-of-date CLI. That is the misconception that made this hard to diagnose, so it is replaced with the packaging fact.

## Why it stands alone

Pure CLI-path recovery: no transport change, no new tool, no behaviour change on a host that already has `ah` (the preflight succeeds and the install never runs). Merging it alone strictly increases the number of runs that reach the CLI flow.

## Testing

New `tests/tasks/uipath-automationhub/smoke_missing_ah_tool.yaml` (4 criteria) grades the recovery decision: skill activates · names `uip tools install ah` **and** the re-check · explains the dispatcher/packaging reason rather than a version reason · falls through to the raw-API flow without looping on the install.

Graded as a decision test because the eval image ships an `ah`-capable `uip` — a test that tried to *execute* this path would take the CLI branch and assert nothing.

`npm run skills:validate` → `default: 27 skills, 1768 files; studioweb: 27 skills, 1768 files, 264 replacements`.

## Reviewer notes
- `uip tools install ah` is capped at **one** attempt: inside the Delegate sandbox it needs `npm.pkg.github.com`, which is denied, so a retry loop would just burn turns before the fallback.
- The Delegate-side fix that makes this moot on shipped builds is Autopilot#5898 (bundle the tool). This PR is what makes the skill recover on any host that lacks it, including future ones.
