### PR TITLE
fix(uipath-troubleshoot): route the domains that have no playbook corpus

### DIFF
--- a/skills/uipath-troubleshoot/SKILL.md
+++ b/skills/uipath-troubleshoot/SKILL.md
@@ -32,7 +32,7 @@ ALL phases. Never override.
 
 ## 2. Anchor & primary evidence
 
-1. **Classify (system, entity) from the user's message.** Cross-check against `references/summary.md` domains.
+1. **Classify (system, entity) from the user's message.** Cross-check against `references/summary.md` domains — including its § Domains without a playbook corpus, which covers the products this skill carries no playbooks for.
 2. **Branch on anchor presence:**
    - **Anchored** — user named a concrete locator (id/key, process/package/queue/folder name, instance/incident id, specific error code/message), or the working directory contains a recognisable UiPath project at top level (`project.json`, `agent.json`, `caseplan.json`). Run the first locator command documented in the system's `investigation_guide.md`; if the system has no guide, proceed with the user-supplied signals to §3–§4 — the matched playbook's `## Investigation` supplies the commands.
    - **No anchor** — ask via `AskUserQuestion`, offering plausible anchor candidates. Do NOT broad-scan, do NOT fetch a placeholder entity, do NOT enumerate folders/queues hoping to find the right one. A bounded locate pass only if the user explicitly authorizes a scan — then confirm the candidate with them.
@@ -54,6 +54,7 @@ Grep the playbook corpus for each extracted signal — fixed-string, filenames o
 - **One dominant playbook** — most distinct signal hits; ties break by reading each hit's `## Context` and keeping the one whose preconditions fit the evidence; honor a playbook's explicit redirects to sibling playbooks. → Load ONLY that playbook + its domain's `investigation_guide.md` (if the domain has one). Go to §5.
 - **Cross-domain signal** — evidence carries a key/ID/exception belonging to another product (e.g., an Excel fault wrapping an Integration Service connection error, an Orchestrator job spawned by a Maestro instance). → Follow the chain **one hop**: fetch the linked entity's error surface, extract its signals, re-grep. The upstream playbook drives the resolution; the downstream domain contributes a propagation fix (`references/presenting.md`). Deeper than one hop → escalate.
 - **Fault signal but no grep hit** — map the faulting activity/exception namespace to its owning domain (`references/summary.md`) and check that domain's `summary.md` for a family playbook covering the activity. One dominant family playbook → proceed to §5 with it. Still nothing → escalate.
+- **Domain has no playbook corpus** — the classified domain is listed in `references/summary.md` § Domains without a playbook corpus (Insights, Automation Ops, Test Manager, Governance, Data Fabric, IXP, Process Mining, Solutions, Identity & Admin, Actions/HITL, Traces). A grep hit is impossible and escalation has nothing to probe. → Delegate evidence-gathering to the owning skill per that section's protocol, then resume at §5 with the returned evidence. Do NOT escalate first.
 - **No match, or an escalation trigger (§7) fires** → load `references/escalation.md`. For silent failures (no fault signal anywhere: job Successful but wrong output, hang, stuck state), enter via the no-signature routing table in `references/summary.md`.
 
 ## 5. Walk the playbook
@@ -90,7 +91,7 @@ Any check fails → ONE targeted re-fetch for the missing datum. Still failing �
 
 Load `references/escalation.md` when ANY of:
 
-1. **No playbook grep match** — silent failure, hang, wrong results, nothing greppable.
+1. **No playbook grep match** — silent failure, hang, wrong results, nothing greppable. A domain listed in `references/summary.md` § Domains without a playbook corpus does NOT fire this trigger — delegate per §4 first, and escalate only if that returns no usable evidence.
 2. **≥2 co-equal matches** with distinct, independent signatures (different activities/error codes, neither upstream of the other).
 3. **Cross-domain chain deeper than one hop**, or the one-hop follow contradicts the original match.
 4. **Decision tree exhausted** — every branch rejected, or a discriminator stays inconclusive after its named evidence is gathered.

--- a/skills/uipath-troubleshoot/references/summary.md
+++ b/skills/uipath-troubleshoot/references/summary.md
@@ -299,6 +299,28 @@ Namespaces: `UiPath.IPC.Activities`
 - [activity-packages/ipc-activities/summary.md](./activity-packages/ipc-activities/summary.md) — All playbooks for IPC Activities issues
 
 
