### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@62c5a99

### DIFF
--- a/preview/skills/uipath-maestro-bpmn/SKILL.md
+++ b/preview/skills/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ a82b640. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 62c5a99. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/skills/uipath-maestro-case/SKILL.md
+++ b/preview/skills/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ a82b640. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 62c5a99. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,
@@ -21,7 +21,7 @@ Use this as a router: read only the capability reference you need, then let Type
 
 ## Workflow
 
-1. Scaffold with `uip solution init <SolutionName>`, then run `uip maestro case init <CaseName>` inside it. Scaffold once: exactly one `project.uiproj` declaring `ProjectType: "CaseManagement"` may survive, because `uip solution projects import` copies rather than moves and validators cannot choose between duplicates. If a bare `<CaseName>/` project already exists outside the solution, import it and delete the original rather than leaving both.
+1. Scaffold once, running `case init` **from inside the solution dir**: `uip solution init <SolutionName> && cd <SolutionName> && uip maestro case init <CaseName>`. It walks UP for the enclosing `.uipx`; run from anywhere else it finds none, silently creates a SECOND solution `<CaseName>Solution/`, registers the project there, and leaves the first empty with two `project.uiproj` on disk — so check the reply carries no `Data.AutoCreatedSolution`. Exactly one `project.uiproj` declaring `ProjectType: "CaseManagement"` may survive, because `uip solution projects import` copies rather than moves and validators cannot choose between duplicates; if a bare `<CaseName>/` project already exists outside the solution, import it and delete the original rather than leaving both.
 2. Keep `<Name>.case.ts` beside this `SKILL.md` and the workspace `package.json`.
 3. If the request requires `tasks/tasks.md`, write it before code and treat explicit stage/task rules, required flags, routing, and unresolved resources as authoritative and pre-approved.
 4. Import from `@uipath/maestro-builder-sdk/case`; default-export a chain ending in `.build()`.

