### PR TITLE
fix(hooks): resolve agent_model per event and align the telemetry twins

### DIFF
--- a/hooks/send-telemetry.ps1
+++ b/hooks/send-telemetry.ps1
@@ -39,8 +39,9 @@
 #   ENVELOPE (top-level)  -> toolName, toolUseId, permissionMode,
 #                            durationMs, effortLevel (effort.level), agentType,
 #                            source (-> session_source), reason (session-end),
-#                            model (-> agent_model; Claude sends it on
-#                            SessionStart, Codex on every event)
+#                            model (-> agent_model; string or {id,display_name}.
+#                            Claude Code omits it on most events, so the
+#                            transcript is the fallback -- PILOT-7497)
 #   tool_input            -> skillName, uipSubcommand (command), fileExtension
 #                            (file_path), subagentType (subagent_type, or
 #                            agent_type for a Codex spawn_agent call)
@@ -101,12 +102,60 @@ $SCHEMA_VERSION = 3
 function Get-Prop($Obj, [string]$Name) {
   if ($null -eq $Obj) { return $null }
   $p = $Obj.PSObject.Properties[$Name]
-  if ($p) { return $p.Value }
+  # Unary comma stops PowerShell unrolling a single-element array on return.
+  if ($p) { return ,$p.Value }
   return $null
 }
 
 function Test-JsonObject($Value) {
   return ($Value -is [System.Management.Automation.PSCustomObject])
+}
+
+# JSON strings only; any other shape -> ''. A [string] cast would render
+# 'True' / '@{id=...}' where the .sh twin yields ''.
+function ConvertTo-JsonString($Value) {
+  if ($Value -is [string]) { return $Value }
+  return ''
+}
+
+# Fallback when the envelope carried no `model` (PILOT-7497). Reads the LAST
+# assistant entry, so a mid-session /model switch is tracked. Subagent turns go
+# to <session>/subagents/agent-<id>.jsonl, so this yields the main-loop model.
+# 256KB tail: the last assistant entry is within ~28KB of EOF even at 5MB.
+# An absent, unreadable or not-yet-written transcript resolves to empty.
+# FileShare::ReadWrite: the agent still holds the file open.
+function Resolve-AgentModel([string]$TranscriptPath) {
+  if ([string]::IsNullOrEmpty($TranscriptPath)) { return '' }
+  if (-not (Test-Path -LiteralPath $TranscriptPath -PathType Leaf)) { return '' }
+  $text = ''
+  try {
+    $fs = [System.IO.File]::Open(
+      $TranscriptPath,
+      [System.IO.FileMode]::Open,
+      [System.IO.FileAccess]::Read,
+      [System.IO.FileShare]::ReadWrite)
+    try {
+      if ($fs.Length -gt 262144) {
+        [void]$fs.Seek(-262144, [System.IO.SeekOrigin]::End)
+      }
+      $sr = New-Object System.IO.StreamReader($fs, [System.Text.Encoding]::UTF8)
+      try { $text = $sr.ReadToEnd() } finally { $sr.Dispose() }
+    }
+    finally { $fs.Dispose() }
+  }
+  catch { return '' }
+  $model = ''
+  foreach ($line in ($text -split "`n")) {
+    # Whitespace-tolerant: the transcript format is undocumented.
+    if (-not [regex]::IsMatch($line, '"type"[ \t\r]*:[ \t\r]*"assistant"')) { continue }
+    $m = [regex]::Match($line, '"model"[ \t\r]*:[ \t\r]*"([^"]*)"')
+    if ($m.Success) {
+      $v = $m.Groups[1].Value
+      # <synthetic> is a local turn (interrupt/error), not a model id.
+      if ($v -and $v -ne '<synthetic>') { $model = $v }
+    }
+  }
+  return $model
 }
 
 # JSON booleans -> the literal strings 'true'/'false'; everything else -> ''.