+## Domains without a playbook corpus
+
+These products have no playbooks, no overview, and no investigation guide in this skill. Routing (SKILL.md §4) can never produce a grep hit for them, and escalation cannot recover — there are no candidate playbooks to probe. Classify the domain here, then delegate evidence-gathering to the owning skill, which supplies the documented commands invariant 3 requires.
+
+| Domain | CLI | Owning skill | Typical diagnostic ask |
+|---|---|---|---|
+| Insights | `uip insights --help` | `uipath-insights` | Alert did not fire or was not delivered; job-failure metrics; process performance regression |
+| Automation Ops | `uip aops --help` | `uipath-aops` | Pipeline run failed or produced no artifact; source-control binding not resolving |
+| Test Manager | `uip tm --help` | `uipath-test` | Test case or test set failing; results not reported back |
+| Governance | `uip gov --help` | `uipath-governance` | Policy not taking effect; a tool invocation blocked unexpectedly; deployment precedence |
+| Data Fabric | `uip df --help` | `uipath-platform` | Entity or record read/write returning wrong or empty data; choice-set mismatch |
+| IXP | `uip ixp --help` | `uipath-ixp` | Extraction returning wrong or missing fields; a deployment serving an unexpected model version |
+| Process Mining | `uip pm --help` | `uipath-process-mining` | Ingest or dbt transformation failing; dashboards not opening; a query returning nothing |
+| Solutions | `uip solution --help` | `uipath-solution` | Deploy failing or stuck; a package or binding not resolving at deploy time |
+| Identity & Admin | `uip admin --help` | `uipath-admin` | Access denied, login failure, role misconfiguration, IP lockout; org/tenant audit trail |
+| Actions / HITL | `uip tasks --help` | `uipath-tasks` | Action not appearing, not assignable, or not resuming its parent job |
+| Traces / LLMOps | `uip traces --help` | `uipath-platform` | Spans missing or truncated for a run |
+
+**Delegation protocol.** Spawn ONE read-only subagent, name the owning skill, and give it the anchored entity plus the signals recorded in §3. Ask it for evidence, not a diagnosis: the commands it ran, their verbatim output, and the `.local/investigations/raw/` paths it wrote them to. Adjudicate that evidence yourself against the §6 checklist — a subagent's conclusion is an input, never the verdict.
+
+**Degradation.** If no subagent-spawning tool is available, or the owning skill is not installed, name the product the problem belongs to and the evidence needed, then go to §7. Never guess commands for these domains — invariant 3 holds here exactly as it does everywhere else.
+
 ## Playbooks
 
 All playbooks use the same headers: `## Context`, `## Investigation` (optional), `## Resolution` (optional). They vary by confidence level:


### PR DESCRIPTION
## Why Troubleshoot is yellow

From the [08/31 coverage run](https://github.com/UiPath/coder-coverage/blob/main/reports/2026-08-31-skills-coverage.md), Diagnose is the weakest of the three modes:

| Mode | Mean across 29 rows | Rows below 70% |
|---|---|---|
| Build | 76% | 5 |
| Operate | 79% | 4 |
| **Diagnose** | **74%** | **9** |

Two of the nine are structurally unfixable (Notification Service has no CLI surface; Task Mining is EOL 2027-04-30). The other seven are RPA 55%, Studio 50%, Automation Ops 50%, Insights 55%, API Workflow 65%, Test Manager 65%, Governance 65%.

Diagnose is scored off the cross-product `uipath-troubleshoot` skill plus per-product diagnose surfaces. This PR addresses the part that lives in `uipath-troubleshoot`.

## The gap

`references/summary.md` — the Domain Catalog that §2.1 classifies against and §4 routes through — covers 10 product domains and 22 activity packages. Eleven products the skill's own description claims ("across every product") have no playbooks, no overview, and no investigation guide:

Insights · Automation Ops · Test Manager · Governance · Data Fabric · IXP · Process Mining · Solutions · Identity & Admin · Actions/HITL · Traces

That includes four of the seven fixable yellow rows: **Automation Ops 50%, Insights 55%, Test Manager 65%, Governance 65%**.

For those products the investigation dead-ends, and the dead-end is silent:

1. §4 greps the playbook corpus. There is nothing to hit.
2. §7 trigger 1 (*no playbook grep match*) fires.
3. `escalation.md` spawns 2–4 probe subagents over candidate playbooks — a set that is empty.
4. Invariant 3 forbids CLI discovery, and with no guide, overview, or playbook there is no documented command source either. The agent may not run anything.
5. §10 offers to open a support ticket, having gathered no evidence.

This is not a missing-data problem. Every one of these products has a real read surface in the catalog snapshot (`uip insights` 18 read verbs, `uip tm` 47, `uip admin` 37, `uip gov` 21, `uip pm` 27) — the skill just has no sanctioned way to reach it.

## The change

Name the boundary and route through it instead of into escalation.

- **`references/summary.md`** — new `## Domains without a playbook corpus` section: the eleven domains, each with its CLI root and owning skill, plus a delegation protocol and an explicit degradation path.
- **`SKILL.md` §4** — new branch ahead of the escalation bullet: delegate evidence-gathering to the owning skill, resume at §5 with what comes back.
- **`SKILL.md` §7** — trigger 1 carves these domains out, so escalation is the fallback rather than the first stop.
- **`SKILL.md` §2.1** — the classification cross-check points at the new section.

## On the repo rules

- **Self-containment (CLAUDE.md rule 6).** Delegation is runtime-only; no sibling file is read or inlined. With no subagent tool or no sibling installed, the skill names the product and the evidence needed and falls back to §7 — it still returns an actionable result.
- **Invariant 3 (no CLI discovery).** Nothing here invents a command. The table lists CLI *roots*, matching the existing `CLI: \`uip or --help\`` pattern; the owning skill supplies the documented command form. The degradation note restates that invariant 3 holds for these domains too.
- **Frontmatter unchanged** — no `activation-gate.yml` recall-eval churn.

`check-skill-status.py` and `check-skills-sh.py` both pass; all relative links resolve.

## Scope

This closes the routing dead-end. It does not by itself author playbooks for the eleven products — that is the follow-up that actually moves Diagnose past 70% for Automation Ops, Insights, Test Manager and Governance. Worth doing per-product, with the owning team, rather than guessing failure modes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)