### PR TITLE
feat(uipath-automationhub): run the raw-API fallback over SendUiPathRequest

### DIFF
--- a/skills/uipath-automationhub/SKILL.md
+++ b/skills/uipath-automationhub/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uipath-automationhub
-description: "Publish and read business processes in UiPath Automation Hub via the Open API, using the user's cloud login — no admin OpenAPI token needed. PUBLISH an approved process and its PDD/SDD documents (schema-driven payload, base64 file upload or link) to AH as the system of record — e.g. a process captured/approved by Process Scribe. GET a process back by id or search, list its attached documents, and DOWNLOAD their file bytes (e.g. for dedup / related-idea lookups or retrieving a published PDD). Authenticates with the user's cloud bearer token and NEVER sends the admin `x-ah-openapi-auth` header. CLI-first: when the installed `uip` has the `ah` commands, flows run through them (`references/*-cli-guide.md`); otherwise the raw Open API flows apply. Routes by intent to publish (create/upload) or get (read/fetch/download) references over the shared catalogs. Structured to extend to more Automation Hub operations."
-allowed-tools: Bash, Read, AskUserQuestion
+description: "Publish and read business processes in UiPath Automation Hub via the Open API, using the user's cloud login — no admin OpenAPI token needed. PUBLISH an approved process and its PDD/SDD documents (schema-driven payload, base64 file upload or link) to AH as the system of record — e.g. a process captured/approved by Process Scribe. GET a process back by id or search, list its attached documents, and DOWNLOAD their file bytes (e.g. for dedup / related-idea lookups or retrieving a published PDD). Authenticates with the user's cloud bearer token and NEVER sends the admin `x-ah-openapi-auth` header. CLI-first: when `uip` has the `ah` commands, flows run through them (`references/*-cli-guide.md`); otherwise the raw Open API flows apply over `SendUiPathRequest` (or curl outside a UiPath host). Routes by intent to publish (create/upload) or get (read/fetch/download) references over the shared catalogs. Structured to extend to more Automation Hub operations."
+allowed-tools: Bash, Read, AskUserQuestion, SendUiPathRequest
 user-invocable: true
 ---
 
@@ -15,13 +15,13 @@ Run `uip ah --help` once per session.
 
 - **Succeeds** → use the **CLI flows**. Read [`references/cli-commands.md`](references/cli-commands.md) (command catalog + auth), then the matching `*-cli-guide.md` flow. Auth is handled by `uip` itself — never touch a token.
 - **Fails with `unknown command 'ah'`** → the `ah` tool isn't installed. `uip` is a dispatcher: each verb is its own package, and the AH package ships separately from the CLI, so a host can bundle `uip` without it. Run `uip tools install ah` **once**, then re-run `uip ah --help`. If it now succeeds, take the CLI flows.
-- **Still failing** (install refused, no registry access, any other error) → use the **raw Open API flows**. Read [`references/api-endpoints.md`](references/api-endpoints.md) (auth model, gateway URL, exact headers — and the header to never send), then the matching flow. Do not retry the install.
+- **Still failing** (install refused, no registry access, any other error) → use the **raw Open API flows**. Read [`references/api-endpoints.md`](references/api-endpoints.md) → **Transport** to pick how to issue requests, then the matching flow. Do not retry the install.
 
-Never mix the two transports in one run. The domain contract — required fields, wrapping rules, document types — is identical either way and lives in `api-endpoints.md`.
+Never mix transports in one run. The domain contract — required fields, wrapping rules, document types — is identical either way and lives in `api-endpoints.md`.
 
-## Authentication (raw-API flows only — skip when using the CLI flows)
+## Authentication (raw-API **curl** transport only)
 
-> On the CLI path, `uip` handles auth itself (Delegate env-auth or `uip login`) — never touch a token there; see [`references/cli-commands.md`](references/cli-commands.md). The resolution order below applies **only** to the raw-API flows.
+> Nothing to resolve on the other two paths: `uip` handles auth itself on the CLI path (see [`references/cli-commands.md`](references/cli-commands.md)), and the host injects it on `SendUiPathRequest`. The order below applies **only** when you are issuing raw requests with curl.
 
 Resolve the cloud token + base URL + org + tenant in this **priority order**:
 
@@ -48,7 +48,7 @@ The platform injects tenant-routing headers from the `{org}/{tenant}` segments �
 
 ## Routing — pick the flow by intent
 
