### PR TITLE
test(uipath-maestro-flow): accept the native Data Fabric node in the billing gates

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -564,10 +564,10 @@ def run_debug(
     return payload
 
 
-# Reading entity records has two supported node shapes and the tenant decides
-# which: the `uipath-uipath-dataservice` connector activity, or the native
-# `core.datafabric.read` node the skill prefers wherever `canvas.nodes.read-entity`
-# is on (#3041). Keep both — either alone fails a build the skill steers toward.
+# Two node shapes read entity records and tenant availability decides which:
+# the `uipath-uipath-dataservice` connector activity, or the native
+# `core.datafabric.read` node, the better build where `canvas.nodes.read-entity`
+# is on (#3041). Pass to `assert_flow_has_any_node_type`; keep both entries.
 ENTITY_QUERY_HINTS = ("uipath-dataservice.query", "core.datafabric.read")
 
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -564,6 +564,13 @@ def run_debug(
     return payload
 
 
+# Reading entity records has two supported node shapes and the tenant decides
+# which: the `uipath-uipath-dataservice` connector activity, or the native
+# `core.datafabric.read` node the skill prefers wherever `canvas.nodes.read-entity`
+# is on (#3041). Keep both — either alone fails a build the skill steers toward.
+ENTITY_QUERY_HINTS = ("uipath-dataservice.query", "core.datafabric.read")
+
+
 def assert_flow_has_node_type(
     hints: Sequence[str], *, project_glob: str = "**/project.uiproj"
 ) -> None:

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import flow_check  # noqa: E402
 from flow_check import (  # noqa: E402
+    ENTITY_QUERY_HINTS,
     assert_flow_has_any_node_type,
     assert_flow_has_api_node_targeting,
     assert_flow_has_exact_node_type,
@@ -181,6 +182,40 @@ def test_assert_flow_has_any_node_type_fails_when_none_present(tmp_path, monkeyp
 def test_assert_flow_has_any_node_type_empty_hints_is_noop(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)  # no project needed when hints are empty
     assert_flow_has_any_node_type([])
+
+
+# ── ENTITY_QUERY_HINTS (native Data Fabric node, 2026-09-10) ───────────────
+
+
+def test_entity_query_hints_accept_the_dataservice_connector(tmp_path, monkeypatch):
+    """The Integration Service activity remains acceptable wherever the native
+    tenant flag is off."""
+    root = _write_flow(
+        tmp_path, ["uipath.connector.uipath-uipath-dataservice.query-entity-records"]
+    )
+    monkeypatch.chdir(root)
+    assert_flow_has_any_node_type(ENTITY_QUERY_HINTS)
+
+
+def test_entity_query_hints_accept_the_native_node(tmp_path, monkeypatch):
+    """Regression lock for the 2026-09-10 billing failures: with
+    `canvas.nodes.read-entity` on, the skill steers the agent to the native node
+    (#3041), which the connector-only gate rejected before run_debug."""
+    root = _write_flow(tmp_path, ["core.datafabric.read"])
+    monkeypatch.chdir(root)
+    assert_flow_has_any_node_type(ENTITY_QUERY_HINTS)
+
+
+def test_entity_query_hints_reject_a_script_only_flow(tmp_path, monkeypatch):
+    """The anti-hardcode guard survives: a flow that queries nothing still fails,
+    and the message names both shapes."""
+    root = _write_flow(tmp_path, ["core.action.script"])
+    monkeypatch.chdir(root)
+    with pytest.raises(SystemExit) as exc:
+        assert_flow_has_any_node_type(ENTITY_QUERY_HINTS)
+    msg = str(exc.value)
+    assert "uipath-dataservice.query" in msg
+    assert "core.datafabric.read" in msg
 
 
 # ── assert_flow_has_api_node_targeting (slack-weather gate, PR #1301) ───────

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -218,6 +218,21 @@ def test_entity_query_hints_reject_a_script_only_flow(tmp_path, monkeypatch):
     assert "core.datafabric.read" in msg
 
 
+def test_billing_gates_use_the_shared_entity_hints():
+    """The tests above exercise the constant, not the call sites. Without this,
+    reverting either gate to the connector-only hint keeps the suite green and
+    silently restores the 2026-09-10 failure."""
+    suite = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    gates = (
+        "multi_node/billing_invoice_lookup/check_billing_invoice_lookup.py",
+        "multi_node/billing_discrepancy_detector/check_billing_discrepancy_detector.py",
+    )
+    for relative in gates:
+        with open(os.path.join(suite, relative), encoding="utf-8") as handle:
+            source = handle.read()
+        assert "assert_flow_has_any_node_type(ENTITY_QUERY_HINTS)" in source, relative
+
+
 # ── assert_flow_has_api_node_targeting (slack-weather gate, PR #1301) ───────
 
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/check_billing_discrepancy_detector.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/check_billing_discrepancy_detector.py
@@ -5,7 +5,7 @@ computed overcharge, discrepancy count, matched invoice, and account tier.
 
 Inputs map to ERP line 5 (Custom Integration Build): contracted amount 2590,
 disputed at 300*14 = 4200 -> overcharge 1610. CRM account ACCT-98201-NE is the
-Enterprise tier. A Data Service query node is required (anti-hardcode): 1610 and
+Enterprise tier. An entity query node is required (anti-hardcode): 1610 and
 "Enterprise" cannot be produced without querying ERP and CRM for real.
 """
 import os
@@ -18,6 +18,8 @@ while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared"
     _d = os.path.dirname(_d)
 sys.path.insert(0, _d)
 from _shared.flow_check import (  # noqa: E402
+    ENTITY_QUERY_HINTS,
+    assert_flow_has_any_node_type,
     assert_flow_has_node_type,
     assert_output_value,
     run_debug,
@@ -33,10 +35,11 @@ INPUTS = {
 
 
 def main():
-    # Must query Data Service (ERP + CRM) — blocks hardcoding 1610 / Enterprise.
+    # Must query the entities (ERP + CRM) — blocks hardcoding 1610 / Enterprise.
     # The two lookups are independent, so the flow must fan them out as parallel
     # branches joined by a merge (not chained serially) — require the merge node.
-    assert_flow_has_node_type(["uipath-dataservice.query", "core.logic.merge"])
+    assert_flow_has_any_node_type(ENTITY_QUERY_HINTS)
+    assert_flow_has_node_type(["core.logic.merge"])
 
     print(f"debug inputs: {INPUTS}")
     payload = run_debug(inputs=INPUTS, timeout=240)

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/check_billing_discrepancy_detector.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/check_billing_discrepancy_detector.py
@@ -35,7 +35,8 @@ INPUTS = {
 
 
 def main():
-    # Must query the entities (ERP + CRM) — blocks hardcoding 1610 / Enterprise.
+    # Must query an entity: blocks hardcoding 1610 / Enterprise. The ERP+CRM
+    # pair is graded by the structural advisory, not here.
     # The two lookups are independent, so the flow must fan them out as parallel
     # branches joined by a merge (not chained serially) — require the merge node.
     assert_flow_has_any_node_type(ENTITY_QUERY_HINTS)

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/check_billing_invoice_lookup.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/check_billing_invoice_lookup.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """BillingInvoiceLookup: the agent builds + validates only; this check runs
 `uip maestro flow debug` itself for three malformed invoice-number forms and
-asserts each resolves, via a real Data Service query, to invoice MCS-2026-04872
+asserts each resolves, via a real entity query, to invoice MCS-2026-04872
 with 8 line items.
 
 The flow normalizes a raw `invoiceNumber` (trim, uppercase, ensure the "MCS-"
-prefix) and queries the seeded `BillingDisputeERP` entity. A Data Service query
-node is required (anti-hardcode): you cannot fake `lineItemCount == 8` for three
+prefix) and queries the seeded `BillingDisputeERP` entity. An entity query node
+is required (anti-hardcode): you cannot fake `lineItemCount == 8` for three
 different inputs without actually querying. The seeded invoice has exactly 8
 line items, so the count is a deterministic oracle.
 """
@@ -20,7 +20,8 @@ while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared"
     _d = os.path.dirname(_d)
 sys.path.insert(0, _d)
 from _shared.flow_check import (  # noqa: E402
-    assert_flow_has_node_type,
+    ENTITY_QUERY_HINTS,
+    assert_flow_has_any_node_type,
     assert_output_value,
     find_project_dir,
     read_flow_input_vars,
@@ -39,9 +40,9 @@ CASES = [
 
 
 def main():
-    # Must actually query Data Service — blocks hardcoding the answer, which
+    # Must actually query the entity — blocks hardcoding the answer, which
     # would otherwise pass since all three cases expect the same output.
-    assert_flow_has_node_type(["uipath-dataservice.query"])
+    assert_flow_has_any_node_type(ENTITY_QUERY_HINTS)
 
     in_vars = read_flow_input_vars(find_project_dir())
     if not in_vars:


### PR DESCRIPTION
## What

Both DevCon billing e2es gate on the node-type substring `uipath-dataservice.query`:

```python
assert_flow_has_node_type(["uipath-dataservice.query"])                     # invoice lookup
assert_flow_has_node_type(["uipath-dataservice.query", "core.logic.merge"]) # discrepancy detector
```

A flow built with the native `core.datafabric.read` node fails that gate before `flow debug` ever runs. This adds one shared definition of "a node that reads entity records" and points both gates at it through the existing any-of matcher:

```python
ENTITY_QUERY_HINTS = ("uipath-dataservice.query", "core.datafabric.read")
```

The discrepancy detector's single call splits in two, because the all-of matcher cannot express "either entity shape, **and** a merge".

## Why

Since #3041 the skill calls the native node "the better build" wherever `canvas.nodes.read-entity` is on, and it is on in the eval tenant. From the 2026-09-10 run:

| Task | Score | Failure |
|---|---|---|
| `skill-flow-devcon-billing-invoice-lookup` | 0.273 | `No node matches type hint 'uipath-dataservice.query'` |
| `skill-flow-devcon-billing-discrepancy-detector` | 0.300 | same |

Both agents ran `registry get core.datafabric.read` (invoice cmd `[7]`, discrepancy cmd `[5]`), got it, built with it, and passed `uip maestro flow validate`.

The discrepancy detector also debugged its flow live, but with **its own chosen inputs** (line 1, price 1300, qty 1, returning overcharge 100), not the grader's (line 5, 300 × 14, expecting 1610). That shows the wiring resolves against tenant data. It is not evidence the graded oracle is met.

The agents did what the skill tells them to do, and the checkers failed them on a substring. `planning-arch.md:177` and `data-fabric/planning.md:58` both make availability the deciding factor, so pinning the gate to one shape means the path the skill actively steers toward is never gradeable.

## The anti-hardcode guard survives

Both checkers still gate on a query node so the answer cannot be faked in a Script node. A native read hits the tenant exactly as the connector does, so `lineItemCount == 8` across three malformed inputs, and overcharge 1610 with tier Enterprise, still require real queries. `test_entity_query_hints_reject_a_script_only_flow` locks that.

## Verification

```
uv run --with pytest python -m pytest tests/tasks/uipath-maestro-flow/ -q
1191 passed in 23.77s
```

Includes the corpus guards: `test_same_ground_corpus.py`, `test_criterion_budgets.py`, `test_same_ground_advisories.py`, `test_headless_preamble.py`.

Four new tests: the connector shape, the native shape, the script-only rejection, and a guard binding both checkers to the shared constant. That last one was verified to fail when a call site is reverted to the connector-only hint, which the other three do not catch.

The widening is provably safe in one direction: an any-of over `{old hint} ∪ {native}` is strictly more permissive than the old all-of over `[old hint]`, so no flow the old gate accepted can start failing.

## Known gap, handled separately

The three advisories on these tasks (`check_server_side_filter.py`, `check_bindings_no_stubs.py`, `advisory_billing_*.py`) still assume the connector shape and will keep reporting FAIL on a native build. They are report-only (`pass_threshold: 0`), so they do not gate status. Teaching them the native shape needs native reference flows, since `test_advisories_accept_repo_reference_flows` parametrizes each advisory against its `*.reference.flow` fixture. That is a separate PR.

Expected effect: both tasks go FAILURE to SUCCESS. Invoice lookup scores 8/11 = **0.727**, discrepancy detector 8/10 = **0.800**, until the advisories are updated. Cross-check: the observed failures were 3/11 = 0.273 and 3/10 = 0.300.

**Not verified:** the eval has not been rerun. `check_billing_invoice_lookup` then drives three debug runs and only one of those inputs has ever been exercised against a native build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
