### PR TITLE
fix(maestro-case): show the reassign collision shape as a block

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
@@ -46,7 +46,7 @@ For each top-level Step 0 entry, check whether the SDD references it either as a
 
 A `$xref('Stage','Task','output')` marker is not one of those two reference forms: the output it names is still auto-minted, and the `=` row is an additional row that reads it. Collapsing the two into one leaves the `=` row reading the variable it writes, which nothing produces.
 
-- **`<sdd-field-path> -> <sdd-name>`** (extract) → reassign-shape. Let `baseId = camelCase(leaf segment)` and allocate `id` per the global [uniqueness rule](../global-vars/impl-json.md#uniqueness-rule), including its controlled equal-name alias. Emit `{name: <resolved name>, type: <resolved descriptor's type>, id: <allocated id>, var: "<sdd-name>", originalVar: <allocated id>, value: "<sdd-name>", source: "=<sdd-field-path>", target: "=<allocated id>", elementId: "<stage-task>"}`. `<resolved name>` is the top-level schema display name for a top-level path; for a nested path it is the leaf display name when present, otherwise the exact final path segment. **`source` is the SDD's left-side string with `=` prefix, verbatim.** **`type` is required on every emitted output.** The parser keeps an output only when `name`, `type`, `source` and `var` are all present, so a row without one is dropped before anything evaluates it and the variable it names is never written. Packaging does not object: an undefined `type` simply omits the attribute. **`originalVar` is load-bearing and mirrors the allocated `id`** — it records the output slot before reassignment and tells FE's `mutateRootVariables` (`VariableMutationUtils.ts:135`) to skip root-mirroring, preserving the case-Variable companion across FE edits. Example: if another task already owns `id: "aPIOutput1"`, `APIOutput1 -> renamedResult` emits `id: "aPIOutput12"`, `target: "=aPIOutput12"`, `var: "renamedResult"`, and `originalVar: "aPIOutput12"`.
+- **`<sdd-field-path> -> <sdd-name>`** (extract) → reassign-shape. Let `baseId = camelCase(leaf segment)` and allocate `id` per the global [uniqueness rule](../global-vars/impl-json.md#uniqueness-rule), including its controlled equal-name alias. Emit `{name: <resolved name>, type: <resolved descriptor's type>, id: <allocated id>, var: "<sdd-name>", originalVar: <allocated id>, value: "<sdd-name>", source: "=<sdd-field-path>", target: "=<allocated id>", elementId: "<stage-task>"}`. `<resolved name>` is the top-level schema display name for a top-level path; for a nested path it is the leaf display name when present, otherwise the exact final path segment. **`source` is the SDD's left-side string with `=` prefix, verbatim.** **`type` is required on every emitted output.** The parser keeps an output only when `name`, `type`, `source` and `var` are all present, so a row without one is dropped before anything evaluates it and the variable it names is never written. Packaging does not object: an undefined `type` simply omits the attribute. **`originalVar` is load-bearing and mirrors the allocated `id`** — it records the output slot before reassignment and tells FE's `mutateRootVariables` (`VariableMutationUtils.ts:135`) to skip root-mirroring, preserving the case-Variable companion across FE edits. See **Reassign collision** below for the shape a name clash produces.
 - **Bare `<name>`** (no operator) → auto-mint shape: `{name, type: <Step 0 entry's type>, id: <camelCase(name)>, var: <id>, value: <id>, source: <Step 0 entry's source verbatim>, target: "=<id>", elementId}`. No `originalVar`. Used for top-level Step 0 entries the SDD doesn't alias.
 - **`<sdd-name> = <expression>`** (set / compute / copy) → Scenario E shape: `{name: "<sdd-name>", custom: true, var: "<sdd-name>", value: "<expression>", source: "<same as value>", target: "", body: "", type: <case var's type>, elementId: "root"}`. **No `id`**, no `originalVar`. **On this shape only, `target` and `body` are present-but-blank: emit `"target": ""` and `"body": ""` literally rather than dropping the keys.** An omitted key is not the same as a blank one — the FE reads a missing `target` as unset rather than deliberately-empty. Blank values belong to Scenario E and nowhere else:
 
@@ -86,6 +86,24 @@ Never blank a `target` or `value` on a reassign or auto-mint row to satisfy the 
   }
 ]
 ```
+
+**Reassign collision.** The allocated `id` is derived from the field name, never the `v` + 8 form task inputs and formal slots use, so `id` is the field that can clash and the field that takes the suffix. `target` and `originalVar` follow it; `var` and `value` keep pointing at the case variable. Given another task already owns `id: "aPIOutput1"`, the row `APIOutput1 -> renamedResult` emits:
+
+```json
+{
+  "name": "APIOutput1",
+  "type": "string",
+  "id": "aPIOutput12",
+  "var": "renamedResult",
+  "originalVar": "aPIOutput12",
+  "value": "renamedResult",
+  "source": "=APIOutput1",
+  "target": "=aPIOutput12",
+  "elementId": "Stage_verify-tCallApi01"
+}
+```
+
+Eight tasks extracting the same field into one case variable produce this eight times: eight distinct `id` values, one shared `var`. Minting `id` randomly leaves nothing that can clash, the suffix lands on `var` instead, and seven of the eight then name a case variable that was never declared.
 
 **Equal-name extract dispatch.** Dispatch by the explicit operator before comparing names; equal operands select the reassign shape, never the bare auto-mint branch. Apply the global [controlled-alias rule](../global-vars/impl-json.md#uniqueness-rule). With no unrelated collision, `greeting -> greeting` emits `id`, `var`, `originalVar`, and `value` as `"greeting"`, with `source: "=greeting"` and `target: "=greeting"`. `originalVar` distinguishes reassignment from a bare output and keeps the predeclared root companion intact during frontend synchronization; the linked allocator owns any required suffixing.
 


### PR DESCRIPTION
## The problem

On a name clash, a reassign output's `id` takes the suffix and `var` keeps pointing at the case variable. That rule lived only in prose. Both fenced blocks in [`io-binding/impl-json.md` § Output Binding Shapes](https://github.com/UiPath/skills/blob/01d3d5e866eeadbedd53c86ee4ffafe9df5c26e4/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md) show a row with no clash, and one of them has `id` and `var` equal. The clash case appeared as a sentence at the end of a long bullet.

## Which runs

Three supplier-onboarding artifacts. Its SDD writes `response.status -> lastEmailStatus` on eight connector tasks, so eight outputs compete for one `id` base.

| run | `id` base | `var` |
|---|---|---|
| [34088556384](https://github.com/UiPath/skills/actions/runs/34088556384) | `status`, the camelCased leaf | `lastEmailStatus` on all 8 |
| [34054016678](https://github.com/UiPath/skills/actions/runs/34054016678) | `response`, the parent name | `lastEmailStatus` on all 8 |
| [34079451197](https://github.com/UiPath/skills/actions/runs/34079451197) | `v` + 8 random (`vBNBUr0ho`) | `lastEmailStatus2` through `lastEmailStatus8` on 7 of 8 |

Only the run that minted `id` randomly suffixed `var`. A random id can never clash, so the suffix had nowhere else to land. `lastEmailStatus2` through `lastEmailStatus8` are declared in no variable group, so seven of the eight sends write a case variable that does not exist and the one that does is updated only by the first task.

Reading the text was not the gap. Both prohibitions appear in that run's transcript, once each, which is the file it read: `do not suffix the pointer \`var\`` and `Never suffix the root companion or the \`var\` pointer`. Its own line at turn 361, right before writing the seven: **"this task will be the pattern to replicate for the other 7 connector tasks."**

