### PR TITLE
fix(uipath-maestro-flow): plan a filter tree on the offline connector path

### DIFF
--- a/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
@@ -47,7 +47,7 @@ If `node configure` cannot run:
 1. Run `uip maestro flow registry search <keyword>` and `registry get <node-type>` to confirm the operation; see [cli-commands.md — registry](../../../shared/cli-commands.md#uip-maestro-flow-registry).
 2. Run `uip maestro flow node add <file> <node-type> --output json`; inside a loop body, add `--parent <LOOP_NODE_ID>` as described in [loop/impl.md](../loop/impl.md).
 3. Write the planned `--detail` payload, including placeholder connection and folder UUIDs, to a separate file such as `<nodeId>.detail.json`. Do not put partial `inputs.detail` on the node.
-4. Author any filter as a tree under that payload's `filter` key, per [Step 6a](#step-6a--filterbuilder-parameters) steps 1-3. Never write compiled query text under the parameter name, such as `"queryParameters": { "where": "displayName='active'" }`; offline, the tree is the filter's only reviewable form.
+4. Author any filter as a tree under that payload's `filter` key, shaped per [Step 6a](#step-6a--filterbuilder-parameters) step 3. The step-1 `registry get` names the FilterBuilder parameter; if the activity has none, pass no `filter` and filter downstream. Never write compiled query text under the parameter name, such as `"queryParameters": { "where": "displayName='active'" }`; offline, the tree is the filter's only reviewable form.
 5. Report under **Missing connections** or **Open questions** that the node will not pass `flow validate` until real `node configure` runs.
 
 Do not replace a registered connector node with `core.logic.mock`. Use mocks only for genuinely unknown, unpublished, or not-yet-built non-connector resources. Preserve the registered connector key.

--- a/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/plugins/connector/impl.md
@@ -47,7 +47,8 @@ If `node configure` cannot run:
 1. Run `uip maestro flow registry search <keyword>` and `registry get <node-type>` to confirm the operation; see [cli-commands.md — registry](../../../shared/cli-commands.md#uip-maestro-flow-registry).
 2. Run `uip maestro flow node add <file> <node-type> --output json`; inside a loop body, add `--parent <LOOP_NODE_ID>` as described in [loop/impl.md](../loop/impl.md).
 3. Write the planned `--detail` payload, including placeholder connection and folder UUIDs, to a separate file such as `<nodeId>.detail.json`. Do not put partial `inputs.detail` on the node.
-4. Report under **Missing connections** or **Open questions** that the node will not pass `flow validate` until real `node configure` runs.
+4. Author any filter as a tree under that payload's `filter` key, per [Step 6a](#step-6a--filterbuilder-parameters) steps 1-3. Never write compiled query text under the parameter name, such as `"queryParameters": { "where": "displayName='active'" }`; offline, the tree is the filter's only reviewable form.
+5. Report under **Missing connections** or **Open questions** that the node will not pass `flow validate` until real `node configure` runs.
 
 Do not replace a registered connector node with `core.logic.mock`. Use mocks only for genuinely unknown, unpublished, or not-yet-built non-connector resources. Preserve the registered connector key.
 


### PR DESCRIPTION
## What

`connector/impl.md`'s **No-Live-Tenant / Planned Configuration** path tells the agent to write the planned `--detail` payload to a file, but never mentions filters and never links the filter-tree procedure.

That procedure is **Step 6a**, which sits inside the live `node configure` workflow this section exists because you cannot run. So an agent on the offline path writes compiled query text under the parameter name, which Step 6a explicitly forbids in the one section that never says so.

One step added:

> 4. Author any filter as a tree under that payload's `filter` key, per [Step 6a](#step-6a--filterbuilder-parameters) steps 1-3. Never write compiled query text under the parameter name, such as `"queryParameters": { "where": "displayName='active'" }`; offline, the tree is the filter's only reviewable form.

Scoped to steps 1-3 because 6a's steps 4 and 5 run `node configure`.

## Why

`skill-flow-ipe-ceql-where`, 2026-09-10, **score 0.000**. The agent produced:

```json
"queryParameters": { "where": "displayName='active'" }
```

where `check_ceql_where_flow.py` wants a structured tree. Everything else it built was correct: the registered connector key `uipath-microsoft-azureactivedirectory`, the `list-groups` operation, Decision and Terminate routing. Only the planned filter was mis-shaped.

The transcript shows the agent read `impl.md` with `sed -n '/No-Live-Tenant/,/^[#][#]*/p'`, so that block is the only part of the file it saw. Guidance placed anywhere else would have been invisible to it.

## Verification

- ✅ `scripts/check-skill-links.mjs` — 6780 relative links, all resolve
- ✅ Anchor matches the repo convention for em-dash headings (cf. `impl-connector.md#step-2--identify-target-connection`)
- ✅ Chain reaches a passing artifact: new step 4 → Step 6a step 3 → [Filter Trees (CEQL)](https://github.com/UiPath/skills/blob/main/skills/uipath-platform/references/integration-service/activities.md#filter-trees-ceql), whose tree carries `id`, PascalCase `operator`, `value.value`, `isLiteral: true` — satisfying `_looks_like_filter_tree`, `_leaf_field` and `_leaf_value` in the grader
- ✅ No parallel gap: `connector-trigger/impl.md` has no No-Live-Tenant section
- ✅ Nothing references this section in `tests/` or `scripts/`

**Not verified:** the eval has not been rerun. Expected 0.000 → 1.000 is a prediction.

## Scope

Docs only. One file, one added list item. No checker, task or prompt changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