-Classify what the user wants, then follow the matching reference. The **raw-API flows** share the Authentication section above and the endpoint catalog in `references/api-endpoints.md`; the **CLI flows** never touch either — `uip` handles auth itself (see [`references/cli-commands.md`](references/cli-commands.md)).
+Classify what the user wants, then follow the matching reference. The **raw-API flows** share the endpoint catalog and transport rules in `references/api-endpoints.md`; the **CLI flows** never touch either — `uip` handles auth itself (see [`references/cli-commands.md`](references/cli-commands.md)).
 
 | The user wants to... | CLI available (preferred) | CLI unavailable |
 |---|---|---|
@@ -71,4 +71,4 @@ Every addition keeps the skill's three invariants: collect inputs before the fir
 - **Cloud token only** — authorization is the user's real AH permissions; you see and can do exactly what their AH role allows.
 - **If Automation Hub isn't available on the tenant, say so plainly and stop** — never let it surface as a generic failure. Two cases with **different remedies**: *not enabled* (only an admin can fix it) and *reachable but never onboarded* (self-service). Signals, and the exact wording to quote verbatim rather than paraphrase, live in one home per transport: [`references/api-endpoints.md`](references/api-endpoints.md) → **Automation Hub not available on this tenant** for the raw-API flows, [`references/cli-commands.md`](references/cli-commands.md) → same heading for the CLI flows.
 - The publish flow fetches the idea-flow schema live, so it adapts automatically if fields change on the tenant.
-- **Open dependency:** in a hosted runtime (e.g. Process Scribe/Delegate) the cloud token is expected via the environment (Authentication, option 1). Confirm the runtime provides `UIPATH_CLI_AUTH_TOKEN` (or an equivalent) before relying on it in production.
+- **In a UiPath host (Delegate), raw shell HTTP is blocked** — only `uip` and `SendUiPathRequest` reach the network. A curl-based fallback there fails at DNS and reads like a network-policy error rather than the missing `ah` tool it actually is; that is why Step 0 installs the tool and why the raw-API transport is `SendUiPathRequest`.

--- a/skills/uipath-automationhub/references/api-endpoints.md
+++ b/skills/uipath-automationhub/references/api-endpoints.md
@@ -2,9 +2,35 @@
 
 > This skill authenticates with the **user's UiPath cloud access token** — **not** an admin-generated OpenAPI token. This is the AH Open API's `automation-cloud` mode: send the bearer token and **do not** send `x-ah-openapi-auth`.
 
-This is the shared auth + endpoint catalog for both flows — [`publish-process.md`](publish-process.md) (write) and [`get-process.md`](get-process.md) (read).
+This is the shared transport + endpoint catalog for both flows — [`publish-process.md`](publish-process.md) (write) and [`get-process.md`](get-process.md) (read).
 
-## Authentication
+## Transport
+
+Both flows write each call as **`METHOD /endpoint`**, where `/endpoint` is relative to the Open API root. Render it one of two ways — decide once per run, never mix.
+
+### Preferred: the `SendUiPathRequest` tool
+
+Available inside a UiPath host (Delegate). **Required there:** the host sandbox permits `uip` and `SendUiPathRequest` but denies raw shell HTTP, so `curl` fails at DNS with a message that reads like a network-policy problem.
+
+| Tool arg | Value |
+|---|---|
+| `method` | the METHOD |
+| `path` | `automationhub_/api/v1/openapi{endpoint}` — **relative**; the host prepends base URL, org and tenant |
+| `body` | the JSON object (POST/PATCH) |
+| `bodyFromFile` | absolute path to a file holding the body — use for document uploads, so base64 bytes never enter the conversation |
+| `headers` | omit. Auth is injected by the host and `authorization` is stripped from caller headers. The **never send** rule under **Headers** still binds here — `x-ah-openapi-auth` / `x-ah-openapi-app-key` would pass straight through |
+
+Nothing to resolve: no token, no base URL, no org/tenant, no `Content-Type`. The **Authentication** and **Base URL** sections below do not apply on this transport.
+
+**Reading the outcome.** The tool returns the response **body**, not the HTTP status line, so read the status from AH's own envelope — `statusCode` on the standard wrapper, `status` on the schema call. A non-2xx comes back as a tool error whose text carries the API's error body; parse that for `message` / `errorDetails` and treat it as the status the flows describe. Two consequences: a **redirect target** may not be visible, and a bare gateway status (404 / 422 with no AH envelope) can arrive with no code to match on — in both cases classify by the other signals in **Automation Hub not available on this tenant** rather than by number.
+
+**Large responses.** Bodies over `maxInlineBytes` (default 2KB) are written to a file and only previewed. `GET /idea-schema` always exceeds it: pass a larger `maxInlineBytes`, or read the dumped file — never work from the preview alone, which truncates the field catalog.
+
+### Fallback: `curl`
+
+Plain shells only. Resolve auth per **Authentication** below, build the full URL from **Base URL**, and send the **Headers**. Append `-w "\n%{http_code}"` to read the status (a flow may ask for ` %{redirect_url}` too). Never add `-L`.
+
+## Authentication *(curl transport only)*
 
 ### Getting the cloud token + org/tenant (in priority order)
 
