### PR TITLE
fix(uipath-api-workflow): require optional chaining on loop output.as

### DIFF
--- a/skills/uipath-api-workflow/references/task-types.md
+++ b/skills/uipath-api-workflow/references/task-types.md
@@ -219,7 +219,7 @@ Iterates over a collection. Requires `#Body` inside `do`.
 { ...$context, outputs: { ...$context?.outputs, "For_Each_N": { ...$context?.outputs?.For_Each_N, results: [ ...($currentItemIndex == 0 ? [] : ($context?.outputs?.For_Each_N?.results ?? [])), ...([$output] ?? []) ] } } }
 ```
 
-**Output pattern:** `${$context.outputs.For_Each_N}`
+**Output pattern:** `${$context?.outputs?.For_Each_N}` — optional chaining is REQUIRED. With zero iterations the body never runs, so `$context.outputs` is undefined and a bare `$context.outputs.For_Each_N` throws. A trailing `?? { results: [] }` does NOT save it: the throw happens before `??` is reached.
 
 **Minimal JSON:**
 ```json
@@ -240,7 +240,7 @@ Iterates over a collection. Requires `#Body` inside `do`.
         }
       }
     ],
-    "output": { "as": "${$context.outputs.For_Each_1}" },
+    "output": { "as": "${$context?.outputs?.For_Each_1}" },
     "metadata": { "activityType": "ForEach", "displayName": "For Each", "fullName": "ForEach" }
   }
 }
@@ -253,6 +253,7 @@ Inside the body, the iterator and index are accessible as globals **with a `$` p
 - Wrapping `each` or `at` in `${...}` — they are plain variable names, not expressions
 - Missing `for.at`
 - Wrong body export pattern (must use the index-aware reset shown above, not the simpler DoWhile pattern)
+- Dropping the `?.` in `output.as` — a bare `$context.outputs.For_Each_N` throws when the loop runs zero times
 
 **Nesting:**
 - Each ForEach activity's iterator and index variable names are scoped to that loop. Inner loops MUST use distinct names — e.g. outer `for.each: "outerItem"` / inner `for.each: "innerItem"`. Reusing `currentItem` in both loops shadows the outer one.
@@ -288,7 +289,7 @@ Repeat-until loop. Body always executes at least once.
         }
       }
     ],
-    "output": { "as": "${$context.outputs.Do_While_1}" },
+    "output": { "as": "${$context?.outputs?.Do_While_1}" },
     "metadata": { "activityType": "DoWhile", "displayName": "Do While", "fullName": "DoWhile" }
   }
 }
@@ -298,6 +299,7 @@ The body MUST update the condition variable, otherwise the loop runs forever.
 
 **Common mistakes:**
 - Using a real collection for `for.in` instead of `"${ [1] }"`
+- Dropping the `?.` in `output.as` — write `${$context?.outputs?.Do_While_N}`, never `${$context.outputs.Do_While_N}`
 - Missing `#Body` suffix
 - Body does not update the `doWhile` condition variable → infinite loop
 - Missing `output.as` on the loop itself

--- a/skills/uipath-api-workflow/references/troubleshooting.md
+++ b/skills/uipath-api-workflow/references/troubleshooting.md
@@ -60,6 +60,11 @@ Common failure modes when authoring, running, packaging, or publishing API workf
 - **Cause:** Using `$context.outputs` without optional chaining when no outputs exist yet
 - **Fix:** Always use `$context?.outputs` in export patterns
 
+### Loop fails only when it runs zero times
+- **Symptom:** A ForEach (or DoWhile) works for a non-empty collection but the run errors when the collection is empty or the count is `0`. Non-zero inputs pass, so the bug survives casual testing.
+- **Cause:** `output.as` reads `$context.outputs.<Loop_N>` without optional chaining. With zero iterations the body never runs, nothing ever creates `$context.outputs`, and the property access throws. A trailing `?? { results: [] }` does not help — the throw happens before `??` is evaluated.
+- **Fix:** For now, every loop `output.as` needs the optional form: `${$context?.outputs?.For_Each_N}` / `${$context?.outputs?.Do_While_N}`. Apply it even when the loop "obviously" always iterates — the input that makes it zero usually shows up later.
+
 ### ForEach body export missing index reset
 - **Symptom:** Results array grows incorrectly across loop iterations
 - **Cause:** Using the simpler DoWhile accumulation pattern instead of the ForEach index-aware pattern


### PR DESCRIPTION
## What

The ForEach and DoWhile templates in `references/task-types.md` shipped `output.as` as `${\$context.outputs.<Loop_N>}` — without optional chaining — while the body export pattern two lines above correctly used `\$context?.outputs?.`.

```diff
-    "output": { "as": "${\$context.outputs.For_Each_1}" },
+    "output": { "as": "${\$context?.outputs?.For_Each_1}" },
```

## Why

When a loop runs zero times the body never executes, so nothing ever creates `\$context.outputs`. The bare property access then throws. A trailing `?? { results: [] }` does **not** rescue it — the throw happens before `??` is evaluated.

The failure is input-dependent: a ForEach over a non-empty collection works fine, so an agent that copies the template ships a workflow that only breaks on the empty-collection / `count: 0` path. Observed in a codereval run of `skill-api-workflow-diagnose-unsupported-activity-type`, where `count: 3` and `count: 5` passed and only `count: 0` failed.

For now, treat the optional form as mandatory on every loop `output.as`, including loops that look like they always iterate.

## Changes

- `references/task-types.md` — ForEach output pattern + both minimal-JSON templates use `\$context?.outputs?.`; a Common mistakes bullet in each loop section
- `references/troubleshooting.md` — new entry: *Loop fails only when it runs zero times*

Docs only — no frontmatter, skill set, or registry changes. `check-skill-status.py` and `check-skills-sh.py` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)