### PR TITLE
fix(uipath-maestro-bpmn): no-tenant/offline registry carve-out (supersedes #3217, #3225)

### DIFF
--- a/skills/uipath-maestro-bpmn/references/registry-workflow.md
+++ b/skills/uipath-maestro-bpmn/references/registry-workflow.md
@@ -25,18 +25,23 @@ found via `registry search`, is a **false negative** — never conclude "no
 connection exists" or ask the user to create one until you have searched the
 registry for the real connector key and listed across all folders.
 
-**Greenfield / synthetic authoring is the exception — do not discover live
-instances that do not exist.** When the task is to author a local project with
-no tenant, no deployed resources, and no login (a synthetic or greenfield pass,
-which every offline eval and most first-draft authoring is), do NOT run `uip or
-processes list`, `uip is connections list`, or `uip login` looking for a live
-process, agent, or connection to bind: there are none, and their absence is
-expected, not a false negative. Instead: pick the extension type by intent,
+**With no tenant reachable, do not discover live instances that do not exist.**
+The exhaustive-discovery rule above assumes a connected tenant. When you are
+authoring offline — no `uip login`, no reachable tenant, no deployed resources
+(every synthetic eval, and any draft done before a tenant is connected) — do NOT
+run `uip or processes list`, `uip is connections list`, or `uip login` looking
+for a live process, agent, or connection to bind: there are none, and their
+absence is expected, not a false negative. Pick the extension type by intent,
 `registry get` its `xmlTemplate`, and author the node as a **draft** — paste the
 template and leave its binding placeholders (release keys, folder ids,
-connection ids, `<uipath:bindings>` `default`s) unresolved. The exhaustive-
-discovery rules above, and the `processType` selection below, apply only once a
-real tenant with deployed resources is in play.
+connection ids, `<uipath:bindings>` `default`s) unresolved.
+
+**When a tenant IS connected, the exhaustive-discovery rule above and the
+`processType` selection below fully apply** — this includes a real greenfield
+first draft against a live tenant: discover and bind the actually-deployed
+processes, agents, and connections, and treat an empty result as the false
+negative described above. The distinction is whether a tenant is reachable, not
+whether the work is greenfield or brownfield.
 
 **A node's output mapping is enrichment too — do not resolve it while drafting.**
 When a downstream gateway or node reads a value a job / agent / activity
@@ -45,7 +50,8 @@ authoring job is to **declare that variable** (`BPMN.Variables`) and reference
 it in the condition or mapping. Leave the node's `<uipath:output>` → variable
 wiring — the exact output field path, `OutputArguments`, `result.*`, the job
 response shape — unresolved: it comes from the deployed resource's real output
-schema, which a greenfield pass does not have. Do not grep the references or
+schema, which an offline / no-tenant pass does not have (resolve it once a tenant
+is connected). Do not grep the references or
 registry templates trying to pin the output path before authoring; declare the
 variable, write the condition, and move on.
 
@@ -153,10 +159,12 @@ canvas treats the task as misconfigured. Use `StartAgentJob`/`StartJob` for
 folder-deployed resources.
 
 `processType` selection requires a deployed process to read, so it applies only
-when a tenant exists. With no tenant (a synthetic or greenfield pass), do not
+when a tenant is reachable — including a real greenfield draft against a live
+tenant, where you read `processType` and bind the deployed process. With no
+tenant reachable (offline authoring), do not
 page `uip or processes list` for a resource that is not deployed: default to
 `Orchestrator.StartAgentJob`, `registry get` its template, and author the node
-as a draft with the process binding unresolved (per the greenfield exception in
+as a draft with the process binding unresolved (per the no-tenant exception in
 §1).
 
 ## API workflow — wait vs fire-and-forget

--- a/skills/uipath-maestro-bpmn/references/registry-workflow.md
+++ b/skills/uipath-maestro-bpmn/references/registry-workflow.md
@@ -38,6 +38,17 @@ connection ids, `<uipath:bindings>` `default`s) unresolved. The exhaustive-
 discovery rules above, and the `processType` selection below, apply only once a
 real tenant with deployed resources is in play.
 
+**A node's output mapping is enrichment too — do not resolve it while drafting.**
+When a downstream gateway or node reads a value a job / agent / activity
+produces (`=vars.aiConfidence`, `=vars.routeCategory`, a batch summary), the
+authoring job is to **declare that variable** (`BPMN.Variables`) and reference
+it in the condition or mapping. Leave the node's `<uipath:output>` → variable
+wiring — the exact output field path, `OutputArguments`, `result.*`, the job
+response shape — unresolved: it comes from the deployed resource's real output
+schema, which a greenfield pass does not have. Do not grep the references or
+registry templates trying to pin the output path before authoring; declare the
+variable, write the condition, and move on.
+
 `registry list` returns three buckets in `Data`: `ExtensionTypes` (the OOTB
 extension types, always available), `Connectors` and `Processes` (only after
 `uip login`). Each extension-type row carries `ExtensionType`, `Label`,

--- a/skills/uipath-maestro-bpmn/references/registry-workflow.md
+++ b/skills/uipath-maestro-bpmn/references/registry-workflow.md
@@ -25,6 +25,19 @@ found via `registry search`, is a **false negative** — never conclude "no
 connection exists" or ask the user to create one until you have searched the
 registry for the real connector key and listed across all folders.
 