@@ -22,7 +48,7 @@ Never fall back to an admin OpenAPI token. If none of the above yields a token, 
 
 e.g. `https://cloud.uipath.com/acme/prod/automationhub_/api/v1/openapi`. Always use this **gateway** URL — the platform injects the tenant-routing headers from the `{org}/{tenant}` segments. (Local dev: base `http://localhost:3002`, path `/api/v1/openapi`, and you must confirm how org/tenant are supplied locally.)
 
-### Headers (every request)
+### Headers (every curl request)
 
 | Header | Value | When |
 |--------|-------|------|

--- a/skills/uipath-automationhub/references/get-process.md
+++ b/skills/uipath-automationhub/references/get-process.md
@@ -2,36 +2,29 @@
 
 Fetches one process (by id or search) and its documents from Automation Hub, authenticating with the **user's cloud token** — no admin OpenAPI token required. Read-only: this flow never writes.
 
-> Auth, base/gateway URL, headers (and the header to **never** send), and the read endpoints are defined in [`api-endpoints.md`](api-endpoints.md). Resolve `$ACCESS_TOKEN` / `$BASE_URL` / `$ORG` / `$TENANT` via the shared **Authentication** section in [`../SKILL.md`](../SKILL.md) before starting.
+> Requests are written as `METHOD /endpoint`. Pick the transport **once** — `SendUiPathRequest` inside a UiPath host, `curl` in a plain shell — per [`api-endpoints.md`](api-endpoints.md) → **Transport**, which also holds the read endpoints, the header to **never** send, and (curl only) how to resolve auth.
 
 ## Step 1: Resolve the process
 
 - If the caller gives a **process id**, use it directly.
 - Otherwise search by name:
-  ```bash
-  curl -s -w "\n%{http_code} %{redirect_url}" -H "Authorization: Bearer $ACCESS_TOKEN" \
-    "$BASE_URL/$ORG/$TENANT/automationhub_/api/v1/openapi/automations?search=$QUERY&limit=20"
-  ```
-  The last line is `<status> <redirect target>` (empty target unless 3xx). Check it **before** the results: a **404 / 3xx to `portal_/unregistered` / 422 tenant lookup** means AH isn't available on this tenant at all — handle it as in Step 2, don't report it as "no match". Never add `-L`.
+  **`GET /automations?search={query}&limit=20`**
+
+  Check the status (and the redirect target, where the transport exposes it) **before** the results: a **404 / 3xx to `portal_/unregistered` / 422 tenant lookup** means AH isn't available on this tenant at all — handle it as in Step 2, don't report it as "no match".
 
   On a 200: one clear match → use its `process_id`. If several → show a short list (name + id + owner) and ask the user to pick. If none → tell the user and stop.
 
 ## Step 2: Fetch the process
 
-```bash
-curl -s -w "\n%{http_code} %{redirect_url}" -H "Authorization: Bearer $ACCESS_TOKEN" \
-  "$BASE_URL/$ORG/$TENANT/automationhub_/api/v1/openapi/automations/$PROCESS_ID"
-```
-The last line is `<status> <redirect target>` (empty target unless 3xx) — the target is what separates a `portal_/unregistered` redirect from any other 3xx. Never add `-L`.
+**`GET /automations/{process_id}`**
+
+The redirect target, where the transport exposes it, is what separates a `portal_/unregistered` redirect from any other 3xx.
 - **200** → keep the record; project to the useful fields for display (name, status/phase, category, owner, description). The raw record is large — don't dump it all unless asked.
 - **401** → re-authenticate. **403** → the user can't view this process. **404** → no such process — *unless* the body says `not found in organization` (or the call 3xx-redirects to `portal_/unregistered`, or answers **422 tenant lookup**), which means AH itself is not available on this tenant: report the message for the matching case, verbatim, from [`api-endpoints.md`](api-endpoints.md) → **Automation Hub not available on this tenant**, and stop.
 
 ## Step 3: Fetch the documents
 
