### PR TITLE
test(uipath-maestro-flow): pin the two billing lookups to the Data Service connector

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
@@ -42,6 +42,19 @@ FORBIDDEN_PROMPT_EXCEPTIONS = {
 
 DEBUG_SOLUTION_ALLOWLIST = set()
 
+# The two billing lookups name only a "Data Service entity", which since #3041
+# denotes two node families. Their prompts pin the connector so the graded
+# structure is deterministic; the sibling dispute-resolution task pins it in the
+# same way. Native Data Fabric authoring is covered by its own task, not these.
+CONNECTOR_PINNED_LOOKUPS = {
+    "multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml",
+    "multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml",
+}
+CONNECTOR_PIN = (
+    "on the data service `query-entity-records` activity, "
+    "not the native data fabric nodes"
+)
+
 # F1 freezes the #2557 task even though its prompt predates the exact phrase.
 DEBUG_PROJECT_LAYOUT_EXCEPTIONS = {"single_node/coded_agent/coded_agent.yaml"}
 
@@ -190,6 +203,15 @@ def test_debug_graded_prompts_name_a_same_name_solution() -> None:
         if not re.search(r"\b(?:in|inside) a solution of the same name\b", prompt):
             offenders.add(relative)
     assert offenders == DEBUG_SOLUTION_ALLOWLIST | DEBUG_PROJECT_LAYOUT_EXCEPTIONS
+
+
+def test_billing_lookup_prompts_pin_the_data_service_connector() -> None:
+    offenders = {
+        relative
+        for relative in CONNECTOR_PINNED_LOOKUPS
+        if CONNECTOR_PIN not in " ".join(_prompt_text(_task_text(relative)).lower().split())
+    }
+    assert offenders == set()
 
 
 def test_external_graders_use_package_qualified_shared_imports() -> None:

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml
@@ -43,6 +43,10 @@ initial_prompt: |
     `matchedInvoiceNumber` (string, first ERP row), `accountTier` (string, from
     CRM).
 
+  Build both lookups on the Data Service `query-entity-records` activity, not
+  the native Data Fabric nodes: the tenants this ships to do not all enable
+  them.
+
   Validate the final flow file — the task is not complete until `uip maestro
   flow validate` passes. Grading then runs the flow under debug against live
   tenant data, so build it to actually run, not merely validate.

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
@@ -31,6 +31,10 @@ initial_prompt: |
   - Outputs: `matchedInvoiceNumber` (string, first matched row's invoiceNumber)
     and `lineItemCount` (number of rows returned).
 
+  Build the lookup on the Data Service `query-entity-records` activity, not
+  the native Data Fabric nodes: the tenants this ships to do not all enable
+  them.
+
   Validate the final flow file — the task is not complete until `uip maestro
   flow validate` passes. Grading then runs the flow under debug against live
   tenant data, so build it to actually run, not merely validate.


### PR DESCRIPTION
Follow-up to #3231, which widened the *hard gates* to accept either entity node shape. This pins which shape the *task* asks for, so the graded structure is deterministic. Together they are the two halves of the same decision: a skill-conformant build is never failed outright, and the task still states what it exercises.

## What

One sentence in each of the two billing lookup prompts:

> Build the lookup on the Data Service `query-entity-records` activity, not the native Data Fabric nodes: the tenants this ships to do not all enable them.

Plus a guard test beside the existing per-task prompt guards in `test_same_ground_corpus.py`.

## Why

Both prompts say only "Data Service entity". Since #3041 that phrase denotes two node families, and the eval tenant has `canvas.nodes.read-entity` on. On 2026-09-10 both agents read the entity name, found the native node available, and built it. Both structural advisories then reported FAIL against a connector-shaped contract.

The builds were defensible. The prompts were ambiguous.

**The third task in this family never drifted, and it is the one that already pins.** `billing_dispute_resolution` says *"two Data Service query-entity-records nodes"* in its prompt. The two that failed are exactly the two that name only the entity. This PR brings them to the same standard rather than inventing one.

**The stated reason is real, not a checker hint.** All four `canvas.nodes.*-entity` flags default to off (`data-fabric/planning.md:58`), so the connector is the path that works on every target tenant. An agent reading it learns something true about deployment, not something about the grader.

## Why pin rather than teach the advisories both shapes

Considered and rejected, because the two conflict:

- **Assertion 7 has no native analogue.** Both advisories check the query node resolves to a connection/folder pair of distinct uuids, a check that exists because of a measured 401 where a FolderKey entry carried the connection id. A native node has no connection, no folder key, and for a tenant-scoped entity no bindings row. `BillingDisputeERP` is tenant-scoped.
- **Part of the filter assertion is connector-only by construction.** `queryExpression` must be single-quoted CEQL because the `sql-where` grammar 400s otherwise. Native `_filters.rows` never compiles to CEQL.
- **It would delete the drift signal.** With the prompt pinned, an advisory FAIL on a native build is the correct report. Teaching the advisory to accept native removes the very signal the pin creates.

Native authoring deserves grading, and it will get its own task rather than sharing one with a connector contract.

## Verification

```
uv run --with pytest python -m pytest tests/tasks/uipath-maestro-flow/ -q
1192 passed in 22.70s
```

Baseline on `main` (`84a6a3b7e`) is 1191; the new guard is the difference.

Checked against the corpus contract in `test_same_ground_corpus.py`:

- `test_forbidden_prompt_phrases_match_the_temporary_allowlist` — the regex is `do not [^.]*\bdebug\b`. The added sentence contains "do not all enable them." with no `debug` before the sentence end, and no UUID. Passes.
- `test_debug_graded_prompts_name_a_same_name_solution` — untouched, both prompts still name a same-name solution.
- `test_headless_preamble.py` — the canonical preamble is byte-identical; the sentence lands above it.

## Note for review

These are same-ground prompts. Prompt edits in this corpus have historically landed uniformly (#3088 touched 121 files, #2756 touched 188), so a two-file prompt change wants a second opinion from the campaign owner. @tmatup — flagging for that reason; the scope is the two tasks whose prompts are ambiguous about a distinction that did not exist when they were written.

## Follow-ups, not in this PR

- The advisories' failure message still reads `expected exactly ONE Data Service connector node, found 0`. With the pin in place it should name the pin instead. Small, separate.
- A native `core.datafabric.*` authoring task. #3041 shipped four node types with no eval coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