+**Greenfield / synthetic authoring is the exception — do not discover live
+instances that do not exist.** When the task is to author a local project with
+no tenant, no deployed resources, and no login (a synthetic or greenfield pass,
+which every offline eval and most first-draft authoring is), do NOT run `uip or
+processes list`, `uip is connections list`, or `uip login` looking for a live
+process, agent, or connection to bind: there are none, and their absence is
+expected, not a false negative. Instead: pick the extension type by intent,
+`registry get` its `xmlTemplate`, and author the node as a **draft** — paste the
+template and leave its binding placeholders (release keys, folder ids,
+connection ids, `<uipath:bindings>` `default`s) unresolved. The exhaustive-
+discovery rules above, and the `processType` selection below, apply only once a
+real tenant with deployed resources is in play.
+
 `registry list` returns three buckets in `Data`: `ExtensionTypes` (the OOTB
 extension types, always available), `Connectors` and `Processes` (only after
 `uip login`). Each extension-type row carries `ExtensionType`, `Label`,
@@ -127,6 +140,13 @@ Gotcha: `A2A.AgentExecution` renders as an external A2A node and **disables the
 Action dropdown** in Studio Web. Do not use it for a folder-deployed agent — the
 canvas treats the task as misconfigured. Use `StartAgentJob`/`StartJob` for
 folder-deployed resources.
+
+`processType` selection requires a deployed process to read, so it applies only
+when a tenant exists. With no tenant (a synthetic or greenfield pass), do not
+page `uip or processes list` for a resource that is not deployed: default to
+`Orchestrator.StartAgentJob`, `registry get` its template, and author the node
+as a draft with the process binding unresolved (per the greenfield exception in
+§1).
 
 ## API workflow — wait vs fire-and-forget
 


### PR DESCRIPTION
## Summary
Single-layer fix for the registry-hunt turn-waste that #3210 (merged), #3217, and #3225 each patched in their own pattern guide. Per @rockymadden's #3225 review: the instruction that sends the agent hunting lives in `registry-workflow.md`, so fix it there once.

## The shared root cause
Two rules in `registry-workflow.md` are correct for a real tenant and wrong for a greenfield/synthetic pass (every offline eval, most first-draft authoring):
- **§1** mandates exhaustive `uip is connections list --all-folders` / process discovery and labels an empty result a **false negative** — "never conclude no connection exists."
- **Agent wrapper selection** mandates `uip or processes list --all-fields` to pick `StartJob` vs `StartAgentJob` by `processType`.

With no tenant, the agent obeys these literally — paging `uip or processes`, listing connections, `uip login` — for resources that don't exist, burning its turn budget (the `smart-triage` MAX_TURNS, the `high-volume-batch` residual hunt, the `queue-distribution` hunt).

## Fix
One carve-out in each place:
- **§1:** greenfield/no-tenant exception — do not discover live instances that don't exist; `registry get` the template and author the node as a **draft** with binding placeholders unresolved. Absence is expected, not a false negative.
- **Wrapper selection:** with no `processType` to read, default to `Orchestrator.StartAgentJob` and author a draft — don't page `uip or processes`.

Uses the existing **draft** vocabulary (`registry-workflow.md:181-186`). Fixes `smart-triage`, `high-volume-batch`, and `queue-distribution` at the shared layer, so the per-guide patches (#3217, #3225) are superseded and closed.

## Verification (`claude`/`claude-sonnet-5`)
The carve-out covers two enrichment facets — input discovery and output mapping:

- **Input hunt eliminated:** a smart-triage run on the input-only carve-out did **0** `uip or` / `uip is connections` / `registry search` commands (was **16** in the failing nightly).
- **Output-mapping flail cut:** the input-only carve-out still timed out **0/2** — the agent flailed (~15 greps) resolving the agent-job `<uipath:output>`→variable wiring the check doesn't grade. After extending the carve-out to output mappings, smart-triage went to **2/3 SUCCESS** (1112s, 1704s; one timeout at 1803s), with lower passing durations.
- **No regression:** `queue-distribution` (merged) passes on this branch — SUCCESS, 919s.

**Residual:** smart-triage still flakes ~1/3 at the 1800s edge even with both hunt and output-flail removed — its shape is large (extract / classify / 2 gateways / HITL / 3 handlers / 3 ends / diagram / package metadata) and some runs simply don't finish authoring in time. That last gap is intrinsic weight, tracked in #3233 (decomposition / authoring-recipe). This PR removes the two enrichment causes at the shared layer — a large, verified improvement (0→2/3 on smart-triage; hunt eliminated for all patterns) — but does not by itself make the heaviest tasks 100% reliable.

## Not covered here (separate follow-ups)
- `high-volume-batch` `aggregate` must be a `BPMN.ScriptTask`, not a bare serviceTask, to set `policySatisfied` — a distinct guide-correctness bug (#3217 review). Filed separately.
- A CI guard that checks `Namespace.Type` / `uipath.*` tokens in `references/**.md` against `bpmn-spec.json` (Rocky's suggestion) — would catch false-absolutes at CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