-```bash
-curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
-  "$BASE_URL/$ORG/$TENANT/automationhub_/api/v1/openapi/automations/$PROCESS_ID/documents"
-```
+**`GET /automations/{process_id}/documents`**
 
 The list is under **`data.documents[]`** (standard envelope). Each entry carries `document_id`, `document_title`, `document_type_id`, and **either** a `file_id` (file-backed) **or** an `embed_link` (link-backed). *(Optional: `/automations/$PROCESS_ID/components` for linked components.)*
 
@@ -39,13 +32,8 @@ The list is under **`data.documents[]`** (standard envelope). Each entry carries
 
 Only **file-backed** documents can be downloaded, and the endpoint takes the **`file_id`** — not the `document_id`:
 
-```bash
-curl -s -w "%{http_code}" -H "Authorization: Bearer $ACCESS_TOKEN" \
-  -o "<destination-path>" \
-  "$BASE_URL/$ORG/$TENANT/automationhub_/api/v1/openapi/download/file/$FILE_ID"
-```
+**`GET /download/file/{file_id}`** — the response body is the **raw file**, no JSON envelope, so write it straight to disk rather than into the conversation: `responseType: "binary"` on `SendUiPathRequest`, `-o "<destination-path>"` on curl. Pick the filename from `document_title` or ask the user.
 
-- The response body is the **raw file** (no JSON envelope) — always save with `-o`; pick the filename from `document_title` or ask the user.
 - **200** → confirm the file exists and is non-empty before reporting success.
 - A **link-backed** document (`file_id` absent) has nothing to download — present its `embed_link` to the user instead. Never invent a download URL for it.
 - Do not guess other paths (`/documents/{id}/download`, `/files/{id}`, …) — `/download/file/{file_id}` is the only download route.

--- a/skills/uipath-automationhub/references/publish-process.md
+++ b/skills/uipath-automationhub/references/publish-process.md
@@ -2,19 +2,15 @@
 
 Creates one process in Automation Hub from a schema-driven payload and attaches its documents (PDD/SDD). Authenticates with the **user's cloud token** — the user does **not** need an admin-generated OpenAPI token.
 
-> Auth, base/gateway URL, headers (and the header to **never** send), and every endpoint below are defined in [`api-endpoints.md`](api-endpoints.md). Resolve `$ACCESS_TOKEN` / `$BASE_URL` / `$ORG` / `$TENANT` via the shared **Authentication** section in [`../SKILL.md`](../SKILL.md) before starting.
+> Requests are written as `METHOD /endpoint`. Pick the transport **once** — `SendUiPathRequest` inside a UiPath host, `curl` in a plain shell — per [`api-endpoints.md`](api-endpoints.md) → **Transport**, which also holds every endpoint, the header to **never** send, and (curl only) how to resolve auth.
 
 ## Step 1: Verify connectivity (and fetch the idea flows)
 
-Verify the resolved token with a cheap call — this also fetches the idea flows you need next:
+Verify the transport works with a cheap call — this also fetches the idea flows you need next:
 
-```bash
-curl -s -w "\n%{http_code} %{redirect_url}" \
-  -H "Authorization: Bearer $ACCESS_TOKEN" \
-  "$BASE_URL/$ORG/$TENANT/automationhub_/api/v1/openapi/idea-flows"
-```
+**`GET /idea-flows`**
 
-The last line is `<status> <redirect target>` — the target is empty unless the response was a 3xx. Read both: a 3xx alone is ambiguous, a 3xx **to `portal_/unregistered`** is the tenant-not-enabled signal below. Never add `-L`.
+Read the status **and**, if the transport exposes it, the redirect target: a 3xx alone is ambiguous, a 3xx **to `portal_/unregistered`** is the tenant-not-enabled signal below. On curl that means `-w "\n%{http_code} %{redirect_url}"` and never `-L`.
 
 - **200** → save the `data` array (reused in Step 2) and tell the user "Connected to Automation Hub."
 - **401** → token missing/expired: if it came from `~/.uipath/.auth`, ask the user to run `uip login` again; re-resolve and retry. **Never** add `x-ah-openapi-auth` to "fix" a 401 — that routes to the admin-token path and guarantees failure.
