### PR TITLE
chore: refresh uip CLI catalog (1.203.0-dev.8632)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-09-10T04:08:50Z",
-  "cli_version": "1.203.0-dev.8609",
+  "generated_at": "2026-09-11T04:06:55Z",
+  "cli_version": "1.203.0-dev.8632",
   "verbs": [
     "admin",
     "admin audit",
@@ -780,6 +780,8 @@
     "maestro bpmn update-metadata",
     "maestro bpmn validate",
     "maestro case",
+    "maestro case bindings",
+    "maestro case bindings sync",
     "maestro case case-exit-conditions",
     "maestro case case-exit-conditions get",
     "maestro case cases",
@@ -790,6 +792,7 @@
     "maestro case decompile",
     "maestro case edges",
     "maestro case edges get",
+    "maestro case format",
     "maestro case incident",
     "maestro case incident get",
     "maestro case incident summary",
@@ -1081,6 +1084,7 @@
     "or machines unassign",
     "or machines update",
     "or packages",
+    "or packages delete",
     "or packages download",
     "or packages entry-points",
     "or packages get",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.203.0-dev.8632`. The catalog has 1574 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.