### PR TITLE
fix(case): name the third column of the SDD's Task envelope table

### DIFF
--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -184,7 +184,7 @@ Preserve each explicit `selected-tasks-completed` row and selector only after co
 
 **Pass `lane: <n>` on every task** only when required by the artifact contract. Default: increment per task within a stage starting at 0; lane is a `data.tasks` task-set index. A strict sequential chain is represented as consecutive single-task sets (`[[A], [B], [C]]`) plus `runs-sequentially` on each task. Reuse the same lane only for intentionally parallel siblings, including stage-start siblings (`[[A, B], [C]]`) and siblings after a predecessor (`[[A], [B, C], [D]]`). Sequencing comes from the task's `entryConditions` and the order of task sets in `data.tasks`, not from lane-sharing alone.
 
-**Task envelope fields.** Write `isRequired` and `shouldRunOnlyOnce` from the SDD's **Task envelope** table (`Required` / `Run Only Once`). If `runOnlyOnce` is omitted, default `shouldRunOnlyOnce` to `false` to match frontend new-task behavior. Do not infer `true` from task type; re-entry semantics from the SDD are the source of truth.
+**Task envelope fields.** Write `isRequired`, `shouldRunOnlyOnce` and `skipCondition` from the SDD's **Task envelope** table (`Required` / `Run Only Once` / `Skip Condition`), which some SDDs write as rows of a vertical `| Field | Value |` table instead. If `runOnlyOnce` is omitted, default `shouldRunOnlyOnce` to `false` to match frontend new-task behavior. Do not infer `true` from task type; re-entry semantics from the SDD are the source of truth.
 
 ### Step 9.1 — Placeholder tasks for unresolved resources
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
@@ -12,6 +12,7 @@
   "elementId": "Stage_aB3kL9-ty5UcykfU",
   "isRequired": true,
   "shouldRunOnlyOnce": false,