@@ -33,10 +29,7 @@ Store `idea_flow_id`.
 
 ## Step 3: Fetch the schema
 
-```bash
-curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
-  "$BASE_URL/$ORG/$TENANT/automationhub_/api/v1/openapi/idea-schema?idea_flow_id=$IDEA_FLOW_ID"
-```
+**`GET /idea-schema?idea_flow_id={idea_flow_id}`**
 
 Parse `data.properties.schema.properties` for the field catalog (Assessment Type > Section > Question; note types, required flags, enum `answer_option` codes/labels) and keep `data.user_inputs` as the payload template. The process-name question (key contains `OVERVIEW_NAME`) is **required**.
 
@@ -81,14 +74,7 @@ Include only sections that have at least one populated field. Show the user a co
 
 ## Step 5: Create the process
 
-```bash
-curl -s -w "\n%{http_code}" -X POST \
-  -H "Authorization: Bearer $ACCESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "$PAYLOAD" \
-  "$BASE_URL/$ORG/$TENANT/automationhub_/api/v1/openapi/idea-from-schema"
-```
-where `$PAYLOAD` is `{ "idea_flow_id": <id>, "user_inputs": { … } }`.
+**`POST /idea-from-schema`** with body `{ "idea_flow_id": <id>, "user_inputs": { … } }`.
 
 - **201** → the envelope is `{ "message": "Resource Created", "statusCode": 201, "data": { … } }` — read **`data.process_id`** (it is nested, NOT top-level). Keep it for Step 6. A 201 means the process WAS created: if a field read comes back undefined, re-read the response — **never re-POST** (that creates a duplicate and 409s).
 - **400** → fix and retry. The message shapes seen live:
@@ -102,15 +88,7 @@ where `$PAYLOAD` is `{ "idea_flow_id": <id>, "user_inputs": { … } }`.
 
 Attach each document the caller supplies — **default to all of them**; never silently skip a supplied file. The one exception: if two supplied files appear to be the *same document in different formats*, ask which to attach — as part of the single up-front clarifying round (Step 4), not a separate round. **Upload the bytes** — the endpoint takes a base64 `file` object directly, so nothing needs hosting first. Fall back to `embed_link` only when the caller has a URL instead of bytes.
 
-```bash
-curl -s -w "\n%{http_code}" -X POST \
-  -H "Authorization: Bearer $ACCESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "$DOC_PAYLOAD" \
-  "$BASE_URL/$ORG/$TENANT/automationhub_/api/v1/openapi/automations/$PROCESS_ID/documents"
-```
-
-Build `$DOC_PAYLOAD` per `ProcessDocumentValidator`:
+**`POST /automations/{process_id}/documents`**, body per `ProcessDocumentValidator`:
 
 ```json
 {
@@ -145,13 +123,7 @@ Record each returned id — it is nested: read **`data.document_id`** from the r
 
 When the caller wants the process linked to a Studio Web solution (or supplies one), set the `OVR-OVERVIEW_STUDIO_WEB_LINK` question — at create time inside `user_inputs` (Step 4), or afterwards:
 
-```bash
-curl -s -w "\n%{http_code}" -X PATCH \
-  -H "Authorization: Bearer $ACCESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"user_inputs": { ...only this question, in its Step-4 shape... }}' \
-  "$BASE_URL/$ORG/$TENANT/automationhub_/api/v1/openapi/automations/$PROCESS_ID"
-```
+**`PATCH /automations/{process_id}`** with body `{"user_inputs": { …only this question, in its Step-4 shape… }}`.
 
 The answer's exact value format (JSON-string `value` with a required `url`, `hasProcessMap` semantics, empty string to unlink) is a domain fact — read it in [`api-endpoints.md`](api-endpoints.md) (**Studio Web link**). Resolve the solution from the caller — ask for the designer URL (no discovery API exists on this path either); **never invent, guess, or search for a solution id or URL**, and omit `hasProcessMap` if the caller doesn't know whether the solution has a `.bpmn`.
 
@@ -159,10 +131,7 @@ The answer's exact value format (JSON-string `value` with a required `url`, `has
 
 **Verify before claiming success** — read the process back and confirm the documents landed:
 