--- a/preview/skills/uipath-maestro-case/references/api.md
+++ b/preview/skills/uipath-maestro-case/references/api.md
@@ -214,7 +214,13 @@ declare class StageBuilder {
     description(text: string): this;
     /** Mark this stage required, so the case cannot complete without it. */
     required(value?: boolean): this;
-    /** Add a task. `fn` receives a task sub-builder. `lane` selects a parallel lane (default 0). */
+    /**
+     * Add a task. `fn` receives a task sub-builder. `lane` is the index of the
+     * task's SET in `data.tasks[][]` (default 0) and orders SEQUENTIAL sets — a
+     * task whose entry conditions are all `runs-sequentially` waits for the
+     * previous set. It does NOT make tasks parallel: every other task runs when
+     * its own entry condition fires, whatever set it sits in.
+     */
     task(displayName: string, fn: (t: TaskBuilder) => void, opts?: {
             lane?: number;
         }): this;
@@ -586,6 +592,14 @@ export interface SlaOpts {
 ````ts
 /** Options common to a stage/task entry condition. */
 export interface EntryOpts {
+    /**
+     * Names the condition. Omit it and the name is derived from the owner —
+     * `"<stage> entry"` / `"<task> entry"` — because `uip maestro case validate`
+     * requires condition names to be unique across the whole case and rejects a
+     * repeat as `CASE_MGMT_RULE_NAME_DUPLICATE`, at error severity. A name given
+     * here is emitted verbatim; duplicating one is reported by `case check` as
+     * `DUP_RULE_NAME`.
+     */
     displayName?: string;
     isInterrupting?: boolean;
 }
@@ -596,6 +610,12 @@ export interface EntryOpts {
 ````ts
 /** Options for `stage.exitWhen(rules, opts)` — one call per outcome. */
 export interface ExitOpts {
+    /**
+     * Names the condition. Omit it and the name is derived from the owner —
+     * `"<stage> complete"`, or `"<stage> exit"` when this exit does not mark the
+     * stage complete. See `EntryOpts.displayName` for why the default is
+     * derived rather than constant.
+     */
     displayName?: string;
     /** Mark the stage complete on this exit. Every stage needs at least one. */
     marksStageComplete?: boolean;

--- a/preview/skills/uipath-maestro-flow/SKILL.md
+++ b/preview/skills/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ a82b640. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 62c5a99. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -22,26 +22,42 @@ An existing Flow JSON can also be decompiled back into TypeScript for editing.
 ## Project layout
 
 The workspace installs `@uipath/maestro-builder-sdk` in `node_modules/`; `examples/` contains authored examples, and `references/` contains the details routed from this guide.
-To author a Flow, create a root-level `<Name>.flow.ts` and import the package directly.
+A Flow is authored as a root-level `<Name>.flow.ts` that imports the package directly.
 
-**The source lives at the root; the compiled artifact does not.** Scaffold the project
-before authoring, then emit into it — `compile -o` is the authority over where the
-emitted file is written. `<Solution>` and `<Name>` are the request's own names, used
-verbatim: a request that gives one name for both ("inside a solution of the same
-name") uses it for both, and a request that names only the Flow uses `<Name>` for both.
+**The source lives at the root; the compiled artifact does not.**
+Scaffold the project first, seed the source from it, then emit back into it — `compile -o` is the authority over where the emitted file is written.
+`<Solution>` and `<Name>` are the request's own names, used verbatim: a request that gives one name for both ("inside a solution of the same name") uses it for both, and a request that names only the Flow uses `<Name>` for both.
 
 ```bash
 uip solution init <Solution>
 ( cd <Solution> && uip maestro flow init <Name> )
+uip maestro flow decompile <Solution>/<Name>/<Name>.flow -o <Name>.flow.ts --no-pipeline
+# edit <Name>.flow.ts
 uip maestro flow compile <Name>.flow.ts -o <Solution>/<Name>/<Name>.flow
 ```
 
-Exactly one emitted `<Name>.flow` may exist, at that path. Never leave a second copy
-at the workspace root, and never leave behind the trigger-only stub `flow init` writes —
-validators and evidence collectors cannot choose safely between duplicates, and an
-abandoned stub outranks the real work. Emitting to the root is correct only for the
-packaged-SDK local gates, which never scaffold a project; pick the loop first
-([`references/CLI-LOOP.md`](references/CLI-LOOP.md)) and do not mix the two.
+Do not hand-write the skeleton.
+Decompiling the trigger-only artifact `flow init` writes produces exactly that skeleton, and it carries the flow id and name the product already assigned — a hand-written `flow('<name>')` invents an id instead.
+So the stub is the seed rather than litter: the first `compile -o` overwrites it in place.
+`--no-pipeline` keeps the greenfield seed to one file; `<Name>.pipeline.mjs` is the brownfield read/modify/write helper ([`references/brownfield.md`](references/brownfield.md)) and is noise here.
+
+An existing project needs no `init`: skip the first two commands and seed from the `.flow` that is already there.
+Exactly one emitted `<Name>.flow` may exist, at that path, and never a second copy at the workspace root — validators and evidence collectors cannot choose safely between duplicates.
+Emitting to the root is correct only for the packaged-SDK local gates, which never scaffold a project; pick the loop first ([`references/CLI-LOOP.md`](references/CLI-LOOP.md)) and do not mix the two.
+
+### Installing the package into a bare workspace
+
+Skip this when `node_modules/@uipath/maestro-builder-sdk` is already present, as it is in a prepared workspace.
+Every `uip maestro flow` authoring verb — `check`, `compile`, `decompile` — runs from the installed package, so all of them refuse until it is installed; the package cannot bootstrap itself.
+One install does the whole bootstrap, writing `package.json` itself when the directory has none:
+
+```bash
+npm install --save-dev @uipath/maestro-builder-sdk
+```
+
+It resolves the `@uipath` scope through GitHub Packages, so `.npmrc` must route the scope and carry a `read:packages` token before it can succeed.
+npm records the dependency in the nearest `package.json` up the directory tree, installing `node_modules/` beside that file rather than in the current directory — so when an unrelated ancestor owns one, claim the intended root first with `[ -f package.json ] || npm init -y`.
+On a `package.json` npm generated itself, `npm pkg set type=module` silences the `MODULE_TYPELESS_PACKAGE_JSON` warning every compile otherwise prints; leave an existing project's `type` alone.
 
 Integrations with non-UiPath systems are handled through connectors.
 Connectors require a root-level [`bindings.json`](references/bindings.md).
@@ -61,9 +77,10 @@ lookup token with no recorded value, `CONNECTOR_INPUT` for a field the
 operation does not declare. Run that one
 `npx flow-sdk registry prepare <connector-key> <action>` — `--object`,
 `--resolve` and `-f` compose in a single invocation, it finds the connection
-itself and writes `bindings.json` — switch the import to the generated
-`connectors-local/<key>.ts` descriptor where it printed one, and re-run
-`check`, then compile.
+itself, writes `bindings.json`, and repoints your import at the generated
+`connectors-local/<key>.ts` descriptor — then re-run `check` and compile.
+Where two flows import the same connector it names them instead of guessing,
+and asks for `--source`.
 
 The gate this replaces still holds for schema-dynamic operations
 (`loadByDefault`, dependent dropdowns, `customFieldsRequestDetails`): the
@@ -186,9 +203,9 @@ under `examples/` resolve inside this skill folder.
 | Filter | `core.action.transform.filter` | `transform({ variant: 'filter', ... })` | [Transform](#transform) | [transform.md](references/transform.md) | `examples/TrailLogSummary.flow.ts` |
 | Map | `core.action.transform.map` | `transform({ variant: 'map', ... })` | [Transform](#transform) | [transform.md](references/transform.md) | `examples/TrailLogSummary.flow.ts` |
 | Group by | `core.action.transform.group-by` | `transform({ variant: 'group-by', ... })` | [Transform](#transform) | [transform.md](references/transform.md) | `examples/TrailLogSummary.flow.ts` |
-| Integration Service action | `uipath.connector.<key>.<action>` (Data Fabric / Data Service entity ops — create, delete, get-by-id, query-many: `uipath.connector.uipath-uipath-dataservice.*`) | `connector(...)` | [Integration Service connectors](#integration-service-connectors) | [connector-params.md](references/connector-params.md) | `examples/ClubDirectory.flow.ts` |
-| Data Fabric read | `core.datafabric.read` | `dataFabricRead(...)` | [Data Fabric](#data-fabric) | [data-fabric.md](references/data-fabric.md) | `examples/BeeHiveLedger.flow.ts` |
-| Data Fabric update | `core.datafabric.update` | `dataFabricUpdate(...)` | [Data Fabric](#data-fabric) | [data-fabric.md](references/data-fabric.md) | `examples/BeeHiveLedger.flow.ts` |
+| Integration Service action | `uipath.connector.<key>.<action>` (Data Fabric / Data Service — **every** entity op: create, get-by-id, query, update, delete, file fields, events: `uipath.connector.uipath-uipath-dataservice.*`) | `connector(...)` | [Integration Service connectors](#integration-service-connectors) | [connector-params.md](references/connector-params.md) | `examples/ClubDirectory.flow.ts` |
+| Data Fabric read | `core.datafabric.read` (transitional — prefer the connector row above unless the scenario names this node) | `dataFabricRead(...)` | [Data Fabric](#data-fabric) | [data-fabric.md](references/data-fabric.md) | `examples/BeeHiveLedger.flow.ts` |
+| Data Fabric update | `core.datafabric.update` (transitional — prefer the connector row above unless the scenario names this node) | `dataFabricUpdate(...)` | [Data Fabric](#data-fabric) | [data-fabric.md](references/data-fabric.md) | `examples/BeeHiveLedger.flow.ts` |
 | Subflow | `core.subflow` | `subflow(...)` | [Subflow](#subflow) | [subflow.md](references/subflow.md) | `examples/RecipeScaler.flow.ts` |
 | Human task | `uipath.human-in-the-loop` | `hitl(...)` | [Human task](#human-task) | [hitl.md](references/hitl.md) | `examples/GallerySubmission.flow.ts` |
 | Human quick form | `uipath.human-in-the-loop.quick-form` | `hitl({ variant: 'quick-form', ... })` | [Human task](#human-task) | [hitl.md](references/hitl.md) | `examples/FieldTripQuickForm.flow.ts` |
@@ -561,29 +578,25 @@ Check tenant uniqueness/schema settings; wait only when a consumer exists and it
 
 ## Data Fabric
 
-**Route on the VERB, not the name in the prompt.** "Data Fabric" and "Data
-Service" are one product (key `uipath-uipath-dataservice` shows as *UiPath Data Fabric*).
-`core.datafabric.*` has two verbs and no output schema: `dataFabricRead({ entity, filters? })`
-and `dataFabricUpdate({ entity, record, set })` (`record` is one of `{ byId }` /
-`{ fromRead: '<read step>' }`). **Create, delete, get-by-id, query-many with a row
-limit, file fields, declared outputs and events are
-`connector('uipath-uipath-dataservice', …)`** even when the scenario says "Data
-Fabric" — `registry prepare … -f entityName=<Entity>` first.
+**One product, one surface — the connector.** "Data Fabric" and "Data Service" are one product (key `uipath-uipath-dataservice` shows as *UiPath Data Fabric*).
+**Every entity operation is `connector('uipath-uipath-dataservice', …)`** — create, get-by-id, query, update, delete, file fields, Record Created/Updated events — even when the scenario says "Data Fabric".
+Body fields come from the entity, so `compile` refuses them until `registry prepare … -f entityName=<Entity>` resolves the schema once.
 
 ```ts
-.step('lookup', dataFabricRead({ entity: 'Invoices',
-  filters: [{ field: 'InvoiceId', value: input('invoiceId') }] }))
-.step('markPaid', dataFabricUpdate({ entity: 'Invoices',
-  record: { fromRead: 'lookup' }, set: { Status: 'Paid' } }))
+.step('listInvoices', connector('uipath-uipath-dataservice', 'query-entity-records',
+  { entityName: 'Invoices', queryExpression: tmpl`Amount gt ${input('min')}`, limit: 20 },
+  { connection: 'dataservice', folder: 'shared' }))
 ```
 
-Filters default to `=`; `or: true` joins with OR. **Reference: [`references/data-fabric.md`](references/data-fabric.md)**
+`core.datafabric.*` compiles (`dataFabricRead`, `dataFabricUpdate`) but covers only 2 of those 7 verbs and declares no output schema, so it strands the rest of the flow on the connector: two bindings, two payload shapes, one entity.
+**Do not reach for the native nodes unless the scenario names them** — a routing default, not a rule; `examples/BeeHiveLedger.flow.ts` shows that native pair.
+**Reference: [`references/data-fabric.md`](references/data-fabric.md)**
 
 ## Error handling
 
 Route the immediately preceding action's failure through a handler path.
 
-Signature: `.step(name, action).onError(handler => ... )`; handler may use `err(step, field)` and `stepToRef(target)`. `.stepToList(port, fn)` runs a path from any port; `.stepToRef(port, target)` is a side exit that leaves the success path running.
+Signature: `.step(name, action).onError(handler => ... )`; the handler reads the failure with `h.err(field)` (or `err(step, field)`) and may `stepToRef(target)`. `.stepToList(port, fn)` runs a path from any port; `.stepToRef(port, target)` is a side exit that leaves the success path running. Never read the failed step's `out(...)` inside its own handler — that output was never written.
 
 ```ts
 .step('fetch', http({ url, managed: true }))
@@ -813,8 +826,8 @@ Signatures: `connector(descriptor, inputs, opts?)`;
   { connection: 'jira', folder: 'shared' }))
 ```
 
-Data Fabric is key `uipath-uipath-dataservice`: every entity operation but
-read-one/update-one lives here ([Data Fabric](#data-fabric)). Discover tenant-specific fields and ids; preserve every scenario-named input.
+Data Fabric is key `uipath-uipath-dataservice`: every entity operation lives
+here ([Data Fabric](#data-fabric)). Discover tenant-specific fields and ids; preserve every scenario-named input.
 
 **Reference: [`references/connector-params.md`](references/connector-params.md)**
 

--- a/preview/skills/uipath-maestro-flow/references/CLI-LOOP.md
+++ b/preview/skills/uipath-maestro-flow/references/CLI-LOOP.md
@@ -68,7 +68,11 @@ scaffold once:
 ```bash
 uip solution init <Solution>
 ( cd <Solution> && uip maestro flow init <Name> )
+uip maestro flow decompile <Solution>/<Name>/<Name>.flow -o <Name>.flow.ts --no-pipeline
 ```
+
+That third command seeds the authored source from the stub `flow init` just wrote, so the flow's id and name come from the product instead of being invented, and the stub is overwritten in place by the first `compile -o`.
+Skip it when the source already exists, and skip the whole block for an existing project.
 
 `<Solution>` and `<Name>` are the request's own names, used verbatim: a request
 that gives one name for both ("inside a solution of the same name") uses it for

--- a/preview/skills/uipath-maestro-flow/references/api.md
+++ b/preview/skills/uipath-maestro-flow/references/api.md
@@ -563,6 +563,9 @@ export declare function entryInput(entryPointId: string, name: string): Expr;
 /**
  * Reference an upstream step's output → `$vars.<step>.output[.<path>]`.
  * e.g. `out('fetchRate', 'body.rate')`.
+ *
+ * @enforcedBy VARS_BRACKET_READ Reach a step by a dot, not a bracket — the bracketed
+ *   spelling is the one the compiler cannot rewrite.
  */
 export declare function out(step: string, path?: string): Expr;
 ````
@@ -586,11 +589,13 @@ export declare function ran(step: string): Expr;
  * Reference a FAILED step's error → `$vars.<step>.error[.<field>]`.
  *
  * @enforcedBy ERROR_READ_VIA_OUT Read an error with `err()`, never `out('<step>',
- *   'error')` — the envelope has no `error` field of its own.
+ *   'error')` — the success output has no `error` field of its own.
+ * @enforcedBy ERROR_ENVELOPE_VIA_OUTPUT Inside a handler, the failed step's `.output`
+ *   is empty; an envelope field read from it resolves to nothing.
  */
 export declare function err(step: string, field?: ErrorEnvelopeField): Expr;
 
-// ErrorEnvelopeField = 'code' | 'message' | 'detail' | 'category' | 'status'
+// ErrorEnvelopeField = 'code' | 'message' | 'detail' | 'category' | 'status' | 'response' | 'element'
 ````
 
 ## js (function)
@@ -970,6 +975,8 @@ declare class FlowBuilder extends StepList {
 /** Collects a sequence of steps. Used for the flow body and each branch/loop arm. */
 declare class StepList {
     steps: Step[];
+    /** Read the failure that led into this handler → `err('<the failed step>', field)`. */
+    err(field?: ErrorEnvelopeField): Expr;
     /** Add an action node (see `http` / `script` / `subflow`). */
     step(name: string, spec: FlowActionSpec | FlowAction, options?: NodeOptions): this;
     /**
@@ -1029,6 +1036,8 @@ declare class StepList {
     /** Terminate this path, binding flow outputs to expressions. */
     return(values?: Record<string, Expr | unknown>, options?: ReturnOptions): this;
 }
+
+// ErrorEnvelopeField = 'code' | 'message' | 'detail' | 'category' | 'status' | 'response' | 'element'
 ````
 
 ## ArmBuilder (class)
@@ -2493,7 +2502,7 @@ export type ActionSpec = {
 ## ErrorEnvelopeField (type)
 
 ````ts
-export type ErrorEnvelopeField = 'code' | 'message' | 'detail' | 'category' | 'status';
+export type ErrorEnvelopeField = 'code' | 'message' | 'detail' | 'category' | 'status' | 'response' | 'element';
 ````
 
 ## RawReference (type)

--- a/preview/skills/uipath-maestro-flow/references/connector-params.md
+++ b/preview/skills/uipath-maestro-flow/references/connector-params.md
@@ -38,7 +38,8 @@ source. The loop is:
    `CUSTOM_FIELDS_UNPREPARED`, `CONNECTOR_INPUT`.
 4. **Prepare once** — `--object`, `--resolve` and `-f` compose in a single
    invocation, and it finds the connection itself and writes `bindings.json`.
-   Switch to the generated descriptor import where it printed one.
+   `prepare` repoints the import itself; it only asks when two flows
+   import the same connector, or you passed `--no-source-rewrite`.
 5. **Check again, then compile.**
 
 Every prepare command below is the one `check` prints at step 3 — shown here

--- a/preview/skills/uipath-maestro-flow/references/error-handling.md
+++ b/preview/skills/uipath-maestro-flow/references/error-handling.md
@@ -2,9 +2,9 @@
 
 An error handler is a separate path from the immediately preceding action.
 
-Signature: `.step(name, action).onError(handler => ...)`. Read the failure with
-`err(step, 'code' | 'message' | 'detail' | 'category' | 'status')`; a handler
-may `.return(...)`, `.terminate(...)`, or `.stepToRef(target)`.
+Signature: `.step(name, action).onError(handler => ...)`.
+Read the failure with `h.err(field)` — or `err(step, field)` if you prefer to name the step — where field is one of `code`, `message`, `detail`, `category`, `status` (plus `response` and `element`, present at run time though undeclared).
+A handler may `.return(...)`, `.terminate(...)`, or `.stepToRef(target)`.
 
 ```ts
 .step('fetch', http({ url, managed: true }))
@@ -12,6 +12,34 @@ may `.return(...)`, `.terminate(...)`, or `.stepToRef(target)`.
   .stepToRef('useValue'))
 .step('useValue', script({ code: 'return "done";' }))
 ```
+
+## Reading the failure
+
+`err()` writes ONE shape — `$vars.<step>.error.<field>` — and the compiler resolves where that family actually publishes the envelope.
+Do not hand-write either prefix, and do not read the failed step's `out(...)` inside its own handler: that path runs because the step failed, so its success output was never written (`ERROR_ENVELOPE_VIA_OUTPUT`).
+
+Which variable holds the envelope is a per-node-family runtime fact, measured one debug run per family (2026-09-10):
+
+| family | envelope in | `<step>.error` is |
+| --- | --- | --- |
+| connector (every one) | `<step>.error` | the envelope |
+| `core.action.script` | `<step>.error` | the envelope |
+| `uipath.pattern.deep-rag` | `<step>.error` | the envelope |
+| `core.subflow` | `<step>.error` | the envelope |
+| `core.action.queue.create` | `<step>.error` | the envelope |
+| `core.action.http.v2` (`managed: true`) | `<step>.output` | the boolean `true` |
+| `core.action.http` (`managed: false`) | nowhere | the boolean `true` |
+
+`serialize` rewrites the read for the exception families, so authored source stays uniform and a family moving is a table edit rather than a fleet-wide rewrite.
+A bare `err(step)` is the did-this-fail test and is never rewritten: it reads truthy on every family, the envelope object included.
+
+Plain `http({ managed: false })` publishes no envelope in any version — 1.0.0 and the 1.3 `uip maestro flow migrate` upgrades it to both leave `<step>.output` null — so `check` refuses a handler there (`HTTP_ONERROR_V1`) instead of emitting a read that resolves to nothing.
+That node is also gone from the tenant registry, which serves only `core.action.http.v2`; `check` says so (`HTTP_V1_RETIRED`).
+Moving to the managed node is a behaviour change, not a rename: a non-2xx stops arriving on the success path with `statusCode` and fails the step instead, so a status branch becomes a handler reading `err(step, 'status')`.
+
+A `.loop()` container CAN carry a handler: `.onError()` after `.loop(...)` wires the container's own error port, and a body step's failure routes to it — measured, the container's envelope carries the body's message in `detail` and the failing body step's id in `element`, and the instance completes instead of faulting. Read it the usual way, `h.err('detail')`.
+
+A `.doWhile()` cannot, and the reason is the handle rather than the variable: `core.logic.dowhile@1.0` declares an error variable but its handles are input, success, start, continue and break, so an edge would leave a handle the node does not have — the shape that fails product validate with "the current manifest does not declare that handle". Handle the failure inside the body, on the step that can fail. The builder refuses it by name.
 
 `.onError(...)` is the `error` port case of `.stepToList(port, handler)`, which
 runs a path from any named port. When the failure needs no work of its own, name


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `a82b640` to current `UiPath/flow-builder-sdk@main` (`62c5a99`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)