@@ -275,32 +324,46 @@ function Main {
   if (-not (Test-JsonObject $payload)) { exit 0 }
 
   # ENVELOPE region.
-  $hookEvent      = [string](Get-Prop $payload 'hook_event_name')
-  $tool           = [string](Get-Prop $payload 'tool_name')
-  $toolUseId      = [string](Get-Prop $payload 'tool_use_id')
-  $permissionMode = [string](Get-Prop $payload 'permission_mode')
+  $hookEvent      = ConvertTo-JsonString (Get-Prop $payload 'hook_event_name')
+  $tool           = ConvertTo-JsonString (Get-Prop $payload 'tool_name')
+  $toolUseId      = ConvertTo-JsonString (Get-Prop $payload 'tool_use_id')
+  $permissionMode = ConvertTo-JsonString (Get-Prop $payload 'permission_mode')
   $durationMs     = Get-Prop $payload 'duration_ms'
-  $agentType      = [string](Get-Prop $payload 'agent_type')
-  $sessionSource  = [string](Get-Prop $payload 'source')
-  $reason         = [string](Get-Prop $payload 'reason')
-  $agentModel     = [string](Get-Prop $payload 'model')
+  $agentType      = ConvertTo-JsonString (Get-Prop $payload 'agent_type')
+  $sessionSource  = ConvertTo-JsonString (Get-Prop $payload 'source')
+  $reason         = ConvertTo-JsonString (Get-Prop $payload 'reason')
+  # String, or object with id preferred over display_name.
+  $agentModel = ''
+  $modelRaw = Get-Prop $payload 'model'
+  if (Test-JsonObject $modelRaw) {
+    $agentModel = ConvertTo-JsonString (Get-Prop $modelRaw 'id')
+    if (-not $agentModel) {
+      $agentModel = ConvertTo-JsonString (Get-Prop $modelRaw 'display_name')
+    }
+  }
+  else {
+    $agentModel = ConvertTo-JsonString $modelRaw
+  }
+  if (-not $agentModel) {
+    $agentModel = Resolve-AgentModel (ConvertTo-JsonString (Get-Prop $payload 'transcript_path'))
+  }
 
   $effortLevel = ''
   $effort = Get-Prop $payload 'effort'
-  if (Test-JsonObject $effort) { $effortLevel = [string](Get-Prop $effort 'level') }
+  if (Test-JsonObject $effort) { $effortLevel = ConvertTo-JsonString (Get-Prop $effort 'level') }
 
   # tool_input region.
   $skill = ''; $command = ''; $filePath = ''; $subagentType = ''
   $toolInput = Get-Prop $payload 'tool_input'
   if (Test-JsonObject $toolInput) {
-    $skill        = [string](Get-Prop $toolInput 'skill')
-    $command      = [string](Get-Prop $toolInput 'command')
-    $filePath     = [string](Get-Prop $toolInput 'file_path')
-    $subagentType = [string](Get-Prop $toolInput 'subagent_type')
+    $skill        = ConvertTo-JsonString (Get-Prop $toolInput 'skill')
+    $command      = ConvertTo-JsonString (Get-Prop $toolInput 'command')
+    $filePath     = ConvertTo-JsonString (Get-Prop $toolInput 'file_path')
+    $subagentType = ConvertTo-JsonString (Get-Prop $toolInput 'subagent_type')
     # Codex spawn_agent carries the spawned type in tool_input.agent_type;
     # normalize it to subagentType so it lands in the same field as Claude and
     # never collides with the envelope agent_type (agentType).
-    if (-not $subagentType) { $subagentType = [string](Get-Prop $toolInput 'agent_type') }
+    if (-not $subagentType) { $subagentType = ConvertTo-JsonString (Get-Prop $toolInput 'agent_type') }
   }
 
   # tool_response region. Presence of the KEY (any value shape) marks the
@@ -312,7 +375,7 @@ function Main {
   if (Test-JsonObject $toolResponse) {
     $interrupted   = ConvertTo-BoolString (Get-Prop $toolResponse 'interrupted')
     $success       = ConvertTo-BoolString (Get-Prop $toolResponse 'success')
-    $resolvedModel = [string](Get-Prop $toolResponse 'resolvedModel')
+    $resolvedModel = ConvertTo-JsonString (Get-Prop $toolResponse 'resolvedModel')
   }
 
   # Map the hook event to a canonical eventName; drop unrecognized events.

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -35,8 +35,9 @@
 #   ENVELOPE (top-level)  -> toolName, toolUseId, permissionMode,
 #                            durationMs, effortLevel (effort.level), agentType,
 #                            source (-> session_source), reason (session-end),
-#                            model (-> agent_model; Claude sends it on
-#                            SessionStart, Codex on every event)
+#                            model (-> agent_model; string or {id,display_name}.
+#                            Claude Code omits it on most events, so the
+#                            transcript is the fallback -- PILOT-7497)
 #   tool_input            -> skillName, uipSubcommand (command), fileExtension
 #                            (file_path), subagentType (subagent_type, or
 #                            agent_type for a Codex spawn_agent call)
@@ -109,7 +110,8 @@ extract_fields() {
       if (d == 1)
         return (k=="tool_name"||k=="tool_use_id"|| \
                 k=="permission_mode"||k=="duration_ms"||k=="agent_type"|| \
-                k=="hook_event_name"||k=="source"||k=="reason"||k=="model")
+                k=="hook_event_name"||k=="source"||k=="reason"||k=="model"|| \
+                k=="transcript_path")
       if (d == 2 && c == "input")
         return (k=="skill"||k=="command"||k=="file_path"||k=="subagent_type"|| \
                 k=="agent_type")
@@ -117,6 +119,15 @@ extract_fields() {
         return (k=="interrupted"||k=="success"||k=="resolvedModel")
       if (d == 2 && c == "effort")
         return (k=="level")
+      if (d == 2 && c == "model")
+        return (k=="id"||k=="display_name")
+      return 0
+    }
+    # A JSON literal is meaningful only for these keys; elsewhere it is
+    # malformed input and is dropped, so "null"/"true" never reach telemetry.
+    function scalar_ok(k, d, c) {
+      if (d == 1) return (k=="duration_ms")
+      if (d == 2 && c == "response") return (k=="interrupted"||k=="success")
       return 0
     }
     # outkey: remap a JSON key to the field name read_fields expects. Codex
@@ -125,6 +136,8 @@ extract_fields() {
     # subagent_type) and never collides with the envelope agent_type (agentType).
     function outkey(k, d, c) {
       if (d == 2 && c == "input" && k == "agent_type") return "subagent_type"
+      # Distinct names so id/display_name cannot collide at depth 2.
+      if (d == 2 && c == "model") return "model_" k
       return k
     }
     { buf = buf $0 "\n" }
@@ -171,6 +184,7 @@ extract_fields() {
               if (pkey == "tool_input")        ctx = "input"
               else if (pkey == "tool_response") ctx = "response"
               else if (pkey == "effort")        ctx = "effort"
+              else if (pkey == "model")         ctx = "model"
               else                              ctx = "other"
             }
             pend = 0
@@ -193,7 +207,8 @@ extract_fields() {
             if (c==","||c=="}"||c=="]"||c==" "||c=="\t"||c=="\n"||c=="\r") break
             lit = lit c; i++
           }
-          if (interesting(pkey, pdepth, ctx)) print outkey(pkey, pdepth, ctx) "\t" lit
+          if (interesting(pkey, pdepth, ctx) && scalar_ok(pkey, pdepth, ctx))
+            print outkey(pkey, pdepth, ctx) "\t" lit
           pend = 0; continue                      # leave delimiter for the main loop
         }
         i++
@@ -210,8 +225,9 @@ read_fields() {
   duration_ms=""; agent_type=""; skill=""; command=""; file_path=""
   subagent_type=""; interrupted=""; success=""; resolved_model=""
   effort_level=""; response_seen=""; session_source=""; reason=""
-  agent_model=""
-  local k v
+  agent_model=""; transcript_path=""
+  local k v model_id model_display_name
+  model_id=""; model_display_name=""
   while IFS="$(printf '\t')" read -r k v; do
     case "$k" in
       hook_event_name)    event="$v" ;;
@@ -223,6 +239,9 @@ read_fields() {
       source)             session_source="$v" ;;
       reason)             reason="$v" ;;
       model)              agent_model="$v" ;;