+  "skipCondition": "=js:vars.skipReview === true",
   "data": {
     "taskTitle": "Please review this PO and approve or reject",
     "priority": "High",
@@ -26,7 +27,7 @@
 ```
 
 - `id`: `t` + 8 alphanumeric chars. `elementId`: `${stageId}-${taskId}`.
-- `isRequired` and `shouldRunOnlyOnce` come from the SDD task envelope; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from task type.
+- `isRequired`, `shouldRunOnlyOnce` and `skipCondition` come from the SDD task envelope's three columns; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from task type.
 - `data.name` / `data.folderPath` MUST be `=bindings.<id>` references — never literals.
 
 ## Action-Specific Fields

--- a/skills/uipath-maestro-case/references/plugins/tasks/agent/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/agent/impl-json.md
@@ -12,6 +12,7 @@
   "elementId": "Stage_aB3kL9-tH3kLmNp9",
   "isRequired": true,
   "shouldRunOnlyOnce": false,
+  "skipCondition": "=js:vars.skipReview === true",
   "data": {
     "name": "=bindings.bG0SraLpg",
     "folderPath": "=bindings.bH1iJK2lm",
@@ -22,7 +23,7 @@
 ```
 
 - `id`: `t` + 8 alphanumeric chars. `elementId`: `${stageId}-${taskId}`.
-- `isRequired` and `shouldRunOnlyOnce` come from the SDD task envelope; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from task type.
+- `isRequired`, `shouldRunOnlyOnce` and `skipCondition` come from the SDD task envelope's three columns; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from task type.
 - `data.name` / `data.folderPath` MUST be `=bindings.<id>` references — never literals.
 
 ## Procedure

--- a/skills/uipath-maestro-case/references/plugins/tasks/api-workflow/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/api-workflow/impl-json.md
@@ -12,6 +12,7 @@
   "elementId": "Stage_aB3kL9-tK7nRs3Wp",
   "isRequired": true,
   "shouldRunOnlyOnce": false,
+  "skipCondition": "=js:vars.skipReview === true",
   "data": {
     "name": "=bindings.bG0SraLpg",
     "folderPath": "=bindings.bH1iJK2lm",
@@ -22,7 +23,7 @@
 ```
 
 - `id`: `t` + 8 alphanumeric chars. `elementId`: `${stageId}-${taskId}`.
-- `isRequired` and `shouldRunOnlyOnce` come from the SDD task envelope; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from task type.
+- `isRequired`, `shouldRunOnlyOnce` and `skipCondition` come from the SDD task envelope's three columns; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from task type.
 - `data.name` / `data.folderPath` MUST be `=bindings.<id>` references — never literals.
 
 ## Procedure

--- a/skills/uipath-maestro-case/references/plugins/tasks/case-management/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/case-management/impl-json.md
@@ -12,6 +12,7 @@
   "elementId": "Stage_aB3kL9-tZ8rMn4Vp",
   "isRequired": true,
   "shouldRunOnlyOnce": false,
+  "skipCondition": "=js:vars.skipReview === true",
   "data": {
     "name": "=bindings.bG0SraLpg",
     "folderPath": "=bindings.bH1iJK2lm",
@@ -22,7 +23,7 @@
 ```
 
 - `id`: `t` + 8 alphanumeric chars. `elementId`: `${stageId}-${taskId}`.
-- `isRequired` and `shouldRunOnlyOnce` come from the SDD task envelope; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from task type.
+- `isRequired`, `shouldRunOnlyOnce` and `skipCondition` come from the SDD task envelope's three columns; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from task type.
 - `data.name` / `data.folderPath` MUST be `=bindings.<id>` references — never literals.
 
 ## Procedure

--- a/skills/uipath-maestro-case/references/plugins/tasks/process/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/process/impl-json.md
@@ -12,6 +12,7 @@
   "elementId": "Stage_aB3kL9-t8GQTYo8O",
   "isRequired": true,
   "shouldRunOnlyOnce": false,
+  "skipCondition": "=js:vars.skipReview === true",
   "data": {
     "name": "=bindings.bG0SraLpg",
     "folderPath": "=bindings.bH1iJK2lm",
@@ -22,7 +23,7 @@
 ```
 
 - `id`: `t` + 8 alphanumeric chars. `elementId`: `${stageId}-${taskId}`.
-- `isRequired` and `shouldRunOnlyOnce` come from the SDD task envelope; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from task type.
+- `isRequired`, `shouldRunOnlyOnce` and `skipCondition` come from the SDD task envelope's three columns; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from task type.
 - `data.name` / `data.folderPath` MUST be `=bindings.<id>` references — never literals.
 
 ## Procedure

--- a/skills/uipath-maestro-case/references/plugins/tasks/rpa/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/rpa/impl-json.md
@@ -12,6 +12,7 @@
   "elementId": "Stage_aB3kL9-tQ2pVx7Lm",
   "isRequired": true,
   "shouldRunOnlyOnce": false,
+  "skipCondition": "=js:vars.skipReview === true",
   "data": {
     "name": "=bindings.bG0SraLpg",
     "folderPath": "=bindings.bH1iJK2lm",
@@ -22,7 +23,7 @@
 ```
 
 - `id`: `t` + 8 alphanumeric chars. `elementId`: `${stageId}-${taskId}`.
-- `isRequired` and `shouldRunOnlyOnce` come from the SDD task envelope; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from task type.
+- `isRequired`, `shouldRunOnlyOnce` and `skipCondition` come from the SDD task envelope's three columns; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from task type.
 - `data.name` / `data.folderPath` MUST be `=bindings.<id>` references — never literals.
 - **Do not flip to `type: "process"`** based on registry. The `rpa` vs `process` distinction comes from sdd.md intent.
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/wait-for-timer/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/wait-for-timer/impl-json.md
@@ -24,7 +24,7 @@ Write the timer task directly to `caseplan.json`. No CLI command needed.
 }
 ```
 
-> **Envelope source.** `isRequired` and `shouldRunOnlyOnce` come from the SDD task envelope; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from timer task type.
+> **Envelope source.** `isRequired`, `shouldRunOnlyOnce` and `skipCondition` come from the SDD task envelope's three columns; default `shouldRunOnlyOnce` to `false` when omitted. Do not infer run-once from timer task type.
 > **`data` holds ONLY `timerType` + the duration field.** `skipCondition` and all other envelope fields are top-level siblings of `data`, never nested inside it (a misplaced one passes `validate` silently but is never applied). See [case-schema.md](../../../case-schema.md) §7 Tasks — BaseTask shape.
 
 ## Procedure


### PR DESCRIPTION
## The problem

Eight places in this skill tell the build to read the SDD's **Task envelope** table, and every one of them names two of its three columns. The third is `Skip Condition`, and it maps to the caseplan's `skipCondition`. The phrase does not appear anywhere in the skill.

The field itself is documented, in [`case-schema.md:473`](https://github.com/UiPath/skills/blob/84a6a3b7e3a50e2cecf125ee6fc96ddf165b8106/skills/uipath-maestro-case/references/case-schema.md#L473) and in the timer plugin's JSON shape. Nothing connects the SDD column to the key.

Naming two of three reads as a complete list, which is worse than saying nothing: the reader has no reason to look for a fourth cell it was not told about.

## Which run

[33987705899](https://github.com/UiPath/skills/actions/runs/33987705899), 2026-09-05, scored 0.94. `uip maestro case validate` returned `Valid` and the task's guard check rejected the plan, reporting that the 500000 sign-off threshold appears in no guard and lives only inside the workflow that computes the tier, so the case cannot enforce it.

That SDD gives `Obtain procurement director sign-off` the skip condition `=js:vars.expectedAnnualSpend < 500000`. Of its 32 Task envelope tables it is the only one with the column filled.

**The build had the requirement and no place to put it.** Across 748 turns and 442 tool calls, the SDD's `Skip Condition` heading enters the context 32 times and the expression's own variable 58 times, while the caseplan key name `skipCondition` enters 0 times. It read `action/impl-json.md` and `implementation.md` in full, one call each, with no offset: whatever those two files say about the envelope was in front of it.

## What it costs

The plan's entry guard on that task is correct and fully wired: `selected-tasks-completed` on `Determine sign-off tier`, expression `=js:vars.directorSignOffRequired === true`. The director is still gated, so this is not a task that opens on every application.

What is lost is the second gate the SDD asks for in its own Design Rationale: the director task's own skip condition carrying the 500000 numeral executably, so the policy is enforced case-side and not only inside the workflow. Without it, a deployed workflow returning the wrong flag reaches the director with nothing case-side to stop it.

The engine evaluates the field in `PreExecutionPhaseHandler`: when the element is reached and the expression is truthy it records `NotExecuted` and continues the outgoing flows. A missing or whitespace value means the element executes normally.

## What changed

Eight files, 14 added lines.

`implementation.md` carries the mapping: the envelope table has three columns, the third is `Skip Condition`, an expression in that cell becomes the key and a dash means omit it, and some SDDs write the same three fields as rows of a vertical Field and Value table rather than one row of a horizontal one. Both shapes occur in the artifacts on hand.

The seven task plugins carry the key rather than the column heading. Each one's envelope bullet now reads `isRequired`, `shouldRunOnlyOnce` and `skipCondition` from the table's three columns, and six of them gain the key in their JSON shape block; the timer plugin already had it there.

The placement rule, top-level beside `data` rather than inside it, stays where it already is in `case-schema.md` with its WRONG and RIGHT pair, rather than being restated in seven plugin files.

## Verification

**Mechanism, against the run's own artifact and its own grader.** `check_guards.py` at that run's commit, on that run's caseplan: exit 1 with the threshold finding, `guards: 18`. Putting the key back on the same plan: exit 0, `guards: 19`, and the criterion reports the threshold as enforced case-side.

**Corpus.** Every local caseplan paired with the `sdd.md` it was built from, 286 pairs. Of the skip conditions an SDD declares on a task the plan created, 38, the plan carries 26 and drops 12. No plan carries a skip condition its SDD does not declare.

**Repo checks.** `npm run skills:validate` reports OK for both flavors: default 27 skills and 1768 files, studioweb 27 skills, 1768 files and 264 replacements. The edited passage in `implementation.md` sits outside all 14 of that file's flavor blocks, so studioweb inherits it, and the seven plugin files carry no flavor marker and no override.

**The wording carries the repair, not the guarantee.** Nine codex rounds across three versions of this sentence wrote the key zero times, with the wording and the JSON shape block both in context. [UiPath/cli#4167](https://github.com/UiPath/cli/pull/4167) is what reports a dropped cell: `STRICT_SDD_SKIP_CONDITION_MISSING` under `--sdd`, which fires on this run's own caseplan and on 12 plans across the corpus.