-```bash
-curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
-  "$BASE_URL/$ORG/$TENANT/automationhub_/api/v1/openapi/automations/$PROCESS_ID/documents"
-```
+**`GET /automations/{process_id}/documents`**
 
 Check every attached `document_id` appears (file-backed entries also carry a `file_id`). If one is missing, report it as failed — never report a document as attached without seeing it in this list.
 

--- a/tests/tasks/uipath-automationhub/smoke_no_cli_transport.yaml
+++ b/tests/tasks/uipath-automationhub/smoke_no_cli_transport.yaml
@@ -1,0 +1,96 @@
+task_id: skill-ah-no-cli-transport-smoke
+description: >
+  Regression guard for the Cartographer/Delegate P0 (RPANAV-19070): when the
+  `ah` CLI tool is absent, the skill must not fall through to raw shell HTTP.
+  Inside a UiPath host the sandbox permits `uip` and `SendUiPathRequest` but
+  denies curl, so a curl fallback dies at DNS and gets reported to the user as
+  a network-policy failure instead of the missing tool it actually is. This
+  grades the transport DECISION, not live output: the skill must (1) activate,
+  (2) name `SendUiPathRequest` as the raw-API transport once the CLI path is
+  unavailable, and (3) never reach for curl or the admin-token headers.
+  Recovering the CLI path by installing the tool is covered separately by
+  smoke_missing_ah_tool.
+tags: [uipath-automationhub, smoke, mode:diagnose]
+
+run_limits:
+  expected_turns: 6
+
+initial_prompt: |
+  You are running inside the UiPath Delegate host, and you are about to publish
+  an approved business process and its SDD to UiPath Automation Hub.
+
+  Facts about this runtime — take them as given, do NOT try to verify them by
+  running commands, and do NOT attempt any network call:
+
+    - `uip` is installed, but this build ships it WITHOUT the Automation Hub
+      commands, and the tool cannot be installed here — the CLI path is not
+      available on this run.
+    - The host sandbox permits `uip` and the `SendUiPathRequest` tool. Raw
+      shell HTTP (curl, wget) is denied and fails at DNS resolution.
+    - Auth, organization and tenant are supplied by the host.
+
+  Using the `uipath-automationhub` skill, answer in text only:
+
+    1. Which transport do you use for the raw Open API flow, and what would
+       the first request look like (method and path)?
+    2. How do you read the outcome of that request — where does the status
+       come from?
+    3. What would you tell the user if no transport were available?
+
+  Do NOT run any commands. Do NOT ask for confirmation — this is an automated
+  test.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-automationhub skill"
+    skill_name: "uipath-automationhub"
+    expected_skill: "uipath-automationhub"
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # The P0 itself: a curl fallback inside the host is what produced the
+  # misleading "DNS access is disabled" report.
+  - type: command_not_executed
+    description: "Agent never reached for raw shell HTTP against Automation Hub"
+    tool_name: "Bash"
+    command_pattern: '(?i)(curl|wget)[^\n]*(cloud\.uipath\.com|automationhub_)'
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent never sent the admin-token header x-ah-openapi-auth (would 401 a cloud token)"
+    tool_name: "Bash"
+    command_pattern: '(?i)x-ah-openapi-auth'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent names SendUiPathRequest as the raw-API transport, with a host-relative path and no hand-built auth"
+    include_agent_output: true
+    prompt: |
+      The runtime permits `uip` and the `SendUiPathRequest` tool; raw shell
+      HTTP is denied.
+
+      Score 1.0 if the agent names `SendUiPathRequest` as the transport for the
+      raw Open API flow AND shows a request whose path is relative and starts
+      with `automationhub_/api/v1/openapi` (no scheme/host, no organization or
+      tenant segments), AND does not construct an Authorization header.
+      Score 0.5 if it names `SendUiPathRequest` but gets the path shape wrong
+      (absolute URL, or org/tenant included) or still builds an auth header.
+      Score 0.0 if it proposes curl / raw HTTP, or reports the situation as a
+      network-policy or DNS failure.
+    weight: 3.0
+    pass_threshold: 0.5
+
+  - type: llm_judge
+    description: "Failure message names the real cause (tool not installed), not a network problem"
+    include_agent_output: true
+    prompt: |
+      Score 1.0 if, for the case where no transport is available, the agent
+      would tell the user something actionable about the Automation Hub CLI
+      tool being missing from this build (and/or the host being unable to
+      reach Automation Hub for that reason).
+      Score 0.0 if it would report it as the user's network policy, firewall,
+      or DNS blocking Automation Hub, with no mention of the missing tool.
+    weight: 2.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Stack
Part **2 of 2** — review/merge bottom-up.