+      model_id)           model_id="$v" ;;
+      model_display_name) model_display_name="$v" ;;
+      transcript_path)    transcript_path="$v" ;;
       skill)              skill="$v" ;;
       command)            command="$v" ;;
       file_path)          file_path="$v" ;;
@@ -236,6 +255,37 @@ read_fields() {
   done <<EOF
 $1
 EOF
+  # Object-shaped model emits no top-level scalar; use id, then display_name.
+  if [ -z "$agent_model" ]; then
+    agent_model="${model_id:-$model_display_name}"
+  fi
+  # Escapes are left intact, so a Windows path arrives as C:\\Users\\...;
+  # Git Bash reads the forward-slash form.
+  case "$transcript_path" in
+    *\\\\*) transcript_path="$(printf '%s' "$transcript_path" | sed 's|\\\\|/|g')" ;;
+  esac
+}
+
+# Fallback when the envelope carried no `model` (PILOT-7497). Reads the LAST
+# assistant entry, so a mid-session /model switch is tracked. Subagent turns go
+# to <session>/subagents/agent-<id>.jsonl, so this yields the main-loop model.
+# 256KB tail: the last assistant entry is within ~28KB of EOF even at 5MB.
+# An absent, unreadable or not-yet-written transcript resolves to empty.
+resolve_agent_model() {
+  [ -z "$agent_model" ] || return 0
+  [ -n "$transcript_path" ] && [ -r "$transcript_path" ] || return 0
+  agent_model="$(tail -c 262144 -- "$transcript_path" 2>/dev/null | awk '
+    # Whitespace-tolerant: the transcript format is undocumented.
+    match($0, /"type"[ \t\r]*:[ \t\r]*"assistant"/) > 0 {
+      if (match($0, /"model"[ \t\r]*:[ \t\r]*"[^"]*"/)) {
+        v = substr($0, RSTART, RLENGTH)
+        sub(/^"model"[ \t\r]*:[ \t\r]*"/, "", v)
+        sub(/"$/, "", v)
+        # <synthetic> is a local turn (interrupt/error), not a model id.
+        if (v != "" && v != "<synthetic>") m = v
+      }
+    }
+    END { if (m != "") print m }' 2>/dev/null)"
 }
 
 # --- relevance gate --------------------------------------------------------
@@ -418,6 +468,7 @@ main() {
 
   payload="$(cat)"
   read_fields "$(printf '%s' "$payload" | extract_fields)"
+  resolve_agent_model
 
   # Map the hook event to a canonical eventName; drop unrecognized events.
   event_name="$(map_event_name)"

--- a/tests/scripts/test_send_telemetry_hook.py
+++ b/tests/scripts/test_send_telemetry_hook.py
@@ -97,6 +97,151 @@ def test_session_start_maps_and_carries_source():
     assert event["schemaVersion"] == 3
 
 
+@pytest.mark.parametrize(
+    ("model_value", "expected"),
+    [
+        pytest.param("claude-opus-5", "claude-opus-5", id="string"),
+        pytest.param(
+            {"id": "claude-opus-5", "display_name": "Opus 5"},
+            "claude-opus-5",
+            id="object-prefers-id",
+        ),
+        pytest.param(
+            {"display_name": "Opus 5"}, "Opus 5", id="object-falls-back-to-display-name"
+        ),
+        pytest.param({}, "", id="object-empty"),
+        pytest.param(None, "", id="null"),
+        pytest.param(True, "", id="bool"),
+        pytest.param(5, "", id="number"),
+        pytest.param(["claude-opus-5"], "", id="array"),
+    ],
+)
+def test_session_start_agent_model_is_shape_tolerant(model_value, expected):
+    """String or object (id, else display_name); any other shape -> "".
+    Both twins must agree — a [string] cast renders `True` / `@{id=...}`."""
+    event = run_hook(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "sess-1",
+            "source": "startup",
+            "model": model_value,
+        }
+    )
+    assert event["agent_model"] == expected
+
+
+def test_session_start_without_model_key_is_empty():
+    """An absent key must be "", never the literal "null"."""
+    event = run_hook(
+        {"hook_event_name": "SessionStart", "session_id": "sess-1", "source": "resume"}
+    )
+    assert event["agent_model"] == ""
+
+
+def _transcript(tmp_path, *entries):
+    """Write a JSONL transcript and return its path."""
+    p = tmp_path / "transcript.jsonl"
+    p.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+    return str(p)
+
+
+def _assistant(model):
+    return {"type": "assistant", "message": {"id": "m", "model": model, "content": []}}
+
+
+def test_agent_model_falls_back_to_transcript(tmp_path):
+    """Read from the last assistant entry when the envelope has no model."""
+    tp = _transcript(
+        tmp_path,
+        {"type": "user", "message": {"content": "hi"}},
+        _assistant("claude-opus-5"),
+    )
+    event = run_hook(
+        {
+            "hook_event_name": "Stop",
+            "session_id": "sess-1",
+            "transcript_path": tp,
+        }
+    )
+    assert event["agent_model"] == "claude-opus-5"
+
+
+def test_transcript_tracks_mid_session_model_change(tmp_path):
+    """The LAST entry reflects a mid-session /model switch — why this is
+    resolved per event rather than cached at session start."""
+    tp = _transcript(
+        tmp_path, _assistant("claude-haiku-4-5"), _assistant("claude-sonnet-5")
+    )
+    event = run_hook(
+        {"hook_event_name": "Stop", "session_id": "sess-1", "transcript_path": tp}
+    )
+    assert event["agent_model"] == "claude-sonnet-5"
+
+
+def test_envelope_model_wins_over_transcript(tmp_path):
+    """The payload is authoritative; the transcript is a fallback."""
+    tp = _transcript(tmp_path, _assistant("claude-opus-5"))
+    event = run_hook(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "sess-1",
+            "source": "startup",
+            "model": "claude-fable-5",
+            "transcript_path": tp,
+        }
+    )
+    assert event["agent_model"] == "claude-fable-5"
+
+
+def test_transcript_skips_synthetic_model(tmp_path):
+    """`<synthetic>` is a local turn, not a model id."""
+    tp = _transcript(
+        tmp_path, _assistant("claude-opus-5"), _assistant("<synthetic>")
+    )
+    event = run_hook(
+        {"hook_event_name": "Stop", "session_id": "sess-1", "transcript_path": tp}
+    )
+    assert event["agent_model"] == "claude-opus-5"
+
+
+def test_transcript_ignores_model_json_inside_message_content(tmp_path):
+    """Assistant content can contain JSON-shaped `"model":"..."`. The real key
+    precedes content and embedded quotes are escaped, so injection never wins."""
+    entry = _assistant("claude-opus-5")
+    entry["message"]["content"] = [
+        {"type": "text", "text": 'I wrote "model":"FAKE-INJECTED" in a file'}
+    ]
+    tp = _transcript(tmp_path, entry)
+    event = run_hook(
+        {"hook_event_name": "Stop", "session_id": "sess-1", "transcript_path": tp}
+    )
+    assert event["agent_model"] == "claude-opus-5"
+
+
+def test_missing_transcript_is_a_no_op(tmp_path):
+    """A cold SessionStart fires before the transcript exists -> ""."""
+    event = run_hook(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "sess-1",
+            "source": "startup",
+            "transcript_path": str(tmp_path / "does-not-exist.jsonl"),
+        }
+    )
+    assert event["agent_model"] == ""
+
+
+def test_transcript_path_is_never_forwarded(tmp_path):
+    """transcript_path embeds the project directory name; it must never be
+    forwarded."""
+    tp = _transcript(tmp_path, _assistant("claude-opus-5"))
+    event = run_hook(
+        {"hook_event_name": "Stop", "session_id": "sess-1", "transcript_path": tp}
+    )
+    assert not any("transcript" in k.lower() for k in event)
+    assert tp not in json.dumps(event)
+
+
 def test_session_end_carries_reason():
     event = run_hook(
         {


### PR DESCRIPTION
Fixes [PILOT-7497](https://uipath.atlassian.net/browse/PILOT-7497).

## The problem

`agent_model` was empty on **97% of `uip.skills.*` events** — 100% on `tool-use`, `completion` and `session-end`.

The ticket attributed this to the hook dropping an object-shaped `model`. That extractor limitation is real, but it is **not** the cause: Claude Code never sends an object. The actual cause is upstream omission.

Verified against Claude Code 2.1.236, both by capturing live hook payloads and by tracing the bundled implementation:

- The **shared envelope** behind `PreToolUse` / `PostToolUse` / `Stop` / `SessionEnd` / `Notification` has **no `model` key at all**. It reads `mainLoopModel` only to compute `effort.level`, then discards it. So `tool-use`, `completion` and `session-end` were 100% empty *by construction*.
- `SessionStart` is the only event that adds `model`, and it takes it as an **optional** argument. Only some call sites pass it — which predicts the observed rates exactly:

| SessionStart source | passes `model`? | measured |
|---|---|---|
| `compact` | yes | 8/8 — 100% |
| `startup` (interactive TUI) | yes | } 53/240 |
| `startup` (setup, resume-from, `--print`, json) | no | } — 22% |
| `resume`/`fork` (path A / path B) | no / yes | 3/102 — 3% |
| `clear` | no | 0/10 — 0% |

Per-install the split is bimodal (52 installs at 0%, 35 at 100%), consistent with *how* a user starts sessions — not payload variance.

## The fix

Resolve `agent_model` **per event**: envelope `model` first, then the last assistant entry of `transcript_path`.

Per-event rather than cached at session start, because a `/model` switch mid-session would otherwise attribute every later event to a stale model — replacing missing data with wrong data. Subagent turns are written to a separate `<session>/subagents/agent-<id>.jsonl`, so the main transcript yields the **main-loop** model; a subagent's own model already rides as `subagentModel` via `resolvedModel`.

A bounded 256KB tail keeps this O(1) in transcript size (~10ms, vs ~18ms for the hook's existing awk pass) — the last assistant entry sits within ~28KB of EOF even in a 5MB transcript. A cold `SessionStart` fires *before* the transcript exists, so that path still relies on the envelope and degrades to `""`.

**Projected coverage: 3% → ~93%.**

## Two twin divergences the parity suite did not cover

Both found by running the suite under a real `pwsh`, not by reading the code:

1. An **object-shaped `model`** was silently dropped by the bash twin but stringified to `@{id=…; display_name=…}` by the PowerShell one. Both now accept a string, or an object's `id` falling back to `display_name`.
2. **`Get-Prop` unrolled a single-element array on return**, so `["x"]` arrived as the string `x` where bash yielded `""`. Fixed with `return ,$value`. This affected *every* field, not just `model`.

String-typed fields now reject JSON literals in both twins, so `null` / `true` can no longer land as the text `"null"` / `"True"`. I checked 14 days of live data first: no field has ever carried a literal, and `effortLevel` is always a string — nothing observed changes.

## Testing

**68/68 pass, 34 per twin**, on the parametrized bash+pwsh suite. 9 new tests: transcript fallback, mid-session model change, payload-wins precedence, `<synthetic>` skip, injection resistance, missing transcript, and path non-leakage.

Beyond the suite, verified end-to-end on 6 real transcripts through the full hook — **bash and pwsh return identical values**, and a `completion` event that was previously always empty now emits `claude-opus-5`.

## Notes

- `transcript_path` is read locally only to resolve the model; a test asserts it never reaches the emitted payload, since it embeds the project directory name.
- Assistant content *can* contain `"model":"…"` text, but it arrives backslash-escaped and the real key precedes content on the line, so an injected value never wins. Pinned by a test.
- Both matchers tolerate JSON whitespace around colons rather than depending on the transcript staying byte-compact — the format is undocumented.
- Side benefit: the transcript records `claude-opus-5`, not `claude-opus-5[1m]`, so this also sidesteps the `san()` bracket mangling and the Bedrock ARN leak noted in the ticket, since both came from the envelope value. **`san()` itself is unchanged** — that half of the ticket is still open.
- No `SCHEMA_VERSION` bump: the key set is unchanged. Worth considering separately, since the dimension's meaning shifts from "model at session start" to "model for this event".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PILOT-7497]: https://uipath.atlassian.net/browse/PILOT-7497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