The `v` + 8 form is real and belongs elsewhere: [`io-binding/impl-json.md:18`](https://github.com/UiPath/skills/blob/01d3d5e866eeadbedd53c86ee4ffafe9df5c26e4/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md#L18) gives it to task **inputs**, [`global-vars/impl-json.md:97`](https://github.com/UiPath/skills/blob/01d3d5e866eeadbedd53c86ee4ffafe9df5c26e4/skills/uipath-maestro-case/references/plugins/variables/global-vars/impl-json.md#L97) to formal argument slots. Nothing in the output section said which one an output `id` uses, except inside that bullet.

## What changed

One fenced JSON block, `**Reassign collision.**`, placed with the section's two other standalone worked examples. It shows the clash row with `id` suffixed, `target` and `originalVar` following it, and `var` and `value` unchanged, and it names where the `id` comes from. The bullet's trailing sentence becomes a pointer to it.

Nothing else moved. The four-bullet dispatch list stays intact.

## Verification

**A backstop exists, and it reaches seven of the eight.** `uip maestro case validate --strict --sdd sdd.md` matches each SDD `field -> variable` row against an output with that `source` and that `var`: [`strict-sdd-audit.ts:4158`](https://github.com/UiPath/cli/blob/d4b827de82d0f0055190ece1ea1e98900a31eed8/packages/case-tool/src/services/strict-sdd-audit.ts#L4158), added by [UiPath/cli#4007](https://github.com/UiPath/cli/pull/4007) and extended by [UiPath/cli#4044](https://github.com/UiPath/cli/pull/4044). `STRICT_SDD_EXTRACT_MISSING` reports 7 findings on [34079451197](https://github.com/UiPath/skills/actions/runs/34079451197) and 0 on [34088556384](https://github.com/UiPath/skills/actions/runs/34088556384).

Two things bound what it reaches, and a third thing is out of its reach by design. It needs an SDD: the same failing plan returns 0 of this code under `full` and 0 under bare `--strict`, so a brownfield edit and the Rule 14 version-guard fallback both run without it. And it speaks after the plan is written, while the block speaks before the first row is. [UiPath/cli#4208](https://github.com/UiPath/cli/pull/4208) makes the seven findings name the `var` they found rather than reading as an absent row.

**The eighth task is not a defect, and no rule should report it.** It kept `var: "lastEmailStatus"`, so it writes the variable the SDD asked for and the case runs correctly; only its `id` carries the mint form the other seven were copied from. That `id` reaches no runtime: the engine's `ActivityOutput` record ([`ActivityOutput.cs:9-21`](https://github.com/UiPath/PO.BpmnEngine/blob/188f14bea43d49230284d626ed00bc259799c791/src/BpmnEngine/UiPath.PO.BpmnParser/Models/ActivityOutput.cs#L9-L21)) carries `Name`, `Type`, `Source` and `TargetVar` and no id at all, and the parser that fills it ([`UiPathExtensionsProvider.cs:182`](https://github.com/UiPath/PO.BpmnEngine/blob/188f14bea43d49230284d626ed00bc259799c791/src/BpmnEngine/UiPath.PO.BpmnParser/ExtensionsProviders/UiPathExtensionsProvider.cs#L182)) reads `var` into `TargetVar` and keeps a row only when `Name`, `Type`, `Source` and `TargetVar` are all present. The canvas is the same: it looks an output up by `id` inside that one task's own list, and every match that crosses records goes through `var` or `name` instead. So an output `id` only has to be unique within the plan, which is why the block is about the shape a reader and the next build can follow, not about a finding. What the suffix on `var` costs is real and reported; what the `id` costs is that the eight rows stop reading as eight copies of one field.

**The mechanism, on the failed artifact itself.** Taking [34079451197](https://github.com/UiPath/skills/actions/runs/34079451197)'s own caseplan and moving the suffix off `var` onto `id`, which is what the block asks for (`var` back to `lastEmailStatus`, `id` to `status2` through `status8`, `target` and `originalVar` following), takes those 7 findings to 0. Nothing else about the caseplan changed.

**A guard for this shape is already in the suite and passes.** [`tests/tasks/uipath-maestro-case/io_binding`](https://github.com/UiPath/skills/tree/01d3d5e866eeadbedd53c86ee4ffafe9df5c26e4/tests/tasks/uipath-maestro-case/io_binding) builds two tasks extracting `estimatedAge -> estimatedAge`, the second after the first owns the unsuffixed id. Its checker asserts `id: "estimatedAge2"` with `var: "estimatedAge"`, `target: "=estimatedAge2"` and `originalVar: "estimatedAge2"`, so a build that suffixes `var` fails it. Both artifacts of it on hand emit exactly that shape.

**Suffixing itself is not the problem.** Across the 97 eval artifacts that carry task outputs, 4047 output `id` values collide 0 times. The one artifact that does carry a repeat is [34164524501](https://github.com/UiPath/skills/actions/runs/34164524501), a diagnose task whose staged input is deliberately defective and whose prompt names that repeat as the thing to find. So the counter is being applied; only its landing field was wrong.

**The shape, built right on the artifact family where it broke.** [34567211526](https://github.com/UiPath/skills/actions/runs/34567211526) ran supplier-onboarding on a branch carrying this change, agent claude, 828 turns. Its eight send tasks emit eight distinct `id` values (`status`, `status2`, `status3` and so on) with `target` following each one, and all eight share `var: "lastEmailStatus"`. That is the shape the block shows, on the SDD that produced the defect.

**Reachability.** `io_binding` emits the collision row the block shows, `id: "estimatedAge2"` and `var: "estimatedAge"` with `originalVar` and `target` following the `id`: [34567566705](https://github.com/UiPath/skills/actions/runs/34567566705) codex, [34567568645](https://github.com/UiPath/skills/actions/runs/34567568645) and [34614343110](https://github.com/UiPath/skills/actions/runs/34614343110) claude, and [34791326430](https://github.com/UiPath/skills/actions/runs/34791326430) claude on this head. That last run ends `ERROR` on the 3600 s turn cap, 273 turns with the cap on turns not reached: its `--strict` returns `Valid` with no error at turn 262 and the caseplan is written, and the turns after it read the task's own checker rather than the plan.

**Regression control.** The maestro-case smoke set on this branch ([34567570519](https://github.com/UiPath/skills/actions/runs/34567570519)) against a control branch off main whose only diff is a blank line, so both select the same six tasks ([34563161125](https://github.com/UiPath/skills/actions/runs/34563161125)). All six score `SUCCESS` at 1.00 on both sides.