- [x] 1. #3220 — install the `ah` tool at preflight *(base: `main`)*
- [ ] 2. `rpanav-19070/ah-send-uipath-request-v2` — raw-API fallback over `SendUiPathRequest` *(base: #3220)* ← **this PR**

> Stacked PR — base is #3220, not `main`. The diff shows only this layer.

## What this PR does

Makes the raw Open API fallback usable inside a UiPath host by issuing requests through the **`SendUiPathRequest`** tool instead of `curl`.

## Why

The Delegate sandbox permits `uip` and `SendUiPathRequest` and denies raw shell HTTP. So when the CLI path was unavailable, every `curl` in the fallback died at DNS and the agent reported it as:

> Publishing is currently blocked by this Delegate session's network policy: DNS access to `cloud.uipath.com` is disabled…

The sandbox was doing its job; the fallback was simply unreachable there. #3220 stops us landing on the fallback for the common cause, but the fallback stays reachable whenever a tool is missing, renamed, or a future skill runs on a host without it — and today every one of those degrades into that same misleading message.

## Shape: one request, two renderings

Rather than add a third copy of the flows (there are already CLI + API twins), the flows now state each call **once** as `METHOD /endpoint` and pick a rendering from a single **Transport** section in `api-endpoints.md`. On `SendUiPathRequest` there is no token, base URL, org, tenant or `Content-Type` to resolve — the host injects all of it and strips `authorization` from caller headers — so the auth boilerplate that was repeated at all six request sites is gone. Net for the flow files: **−72 lines**.

The `x-ah-openapi-auth` / `x-ah-openapi-app-key` never-send rule is restated on the tool path deliberately: those headers are not in the tool's protected list and would pass straight through.

## Known limitations, documented in the skill

Two places this transport is weaker than curl. Both are written into the Transport section rather than left for an agent to discover:

1. **No HTTP status line.** The tool returns the response *body*; a non-2xx arrives as a tool error whose text carries the API's error body. The flows branch on 201/400/401/403/404/409/422, so they now read the status from **AH's own envelope** (`statusCode` / `status`). Consequence: a **redirect target** may be invisible, and a bare gateway 404/422 with no AH envelope has no code to match — so the "Automation Hub not available on this tenant" case is classified by signal rather than by number.
2. **Large responses are dumped to a file** past `maxInlineBytes` (default 2KB). `GET /idea-schema` always exceeds it — pass a larger `maxInlineBytes` or read the dumped file, never the truncated preview.

## Why it stands alone

The curl path is unchanged for plain shells, and the CLI path never touches any of this. On a host with `ah` present, nothing in this PR executes.

## Testing

New `tests/tasks/uipath-automationhub/smoke_no_cli_transport.yaml` (5 criteria): skill activates · **never** reaches for curl/wget against Automation Hub · never sends the admin headers · names `SendUiPathRequest` with a host-relative `automationhub_/api/v1/openapi…` path and no hand-built auth · reports a missing transport as the missing tool, not as the user's network policy.

Decision-graded for the same reason as #3220 — the eval image's `uip` has `ah`, so an execution test would take the CLI branch.

`npm run skills:validate` → `default: 27 skills, 1768 files; studioweb: 27 skills, 1768 files, 264 replacements`.

## Open questions for review

- **`autoExecute = false`** on the tool: every call needs user approval, so a publish is ~6 prompts. Acceptable, or should the host auto-approve this tool for skill-driven flows?
- **`availability: "autopilotAgent"`** — please confirm the agent that runs `uipath/skills` in Delegate actually exposes the tool; if it doesn't, this fallback is as unreachable as curl was.
- The tool targets the **session's** org/tenant. Publishing to a different tenant than the host session is not expressible on this transport — fine today, worth knowing.

cc the Delegate-side fix for the same P0: Autopilot#5898.
