### PR TITLE
fix(case-tests): assert parallel timers by their entry conditions, not array shape

### DIFF
--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/check_linear_three_stages.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/check_linear_three_stages.py
@@ -65,12 +65,6 @@ def main():
         sys.exit(f"FAIL: no wait-for-timer task in caseplan. Types seen: {types_seen}")
 
     review_lanes = (review.get("data") or {}).get("tasks") or []
-    timer_lane_indices = {
-        lane_idx
-        for lane_idx, lane in enumerate(review_lanes)
-        for t in (lane or [])
-        if t.get("type") == "wait-for-timer"
-    }
     review_task_ids = {t.get("id") for lane in review_lanes for t in (lane or [])}
     review_timers = [t for t in timer_tasks if t.get("id") in review_task_ids]
     if len(review_timers) < 2:
@@ -79,11 +73,36 @@ def main():
             f"FAIL: Review should have ≥2 parallel wait-for-timer tasks "
             f"('Hold For 1 Hour' + 'Notify Reviewer'); got {len(review_timers)} ({labels})"
         )
-    if len(timer_lane_indices) != 1:
-        sys.exit(
-            f"FAIL: Review's explicit parallel timer tasks must share one "
-            f"data.tasks inner task set; got set indices {sorted(timer_lane_indices)}"
-        )
+    # "Parallel" is a property of the ENTRY CONDITIONS, not of the array shape.
+    #
+    # This used to require both timers in one `data.tasks` set. That is not what
+    # makes case tasks concurrent, and the platform does not write it: in
+    # `@uipath/case-schema`, a stage's tasks are partitioned by
+    # `taskOnlyRunsSequentiallyInStage` — true only when EVERY rule of EVERY
+    # entry condition is `runs-sequentially`. Those keep their set grouping and
+    # run set-by-set; every other task goes into a flat bucket whose position is
+    # never read. Two `current-stage-entered` timers convert to byte-identical
+    # scheduler rules in one set or two.
+    #
+    # And LinearThreeStages.v27 — the platform document this task is modelled on
+    # — puts its two "parallel" timers in SEPARATE sets, so the old assertion
+    # failed the designer's own output. It cost a v2 run a task.
+    for timer in review_timers:
+        label = timer.get("displayName") or timer.get("label")
+        conditions = timer.get("entryConditions") or []
+        rules = [r.get("rule") for c in conditions for g in (c.get("rules") or []) for r in g]
+        if not rules:
+            sys.exit(f"FAIL: Review timer {label!r} has no task-entry condition")
+        if "current-stage-entered" not in rules:
+            sys.exit(
+                f"FAIL: Review timer {label!r} should carry a current-stage-entered "
+                f"task-entry condition so it runs concurrently with its sibling; got {rules}"
+            )
+        if all(r == "runs-sequentially" for r in rules):
+            sys.exit(
+                f"FAIL: Review timer {label!r} runs sequentially, so it waits for the "
+                f"previous task set instead of running alongside its sibling"
+            )
 
     def _by_label(label: str) -> dict | None:
         for t in review_timers:


### PR DESCRIPTION
Pairs with UiPath/flow-builder-sdk#713 (the SDK doc half). Finding 06 of the case-eval triage.

## The assertion

`check_linear_three_stages` required Review's two timers to share one `data.tasks` set:

```python
if len(timer_lane_indices) != 1:
    FAIL: ... must share one data.tasks inner task set
```

## That shape carries no behaviour

In `@uipath/case-schema`, `taskPlansForNewStructuredCase` partitions a stage's tasks:

```js
for (const tasksSet of stage.data?.tasks ?? [])
  for (const task of tasksSet)
    if (taskOnlyRunsSequentiallyInStage(task)) sequentialTaskSet.push(task);
    else allOtherTasks.push(task);
```

`taskOnlyRunsSequentiallyInStage` is true only when **every** rule of **every** entry condition is `runs-sequentially`. Those keep their set grouping and each set waits for the previous one. Everything else lands in a flat `allOtherTasks` bucket whose position is never read.

Measured through the converter:

| tasks | one set vs two |
|---|---|
| two `current-stage-entered` timers | **byte-identical `rulesJson`** |
| two `runs-sequentially` timers | differs — splitting adds the `StageEntered` AND-condition that orders them |

## And it fails the designer's own output

`LinearThreeStages.v27` — the platform document this task is modelled on — puts its two "parallel" timers in **separate** sets:

```
Review data.tasks shape : [['Hold For 1 Hour'], ['Notify Reviewer']]
timer_lane_indices      : [0, 1]
grader requires len == 1 -> FAILS
```

## It cost a real run

In the 2026-09-09 v2 eval the agent read the SDK's `lane` doc — *"selects a parallel lane"* — wrote `{ lane: 1 }` for its second timer, and was failed here. That task scored 0.5 on an artifact that was behaviourally correct. Neither side was right about the wire; the doc half is fixed in flow-builder-sdk#713.

## What it asserts now

What "parallel" actually means for a case task: each Review timer carries a `current-stage-entered` task-entry condition, and none is gated only by `runs-sequentially`.

Verified against four shapes:

| shape | verdict |
|---|---|
| one shared set (what the old grader demanded) | accepted |
| two separate sets (what the designer writes) | accepted |
| both `runs-sequentially` (genuinely not parallel) | rejected |
| a timer with no entry condition | rejected |

So it still catches the things worth catching, and stops failing correct work. 138 grader tests pass. The now-unused `timer_lane_indices` binding is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
