### PR TITLE
test(uipath-maestro-flow): grade the native entity read in the billing advisories

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_discrepancy_detector.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_discrepancy_detector.py
@@ -145,7 +145,7 @@ def main():
 
     # ── 4. both filters computed, each from its own input ─────────────────────
     for label, node, wanted_input in ((ERP, erp, "invoiceNumber"), (CRM, crm, "accountNumber")):
-        assert_read_filters_input(node, shape, wanted_input, label)
+        assert_read_filters_input(node, shape, wanted_input, label, nodes)
 
     # ── 5. no answer is written in ─────────────────────────────────────────────
     for bad in FORBIDDEN_LITERALS:

--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_discrepancy_detector.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_discrepancy_detector.py
@@ -144,8 +144,11 @@ def main():
             fail(f"query {n['id']!r} is not reachable from the trigger {start!r}")
 
     # ── 4. both filters computed, each from its own input ─────────────────────
-    for label, node, wanted_input in ((ERP, erp, "invoiceNumber"), (CRM, crm, "accountNumber")):
-        assert_read_filters_input(node, shape, wanted_input, label, nodes)
+    for label, node, wanted_input, column in (
+        (ERP, erp, "invoiceNumber", "invoiceNumber"),
+        (CRM, crm, "accountNumber", "accountNumber"),
+    ):
+        assert_read_filters_input(node, shape, wanted_input, label, nodes, column=column)
 
     # ── 5. no answer is written in ─────────────────────────────────────────────
     for bad in FORBIDDEN_LITERALS:

--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_discrepancy_detector.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_discrepancy_detector.py
@@ -8,8 +8,9 @@ the trigger and rejoin at a merge — do not chain them"* — because
 `start → ERP → CRM → merge` satisfies it exactly while being a chain with a merge
 bolted on. So this gate asserts the SHAPE:
 
-1. **Two Data Service query nodes**, one on `BillingDisputeERP` and one on
-   `BillingDisputeCRM`, each with its entity in the PATH slot.
+1. **Two entity-read nodes**, in whichever of the two shapes the tenant's flags
+   left available, one on `BillingDisputeERP` and one on `BillingDisputeCRM`,
+   each with its entity in the slot that shape reads.
 2. **Exactly one `core.logic.merge`**, carrying the `bpmn:ParallelGateway`
    definition that makes it a join once deployed, fed by ≥2 distinct sources, and
    continuing downstream.
@@ -23,29 +24,32 @@ bolted on. So this gate asserts the SHAPE:
 6. **The outputs are declared with the contract's names and types**, and each is
    read from the side it belongs to (the tier from the CRM query, the matched
    invoice from the ERP query, the two numbers computed downstream of ERP).
-7. **The connection resolves to a connection/folder PAIR of distinct uuids** on
-   both query nodes.
+7. **Each read resolves to the tenant it is pointed at** — a connection/folder
+   PAIR of distinct uuids on the connector, and a whole entity scope on the
+   native node, which has no connection to resolve.
 
 Usage: advisory_billing_discrepancy_detector.py [<FlowName>.flow]
 """
-import re
 from collections import Counter, defaultdict
 
 from advisory_flow_utils import (
+    CONNECTOR_READ,
     LOOP_BACK_PORTS,
+    assert_read_filters_input,
+    assert_read_resolves,
     carries_literal,
     end_bindings,
+    entity_name,
+    entity_reads,
     fail,
     load_flow,
     node_dependencies,
-    query_references_input,
     source_depends_on,
     successful_end_ids,
     unwrap,
 )
 
 MERGE = "core.logic.merge"
-DS_PREFIX = "uipath.connector.uipath-uipath-dataservice."
 ERP, CRM = "BillingDisputeERP", "BillingDisputeCRM"
 # The measured answers (live 2026-07-31). A flow may not carry any of them.
 FORBIDDEN_LITERALS = ["1610", "2590", "4200", "Enterprise"]
@@ -64,32 +68,20 @@ def main():
     edges = f.get("edges") or []
     types_seen = sorted({str(n.get("type")) for n in nodes})
 
-    # ── 1. two Data Service query nodes, one per entity ───────────────────────
-    ds = [n for n in nodes if str(n.get("type", "")).startswith(DS_PREFIX)]
+    # ── 1. two entity-read nodes, one per entity ──────────────────────────────
+    shape, ds = entity_reads(nodes)
     if len(ds) != 2:
-        fail(f"expected exactly TWO Data Service query nodes (ERP + CRM), found {len(ds)}; node types: {types_seen}")
-    for n in ds:
-        if not n["type"].endswith(".query-entity-records"):
-            fail(f"Data Service node {n['id']!r} is {n['type']!r}; the lookup is query-entity-records")
-
-    def detail(n):
-        return (n.get("inputs") or {}).get("detail") or {}
-
-    def entity_of(n):
-        p = {k: unwrap(v) for k, v in (detail(n).get("pathParameters") or {}).items()}
-        if "entityName" not in p:
-            q = {k: unwrap(v) for k, v in (detail(n).get("queryParameters") or {}).items()}
-            fail(
-                f"query node {n['id']!r} has pathParameters {sorted(p)}; `entityName` belongs in the PATH "
-                f"slot — it is the {{entityName}} of /v2/{{entityName}}/qer. queryParameters: {sorted(q)}"
-            )
-        return str(p["entityName"]).strip()
+        fail(f"expected exactly TWO entity-read nodes (ERP + CRM), found {len(ds)}; node types: {types_seen}")
+    if shape == CONNECTOR_READ:
+        for n in ds:
+            if not n["type"].endswith(".query-entity-records"):
+                fail(f"Data Service node {n['id']!r} is {n['type']!r}; the lookup is query-entity-records")
 
     by_entity = {}
     for n in ds:
-        e = entity_of(n)
+        e = entity_name(n, shape)
         if e in by_entity:
-            fail(f"both query nodes address {e!r}; the scenario needs one {ERP} and one {CRM}")
+            fail(f"both reads address {e!r}; the scenario needs one {ERP} and one {CRM}")
         by_entity[e] = n
     missing = [e for e in (ERP, CRM) if e not in by_entity]
     if missing:
@@ -153,17 +145,7 @@ def main():
 
     # ── 4. both filters computed, each from its own input ─────────────────────
     for label, node, wanted_input in ((ERP, erp, "invoiceNumber"), (CRM, crm, "accountNumber")):
-        q = {k: unwrap(v) for k, v in (detail(node).get("queryParameters") or {}).items()}
-        if "queryExpression" not in q:
-            fail(f"the {label} query sets no queryExpression; queryParameters: {sorted(q)}")
-        expr = str(q["queryExpression"])
-        if not query_references_input(detail(node), wanted_input):
-            fail(
-                f"the {label} queryExpression is {expr!r} and its filterVariables do not reference "
-                f"{wanted_input!r} — each lookup must filter on its own flow input"
-            )
-        if "'" not in expr:
-            fail(f"the {label} queryExpression is {expr!r} — a CEQL string literal has to be single-quoted")
+        assert_read_filters_input(node, shape, wanted_input, label)
 
     # ── 5. no answer is written in ─────────────────────────────────────────────
     for bad in FORBIDDEN_LITERALS:
@@ -209,26 +191,15 @@ def main():
     for name in ("totalOvercharge", "discrepancyCount"):
         sourced_from(name, erp["id"], f"the contracted amount it is computed from lives in the {ERP} rows")
 
-    # ── 7. the resolved connection: two DISTINCT uuids, on BOTH query nodes ───
-    UUID = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-", re.ASCII)
-    for label, node in ((ERP, erp), (CRM, crm)):
-        conn = str(unwrap(detail(node).get("connectionId")) or "")
-        folder = str(unwrap(detail(node).get("connectionFolderKey")) or "")
-        for attr, v in (("connectionId", conn), ("connectionFolderKey", folder)):
-            if not UUID.match(v) or re.match(r"^0{8}-0{4}-", v):
-                fail(f"the {label} query's detail.{attr} is {v!r}, not a real uuid")
-        if conn == folder:
-            fail(
-                f"the {label} query's detail.connectionId and detail.connectionFolderKey are the SAME uuid "
-                f"({conn}) — the folder binding needs the connection's FOLDER key, not its id (measured: the "
-                f"live dispatch then sends the folder key as --connection-id and answers 401)"
-            )
+    # ── 7. each read resolves to the tenant it is pointed at ──────────────────
+    resolutions = [assert_read_resolves(node, shape, label, f) for label, node in ((ERP, erp), (CRM, crm))]
 
     print(
-        f"{len(nodes)} nodes; {ERP}={erp['id']!r} and {CRM}={crm['id']!r} on mutually unreachable branches "
-        f"from {start!r}, converging on {MERGE} {mid!r} (bpmn:ParallelGateway, {len(sources)} sources, "
-        f"continues downstream); both filters computed from their own inputs; no answer literals; "
-        f"outputs {sorted(OUT_CONTRACT)} each read from its own side"
+        f"{len(nodes)} nodes; {shape} reads {ERP}={erp['id']!r} and {CRM}={crm['id']!r} on mutually "
+        f"unreachable branches from {start!r}, converging on {MERGE} {mid!r} (bpmn:ParallelGateway, "
+        f"{len(sources)} sources, continues downstream); both filters computed from their own inputs; "
+        f"no answer literals; outputs {sorted(OUT_CONTRACT)} each read from its own side; "
+        f"{'; '.join(resolutions)}"
     )
 
 

--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_dispute_resolution.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_dispute_resolution.py
@@ -7,13 +7,24 @@ that the flow declares at least two `out` variables. This file asserts only the
 three things v1 CANNOT see — each one a contract measured on the product runtime,
 each one a defect this campaign already paid for once.
 
-1. **The connector's CONNECTION bindings carry a real key.** The platform resolves
-   an Integration Service connection through the flow's native `bindings[]` or
-   `resources[]` declarations, by the names the definition declares. A pair
-   that is missing, or that carries a symbolic name instead of the tenant's key,
-   deploys and then faults with `[102010] Integration Services invalid value in
-   input`. That is board row G-19, and it is invisible to every offline rung
-   except this one: no local executor reads `bindings[]`.
+1. **The two ERP/CRM lookups resolve to the tenant they are pointed at**, in
+   whichever of the two entity-read shapes the tenant's flags left available.
+   Both halves are invisible to every offline rung except this one: no local
+   executor reads `bindings[]`.
+
+   On the **connector**, the platform resolves an Integration Service connection
+   through the flow's native `bindings[]` or `resources[]` declarations, by the
+   names the definition declares. A pair that is missing, or that carries a
+   symbolic name instead of the tenant's key, deploys and then faults with
+   `[102010] Integration Services invalid value in input`. That is board row
+   G-19.
+
+   The **native** `core.datafabric.read` node needs no Integration Service
+   connection and no `bindings[]` connection row at all, so demanding one fails
+   the better build: the 2026-09-11 run scored 0.727 on a flow that validated,
+   debugged green, and returned the right answer. What is checkable there is the
+   entity scope — a `_folderKey` without `_resourceKey` and both
+   `resource: "Entity"` rows packages and breaks on deploy.
 
 2. **The IxP node's `fileRef` is a plain `=js:$vars.…` string.** The expression
    ENVELOPE (`{type:'jsExpression', …}`) is the file format's general spelling and
@@ -38,7 +49,10 @@ import json
 import re
 
 from advisory_flow_utils import (
+    NATIVE_READ,
+    assert_read_resolves,
     connection_binding_values,
+    entity_reads,
     fail,
     is_real_uuid,
     load_flow,
@@ -75,27 +89,39 @@ def main():
     _, flow, nodes = load_flow("BillingDisputeResolution.flow")
     agents = {n["id"] for n in nodes if str(n.get("type") or "") == AGENT_TYPE}
 
-    # ── 1. the connection bindings the platform resolves the connector through ──
-    conn = connection_binding_values(flow)
-    if not conn:
+    # ── 1. the ERP/CRM lookups resolve to the tenant they are pointed at ──────
+    shape, reads = entity_reads(nodes)
+    if not reads:
         fail(
-            "the flow declares NO `connection` binding. The two Data Service lookups are Integration "
-            "Service calls, and the platform resolves their connection through the flow's native "
-            "bindings declaration — without the pair it deploys and faults with [102010] Integration Services "
-            "invalid value in input. (Give the connector its connection + folder: either a `bindings.json` "
-            "mapping your symbolic names to the tenant's keys, or the keys inline.)"
+            "the flow has no entity-read node, so nothing performs the ERP/CRM lookups the pipeline "
+            "is built on (neither `uipath.connector.uipath-uipath-dataservice.*` nor "
+            "`core.datafabric.read`)"
         )
-    bad = [(identifier, values) for identifier, values in conn if not values or any(not is_real_uuid(v) for v in values)]
-    if bad:
-        fail(
-            "connection binding(s) "
-            + ", ".join(f"{identifier!r}={json.dumps(values)}" for identifier, values in bad)
-            + " do not carry a real tenant key (a uuid, and not a zero-prefixed stub). The platform "
-            "substitutes these by name into the connector node, so a symbolic name or a placeholder "
-            "reaches Integration Services verbatim -> [102010]. Look the connection up with "
-            "`uip is connections list --all-folders` and use its `Id` / `FolderKey`."
-        )
-    print(f"OK: {len(conn)} connection binding(s), each carrying a real tenant key")
+
+    if shape == NATIVE_READ:
+        scopes = [assert_read_resolves(node, shape, str(node.get("id")), flow) for node in reads]
+        print(f"OK: {len(reads)} native entity read(s), each resolved: {'; '.join(scopes)}")
+    else:
+        conn = connection_binding_values(flow)
+        if not conn:
+            fail(
+                "the flow declares NO `connection` binding. The two Data Service lookups are Integration "
+                "Service calls, and the platform resolves their connection through the flow's native "
+                "bindings declaration — without the pair it deploys and faults with [102010] Integration Services "
+                "invalid value in input. (Give the connector its connection + folder: either a `bindings.json` "
+                "mapping your symbolic names to the tenant's keys, or the keys inline.)"
+            )
+        bad = [(identifier, values) for identifier, values in conn if not values or any(not is_real_uuid(v) for v in values)]
+        if bad:
+            fail(
+                "connection binding(s) "
+                + ", ".join(f"{identifier!r}={json.dumps(values)}" for identifier, values in bad)
+                + " do not carry a real tenant key (a uuid, and not a zero-prefixed stub). The platform "
+                "substitutes these by name into the connector node, so a symbolic name or a placeholder "
+                "reaches Integration Services verbatim -> [102010]. Look the connection up with "
+                "`uip is connections list --all-folders` and use its `Id` / `FolderKey`."
+            )
+        print(f"OK: {len(conn)} connection binding(s), each carrying a real tenant key")
 
     # ── 2. the IxP fileRef spelling `uip maestro flow validate` requires ───────
     ixp = [n for n in nodes if str(n.get("type") or "").startswith("uipath.ixp.")]

--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_invoice_lookup.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_invoice_lookup.py
@@ -79,7 +79,7 @@ def main():
         fail(f"the read addresses {entity!r}, not {ENTITY!r} — the entity the task names")
 
     # ── 3. the FILTER is computed from the flow's input, not a constant ───────
-    assert_read_filters_input(q, shape, "invoiceNumber", "invoice")
+    assert_read_filters_input(q, shape, "invoiceNumber", "invoice", nodes)
 
     # ── 4. the ANSWER is nowhere in the flow, and neither is a lookup table ───
     if carries_literal(f, CANONICAL):

--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_invoice_lookup.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_invoice_lookup.py
@@ -7,9 +7,10 @@ v1's own checker asserts one structural thing (`assert_flow_has_node_type
 ladder covers the behaviour half in its own rungs (`expect` ×3 offline, `live`
 ×1); this file asserts what neither can:
 
-1. **The query is a Data Service connector node**, exactly one of them, and its
-   `entityName` really went to the PATH slot (the `{entityName}` of
-   `/v2/{entityName}/qer`). A `body` placement compiles and 404s live on an
+1. **The read is one entity-read node**, in whichever of the two shapes the
+   tenant's flags left available, and its entity really went to the slot that
+   shape reads. On the connector that is the PATH slot (the `{entityName}` of
+   `/v2/{entityName}/qer`) — a `body` placement compiles and 404s live on an
    unsubstituted template.
 2. **The filter is COMPUTED, not constant.** This is the anti-hardcode gate, and
    it is the whole reason the three offline `expect` rungs mean anything: a flow
@@ -23,23 +24,27 @@ ladder covers the behaviour half in its own rungs (`expect` ×3 offline, `live`
    every behaviour rung and generalises to nothing.
 4. **The outputs are READ FROM the query step**, and declared with the contract's
    names and types (`matchedInvoiceNumber` string, `lineItemCount` number).
-5. **The connection bindings are a pair** (ConnectionId + FolderKey) and the
-   folder binding does not carry the CONNECTION id — measured while writing this
-   card: a bindings.json whose FolderKey entry pointed at the connection id
-   collapsed both entries into one at FIL emission and the live dispatch sent the
-   FOLDER key as `--connection-id`, answering 401.
+5. **The read resolves to the tenant it is pointed at.** On the connector that
+   is a ConnectionId + FolderKey pair where the folder binding does not carry the
+   CONNECTION id — measured while writing this card: a bindings.json whose
+   FolderKey entry pointed at the connection id collapsed both entries into one
+   at FIL emission and the live dispatch sent the FOLDER key as
+   `--connection-id`, answering 401. The native node has no connection to
+   resolve, so what is checkable there is its entity scope.
 
 Usage: advisory_billing_invoice_lookup.py [<FlowName>.flow]
 """
-import re
-
 from advisory_flow_utils import (
+    CONNECTOR_READ,
+    assert_read_filters_input,
+    assert_read_resolves,
     carries_literal,
     end_bindings,
+    entity_name,
+    entity_reads,
     fail,
     load_flow,
     node_dependencies,
-    query_references_input,
     source_depends_on,
     successful_end_ids,
     unwrap,
@@ -49,7 +54,6 @@ CANONICAL = "MCS-2026-04872"
 # The three malformed forms the offline rungs drive. A flow may not carry any of
 # them as a literal.
 RAW_INPUTS = ["2026-04872", "mcs-2026-04872"]
-DS_TYPE_PREFIX = "uipath.connector.uipath-uipath-dataservice."
 ENTITY = "BillingDisputeERP"
 
 
@@ -57,46 +61,25 @@ def main():
     _, f, nodes = load_flow("BillingInvoiceLookup.flow")
     types_seen = sorted({str(n.get("type")) for n in nodes})
 
-    # ── 1. exactly one Data Service query node ────────────────────────────────
-    ds = [n for n in nodes if str(n.get("type", "")).startswith(DS_TYPE_PREFIX)]
-    if len(ds) != 1:
-        fail(f"expected exactly ONE Data Service connector node, found {len(ds)}; node types: {types_seen}")
-    q = ds[0]
-    if not q["type"].endswith(".query-entity-records"):
+    # ── 1. exactly one entity-read node, in whichever shape the tenant left ───
+    shape, reads = entity_reads(nodes)
+    if len(reads) != 1:
+        fail(f"expected exactly ONE entity-read node, found {len(reads)}; node types: {types_seen}")
+    q = reads[0]
+    if shape == CONNECTOR_READ and not q["type"].endswith(".query-entity-records"):
         fail(f"the Data Service node is {q['type']!r}; the lookup is the query-entity-records operation")
     # A raw HTTP call would satisfy every behaviour rung, so name it out.
     http = [n for n in nodes if str(n.get("type", "")) in ("core.action.http", "uipath.connector.uipath-uipath-http.http-request")]
     if http:
         fail(f"the flow calls Data Service over raw HTTP ({[n['id'] for n in http]}); use the connector action")
 
-    detail = (q.get("inputs") or {}).get("detail") or {}
-    pathp = {k: unwrap(v) for k, v in (detail.get("pathParameters") or {}).items()}
-    queryp = {k: unwrap(v) for k, v in (detail.get("queryParameters") or {}).items()}
-
-    # ── 2. the entity is a PATH parameter, and it is the seeded entity ────────
-    if "entityName" not in pathp:
-        fail(
-            f"the query node's pathParameters are {sorted(pathp)}; `entityName` belongs there — "
-            f"it is the {{entityName}} of /v2/{{entityName}}/qer. queryParameters: {sorted(queryp)}"
-        )
-    if str(pathp["entityName"]).strip() != ENTITY:
-        fail(f"entityName is {pathp['entityName']!r}, not {ENTITY!r} — the entity the task names")
+    # ── 2. the entity slot carries the seeded entity ──────────────────────────
+    entity = entity_name(q, shape)
+    if entity != ENTITY:
+        fail(f"the read addresses {entity!r}, not {ENTITY!r} — the entity the task names")
 
     # ── 3. the FILTER is computed from the flow's input, not a constant ───────
-    if "queryExpression" not in queryp:
-        fail(f"the query node sets no queryExpression; queryParameters: {sorted(queryp)}")
-    expr = str(queryp["queryExpression"])
-    if not query_references_input(detail, "invoiceNumber"):
-        fail(
-            f"queryExpression is {expr!r}, likely a hand-authored =js: concat. filterVariables "
-            f"has no placeholder for invoiceNumber. Author the filter via --detail.filter so "
-            f"the CLI compiles it: dynamic operands become {{var_...}} placeholders in "
-            f"filterVariables"
-        )
-    # A CEQL string literal must be single-quoted; an unquoted RHS parses as
-    # subtraction server-side and 400s (the `sql-where` grammar fil-run enforces).
-    if "'" not in expr:
-        fail(f"queryExpression is {expr!r} — a CEQL string literal has to be single-quoted")
+    assert_read_filters_input(q, shape, "invoiceNumber", "invoice")
 
     # ── 4. the ANSWER is nowhere in the flow, and neither is a lookup table ───
     if carries_literal(f, CANONICAL):
@@ -144,40 +127,17 @@ def main():
                 f"depends on $vars.{q['id']}.output — the value has to come FROM the query step"
             )
 
-    # ── 7. the RESOLVED connection: two DISTINCT uuids on the node ────────────
-    # The compiler resolves `bindings.json`'s symbolic `connection`/`folder` into
-    # the node's own `detail`, so that is where the outcome is checkable (the
-    # emitted `.flow` carries no `bindings[]` of its own for a connector — the
-    # separate bindings-hygiene criterion covers the file the author wrote).
-    #
-    # The failure this catches is not hypothetical: measured while writing this
-    # card, a `bindings.json` whose FolderKey entry carried the CONNECTION id
-    # collapsed both entries into one at FIL emission, and the live dispatch sent
-    # the folder key as `--connection-id` → `401 Unauthorized … invalid Element
-    # token`. Two distinct uuids is the checkable form of "the pair is right".
-    conn_id = str(unwrap(detail.get("connectionId")) or "")
-    folder = str(unwrap(detail.get("connectionFolderKey")) or "")
-    UUID = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-", re.ASCII)
-    for label, v in (("connectionId", conn_id), ("connectionFolderKey", folder)):
-        if not UUID.match(v):
-            fail(
-                f"the query node's detail.{label} is {v!r}, not a uuid — `bindings.json` has to name "
-                f"the real Data Fabric connection and its folder (uip is connections list --all-folders)"
-            )
-        if re.match(r"^0{8}-0{4}-", v):
-            fail(f"the query node's detail.{label} is the stub uuid {v!r}")
-    if conn_id == folder:
-        fail(
-            f"detail.connectionId and detail.connectionFolderKey are the SAME uuid ({conn_id}) — the "
-            f"folder binding needs the connection's FOLDER key, not its id. Measured: the two collapse "
-            f"into one binding at FIL emission and the live dispatch sends the folder key as "
-            f"--connection-id (401 Unauthorized)"
-        )
+    # ── 7. the read resolves to the tenant it is pointed at ───────────────────
+    # For the connector, the compiler resolves `bindings.json`'s symbolic
+    # `connection`/`folder` into the node's own `detail`, so that is where the
+    # outcome is checkable (the emitted `.flow` carries no `bindings[]` of its own
+    # for a connector — the separate bindings-hygiene criterion covers the file the
+    # author wrote). The native node resolves no connection at all.
+    resolution = assert_read_resolves(q, shape, "invoice", f)
 
     print(
-        f"{len(nodes)} nodes; DS query {q['id']} entityName={pathp['entityName']!r} (path) "
-        f"queryExpression computed from $vars; outputs read from {q['id']}; "
-        f"connection={conn_id[:8]}… folder={folder[:8]}…"
+        f"{len(nodes)} nodes; {shape} read {q['id']} on {entity!r}; filter computed from $vars; "
+        f"outputs read from {q['id']}; {resolution}"
     )
 
 

--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_invoice_lookup.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_invoice_lookup.py
@@ -79,7 +79,7 @@ def main():
         fail(f"the read addresses {entity!r}, not {ENTITY!r} — the entity the task names")
 
     # ── 3. the FILTER is computed from the flow's input, not a constant ───────
-    assert_read_filters_input(q, shape, "invoiceNumber", "invoice", nodes)
+    assert_read_filters_input(q, shape, "invoiceNumber", "invoice", nodes, column="invoiceNumber")
 
     # ── 4. the ANSWER is nowhere in the flow, and neither is a lookup table ───
     if carries_literal(f, CANONICAL):

--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_flow_utils.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_flow_utils.py
@@ -210,11 +210,10 @@ def entity_reads(nodes: Iterable[dict[str, Any]]) -> tuple[str, list[dict[str, A
         and str(node.get("type") or "").endswith(CONNECTOR_READ_OPS)
     ]
     native = [node for node in nodes if str(node.get("type") or "") == NATIVE_READ_TYPE]
-    connector_reads = connector
-    if connector_reads and native:
+    if connector and native:
         fail(
             f"the flow mixes both entity-read shapes — connector "
-            f"{[node.get('id') for node in connector_reads]} and native "
+            f"{[node.get('id') for node in connector]} and native "
             f"{[node.get('id') for node in native]}. Availability decides one shape per "
             f"flow; two means one set of reads was left behind"
         )

--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_flow_utils.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_flow_utils.py
@@ -112,19 +112,22 @@ def node_dependencies(nodes: Iterable[dict[str, Any]]) -> dict[str, set[str]]:
     }
 
 
-def source_depends_on(value: Any, producer: str, dependencies: dict[str, set[str]]) -> bool:
-    """Follow exact `$vars.<node>` references through any number of reader nodes."""
+def transitive_refs(value: Any, dependencies: dict[str, set[str]]) -> set[str]:
+    """Every node id reachable from a value's `$vars.<node>` references."""
     pending = list(value_refs(value))
     seen: set[str] = set()
     while pending:
         current = pending.pop()
-        if current == producer:
-            return True
         if current in seen:
             continue
         seen.add(current)
         pending.extend(dependencies.get(current, ()))
-    return False
+    return seen
+
+
+def source_depends_on(value: Any, producer: str, dependencies: dict[str, set[str]]) -> bool:
+    """Follow exact `$vars.<node>` references through any number of reader nodes."""
+    return producer in transitive_refs(value, dependencies)
 
 
 def references_field(value: Any, field: str) -> bool:
@@ -155,8 +158,15 @@ def query_references_input(detail: dict[str, Any], field: str) -> bool:
 # checkers; keep the two in step.
 CONNECTOR_READ = "connector"
 NATIVE_READ = "native"
-CONNECTOR_READ_PREFIX = "uipath.connector.uipath-uipath-dataservice."
+CONNECTOR_NODE_PREFIX = "uipath.connector."
+CONNECTOR_READ_PREFIX = f"{CONNECTOR_NODE_PREFIX}uipath-uipath-dataservice."
 NATIVE_READ_TYPE = "core.datafabric.read"
+# The connector operations that READ. The prefix above covers the whole Data
+# Service family, writes included, and each native op has its own tenant flag
+# (planning.md — Node types), so `read-entity` on with `create-entity` off is a
+# real configuration: a native read beside a connector write. Only a connector
+# READ alongside a native one is a flow with two sets of the same reads.
+CONNECTOR_READ_OPS = (".query-entity-records", ".get-entity-record-by-id")
 
 # Operators the native serializer can emit, spelled as the file spells them
 # (data-fabric/impl.md — Filters). There is deliberately no `not in`, `not
@@ -196,10 +206,14 @@ def entity_reads(nodes: Iterable[dict[str, Any]]) -> tuple[str, list[dict[str, A
         if str(node.get("type") or "").startswith(CONNECTOR_READ_PREFIX)
     ]
     native = [node for node in nodes if str(node.get("type") or "") == NATIVE_READ_TYPE]
-    if connector and native:
+    connector_reads = [
+        node for node in connector
+        if str(node.get("type") or "").endswith(CONNECTOR_READ_OPS)
+    ]
+    if connector_reads and native:
         fail(
             f"the flow mixes both entity-read shapes — connector "
-            f"{[node.get('id') for node in connector]} and native "
+            f"{[node.get('id') for node in connector_reads]} and native "
             f"{[node.get('id') for node in native]}. Availability decides one shape per "
             f"flow; two means one set of reads was left behind"
         )
@@ -246,7 +260,13 @@ def native_filter_rows(node: dict[str, Any]) -> list[dict[str, Any]]:
     return list(walk(entity_config(node).get("_filters")))
 
 
-def assert_read_filters_input(node: dict[str, Any], shape: str, field: str, label: str) -> None:
+def assert_read_filters_input(
+    node: dict[str, Any],
+    shape: str,
+    field: str,
+    label: str,
+    nodes: Iterable[dict[str, Any]] = (),
+) -> None:
     """Assert the read filters on ``field``, computed, in a form the server accepts.
 
     The computed half is the anti-hardcode gate: a filter that writes the answer
@@ -259,14 +279,20 @@ def assert_read_filters_input(node: dict[str, Any], shape: str, field: str, labe
     if shape == NATIVE_READ:
         rows = native_filter_rows(node)
         if not rows:
+            mode = str(unwrap(entity_config(node).get("resultMode")) or "").strip()
+            consequence = (
+                "faults on the over-match as soon as the entity holds more than one row"
+                if mode == "single"
+                else "returns the first 100 rows in arbitrary order, not the record the flow asked for"
+            )
             fail(
                 f"the {label} read sets no `entityConfig._filters` rows — an unfiltered "
-                f"`resultMode: \"multiple\"` read returns the first 100 rows in arbitrary order, "
-                f"not the record the flow asked for"
+                f"`resultMode: {mode or 'multiple'!r}` read {consequence}"
             )
-        if not read_references_input(node, shape, field):
+        if not read_references_input(node, shape, field, nodes):
             fail(
-                f"no {label} filter row takes its value from $vars.…{field} — the rows are "
+                f"no {label} filter row reaches $vars.…{field}, directly or through a node it "
+                f"reads — the rows are "
                 f"{[{'field': row.get('field'), 'value': unwrap(row.get('value'))} for row in rows]!r}. "
                 f"Each lookup must filter on its own flow input; a literal there is the answer "
                 f"written in"
@@ -297,7 +323,7 @@ def assert_read_filters_input(node: dict[str, Any], shape: str, field: str, labe
     if "queryExpression" not in query:
         fail(f"the {label} query sets no queryExpression; queryParameters: {sorted(query)}")
     expression = str(query["queryExpression"])
-    if not read_references_input(node, shape, field):
+    if not read_references_input(node, shape, field, nodes):
         fail(
             f"the {label} queryExpression is {expression!r} and its filterVariables do not reference "
             f"{field!r} — each lookup must filter on its own flow input. Author the filter via "
@@ -311,15 +337,42 @@ def assert_read_filters_input(node: dict[str, Any], shape: str, field: str, labe
         )
 
 
-def read_references_input(node: dict[str, Any], shape: str, field: str) -> bool:
-    """True when the read's filter takes its value from the named flow input."""
-    if shape == NATIVE_READ:
-        return any(
-            "$vars." in str(unwrap(row.get("value")) or "")
-            and references_field(row.get("value"), field)
-            for row in native_filter_rows(node)
-        )
-    return query_references_input(read_detail(node), field)
+def read_references_input(
+    node: dict[str, Any],
+    shape: str,
+    field: str,
+    nodes: Iterable[dict[str, Any]] = (),
+) -> bool:
+    """True when the read's filter reaches the named flow input.
+
+    A filter row may read the input directly, or read a node that does: the
+    prompts ask for normalisation before the lookup ("trim, uppercase, prepend
+    `MCS-`"), and a native row is a single `value`, so a Script hop is at least
+    as natural there as the connector's inline template. The same advisory
+    already tolerates the hop for outputs, and for the same reason.
+    """
+    if shape != NATIVE_READ:
+        return query_references_input(read_detail(node), field)
+
+    nodes = list(nodes)
+    inputs_by_id = {
+        str(other.get("id")): json.dumps(other.get("inputs") or {}, sort_keys=True)
+        for other in nodes
+        if other.get("id")
+    }
+    dependencies = node_dependencies(nodes)
+    for row in native_filter_rows(node):
+        value = row.get("value")
+        if "$vars." not in str(unwrap(value) or ""):
+            continue
+        if references_field(value, field):
+            return True
+        if any(
+            references_field(inputs_by_id.get(upstream, ""), field)
+            for upstream in transitive_refs(value, dependencies)
+        ):
+            return True
+    return False
 
 
 def assert_read_resolves(node: dict[str, Any], shape: str, label: str, flow: dict[str, Any]) -> str:
@@ -340,9 +393,15 @@ def assert_read_resolves(node: dict[str, Any], shape: str, label: str, flow: dic
     """
     if shape == NATIVE_READ:
         config = entity_config(node)
+        if "_folderKey" not in config:
+            return "tenant-scoped entity (no connection, no binding row)"
         folder = str(unwrap(config.get("_folderKey")) or "").strip()
         if not folder:
-            return "tenant-scoped entity (no connection, no binding row)"
+            fail(
+                f"the {label} read declares `_folderKey` but leaves it blank ({config.get('_folderKey')!r}). "
+                f"It is the key's PRESENCE that switches the emitted target to the folder-qualified form, "
+                f"so a blank one emits that form with no folder. Omit the key to stay tenant-scoped"
+            )
 
         key = str(unwrap(config.get("_resourceKey")) or unwrap(config.get("_entityKey")) or "").strip()
         if not key:

--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_flow_utils.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_flow_utils.py
@@ -145,6 +145,250 @@ def query_references_input(detail: dict[str, Any], field: str) -> bool:
     )
 
 
+# ── entity reads: two shapes, tenant availability decides which ──────────────
+# The `uipath-uipath-dataservice` connector activity and the native
+# `core.datafabric.read` node both read entity records. The native flags default
+# to off, so the connector is the working path until `registry get` proves
+# otherwise; where the tenant does have them the native node is "the better
+# build" (data-fabric/planning.md — Native node vs Data Service connector).
+# `flow_check.ENTITY_QUERY_HINTS` gates the same two shapes for the non-advisory
+# checkers; keep the two in step.
+CONNECTOR_READ = "connector"
+NATIVE_READ = "native"
+CONNECTOR_READ_PREFIX = "uipath.connector.uipath-uipath-dataservice."
+NATIVE_READ_TYPE = "core.datafabric.read"
+
+# Operators the native serializer can emit, spelled as the file spells them
+# (data-fabric/impl.md — Filters). There is deliberately no `not in`, `not
+# contains`, or null check, and an operator outside this set refuses the WHOLE
+# query: the node emits nothing and every downstream `$vars` reference breaks.
+NATIVE_FILTER_OPERATORS = {
+    "=",
+    "!=",
+    ">",
+    ">=",
+    "<",
+    "<=",
+    "contains",
+    "starts with",
+    "ends with",
+    "in",
+}
+
+
+def entity_config(node: dict[str, Any]) -> dict[str, Any]:
+    """The native read's single input container (data-fabric/impl.md)."""
+    config = (node.get("inputs") or {}).get("entityConfig")
+    return config if isinstance(config, dict) else {}
+
+
+def read_detail(node: dict[str, Any]) -> dict[str, Any]:
+    """The connector activity's `detail` envelope."""
+    detail = (node.get("inputs") or {}).get("detail")
+    return detail if isinstance(detail, dict) else {}
+
+
+def entity_reads(nodes: Iterable[dict[str, Any]]) -> tuple[str, list[dict[str, Any]]]:
+    """Return ``(shape, reads)`` for the nodes that read entity records."""
+    nodes = list(nodes)
+    connector = [
+        node for node in nodes
+        if str(node.get("type") or "").startswith(CONNECTOR_READ_PREFIX)
+    ]
+    native = [node for node in nodes if str(node.get("type") or "") == NATIVE_READ_TYPE]
+    if connector and native:
+        fail(
+            f"the flow mixes both entity-read shapes — connector "
+            f"{[node.get('id') for node in connector]} and native "
+            f"{[node.get('id') for node in native]}. Availability decides one shape per "
+            f"flow; two means one set of reads was left behind"
+        )
+    return (NATIVE_READ, native) if native else (CONNECTOR_READ, connector)
+
+
+def entity_name(node: dict[str, Any], shape: str) -> str:
+    """The entity a read addresses. Fails naming the slot the name belongs in."""
+    if shape == NATIVE_READ:
+        config = entity_config(node)
+        name = str(unwrap(config.get("entityName")) or "").strip()
+        if not name:
+            fail(
+                f"read node {node.get('id')!r} sets no `inputs.entityConfig.entityName`; "
+                f"entityConfig keys: {sorted(config)}"
+            )
+        return name
+
+    detail = read_detail(node)
+    path = {key: unwrap(value) for key, value in (detail.get("pathParameters") or {}).items()}
+    if "entityName" not in path:
+        query = {key: unwrap(value) for key, value in (detail.get("queryParameters") or {}).items()}
+        fail(
+            f"query node {node.get('id')!r} has pathParameters {sorted(path)}; `entityName` "
+            f"belongs in the PATH slot — it is the {{entityName}} of /v2/{{entityName}}/qer. "
+            f"queryParameters: {sorted(query)}"
+        )
+    return str(path["entityName"]).strip()
+
+
+def native_filter_rows(node: dict[str, Any]) -> list[dict[str, Any]]:
+    """Root filter rows plus every nested group's rows (impl.md — Filters)."""
+
+    def walk(block: Any) -> Iterable[dict[str, Any]]:
+        if isinstance(block, list):  # the legacy bare-array form, still read
+            yield from (row for row in block if isinstance(row, dict))
+            return
+        if not isinstance(block, dict):
+            return
+        yield from (row for row in (block.get("rows") or []) if isinstance(row, dict))
+        for group in block.get("groups") or []:
+            yield from walk(group)
+
+    return list(walk(entity_config(node).get("_filters")))
+
+
+def assert_read_filters_input(node: dict[str, Any], shape: str, field: str, label: str) -> None:
+    """Assert the read filters on ``field``, computed, in a form the server accepts.
+
+    The computed half is the anti-hardcode gate: a filter that writes the answer
+    in satisfies every behaviour rung while querying nothing. The accepted half
+    is a refusal the offline rungs cannot see — CEQL 400s on an unquoted string
+    literal, and the native serializer refuses the WHOLE query on a blank
+    expression, a `$self` reference, or an operator it cannot emit, which leaves
+    the node with no output and breaks every downstream `$vars` reference.
+    """
+    if shape == NATIVE_READ:
+        rows = native_filter_rows(node)
+        if not rows:
+            fail(
+                f"the {label} read sets no `entityConfig._filters` rows — an unfiltered "
+                f"`resultMode: \"multiple\"` read returns the first 100 rows in arbitrary order, "
+                f"not the record the flow asked for"
+            )
+        if not read_references_input(node, shape, field):
+            fail(
+                f"no {label} filter row takes its value from $vars.…{field} — the rows are "
+                f"{[{'field': row.get('field'), 'value': unwrap(row.get('value'))} for row in rows]!r}. "
+                f"Each lookup must filter on its own flow input; a literal there is the answer "
+                f"written in"
+            )
+        for row in rows:
+            operator = str(row.get("operator") or "")
+            if operator not in NATIVE_FILTER_OPERATORS:
+                fail(
+                    f"the {label} filter row on {row.get('field')!r} uses operator {operator!r}; the "
+                    f"serializer can emit only {sorted(NATIVE_FILTER_OPERATORS)} and refuses the whole "
+                    f"query otherwise"
+                )
+            value = str(unwrap(row.get("value")) or "").strip()
+            if not value:
+                fail(
+                    f"the {label} filter row on {row.get('field')!r} has a blank value — an expression "
+                    f"switched on and left blank is refused rather than dropped, so the read emits nothing"
+                )
+            if "$self" in value:
+                fail(
+                    f"the {label} filter row on {row.get('field')!r} references `$self` ({value!r}) — a "
+                    f"query cannot wait on the record it is being run to fetch, and the serializer "
+                    f"refuses the whole query"
+                )
+        return
+
+    query = {key: unwrap(value) for key, value in (read_detail(node).get("queryParameters") or {}).items()}
+    if "queryExpression" not in query:
+        fail(f"the {label} query sets no queryExpression; queryParameters: {sorted(query)}")
+    expression = str(query["queryExpression"])
+    if not read_references_input(node, shape, field):
+        fail(
+            f"the {label} queryExpression is {expression!r} and its filterVariables do not reference "
+            f"{field!r} — each lookup must filter on its own flow input. Author the filter via "
+            f"--detail.filter so the CLI compiles it: dynamic operands become {{var_...}} "
+            f"placeholders in filterVariables"
+        )
+    if "'" not in expression:
+        fail(
+            f"the {label} queryExpression is {expression!r} — a CEQL string literal has to be "
+            f"single-quoted (an unquoted RHS parses as subtraction server-side and 400s)"
+        )
+
+
+def read_references_input(node: dict[str, Any], shape: str, field: str) -> bool:
+    """True when the read's filter takes its value from the named flow input."""
+    if shape == NATIVE_READ:
+        return any(
+            "$vars." in str(unwrap(row.get("value")) or "")
+            and references_field(row.get("value"), field)
+            for row in native_filter_rows(node)
+        )
+    return query_references_input(read_detail(node), field)
+
+
+def assert_read_resolves(node: dict[str, Any], shape: str, label: str, flow: dict[str, Any]) -> str:
+    """Assert the read reaches the tenant it is pointed at; describe how.
+
+    Connector: the resolved connection is a connection/folder pair of distinct
+    real uuids. Measured while writing these cards — a `bindings.json` whose
+    FolderKey entry carried the CONNECTION id collapsed both entries into one at
+    FIL emission and the live dispatch sent the folder key as `--connection-id`,
+    answering 401.
+
+    Native: nothing to resolve while the entity is tenant-scoped — the node
+    needs no Integration Service connection and no `bindings[]` connection row.
+    A `_folderKey` switches the emitted target to the folder-qualified form, and
+    without `_resourceKey`/`_entityKey` plus both `resource: "Entity"` rows the
+    name and folder serialize as source-org literals: it packages and breaks on
+    deploy (impl.md — Folder-scoped entities and bindings).
+    """
+    if shape == NATIVE_READ:
+        config = entity_config(node)
+        folder = str(unwrap(config.get("_folderKey")) or "").strip()
+        if not folder:
+            return "tenant-scoped entity (no connection, no binding row)"
+
+        key = str(unwrap(config.get("_resourceKey")) or unwrap(config.get("_entityKey")) or "").strip()
+        if not key:
+            fail(
+                f"the {label} read carries `_folderKey` {folder!r} but no `_resourceKey`/`_entityKey`, so "
+                f"its name and folder serialize as source-org literals. A half-authored folder scope is "
+                f"worse than none — it packages and breaks on deploy. Keep the entity tenant-scoped, or "
+                f"let the canvas entity picker write all three"
+            )
+        attributes = {
+            str(binding.get("propertyAttribute") or "")
+            for binding in (flow.get("bindings") or [])
+            if isinstance(binding, dict)
+            and str(binding.get("resource") or "") == "Entity"
+            and str(binding.get("resourceKey") or "") == key
+        }
+        missing = sorted({"name", "folderKey"} - attributes)
+        if missing:
+            fail(
+                f"the {label} read is folder-scoped on `_resourceKey` {key!r} but the flow declares no "
+                f"`resource: \"Entity\"` binding row with propertyAttribute {missing} (it declares "
+                f"{sorted(attributes) or 'none'}). Both rows are required, `resource` is the capitalized "
+                f"\"Entity\" — packaging ignores a lowercase row, so the deploy side gets no override"
+            )
+        return f"folder-scoped entity, both Entity binding rows on {key[:8]}…"
+
+    detail = read_detail(node)
+    connection = str(unwrap(detail.get("connectionId")) or "")
+    folder = str(unwrap(detail.get("connectionFolderKey")) or "")
+    for attribute, value in (("connectionId", connection), ("connectionFolderKey", folder)):
+        if not is_real_uuid(value):
+            fail(
+                f"the {label} query's detail.{attribute} is {value!r}, not a real uuid — `bindings.json` "
+                f"has to name the real Data Fabric connection and its folder "
+                f"(uip is connections list --all-folders)"
+            )
+    if connection == folder:
+        fail(
+            f"the {label} query's detail.connectionId and detail.connectionFolderKey are the SAME uuid "
+            f"({connection}) — the folder binding needs the connection's FOLDER key, not its id "
+            f"(measured: the two collapse into one binding at FIL emission and the live dispatch sends "
+            f"the folder key as --connection-id, answering 401 Unauthorized)"
+        )
+    return f"connection={connection[:8]}… folder={folder[:8]}…"
+
+
 def successful_end_ids(
     nodes: Iterable[dict[str, Any]], edges: Iterable[dict[str, Any]], producer: str
 ) -> set[str]:

--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_flow_utils.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_flow_utils.py
@@ -183,6 +183,9 @@ NATIVE_FILTER_OPERATORS = {
     "starts with",
     "ends with",
     "in",
+    # The legacy spelling of `in`. The platform still reads it (impl.md —
+    # Filters), so rejecting it fails a filter the serializer accepts.
+    "is any of",
 }
 
 
@@ -204,12 +207,10 @@ def entity_reads(nodes: Iterable[dict[str, Any]]) -> tuple[str, list[dict[str, A
     connector = [
         node for node in nodes
         if str(node.get("type") or "").startswith(CONNECTOR_READ_PREFIX)
+        and str(node.get("type") or "").endswith(CONNECTOR_READ_OPS)
     ]
     native = [node for node in nodes if str(node.get("type") or "") == NATIVE_READ_TYPE]
-    connector_reads = [
-        node for node in connector
-        if str(node.get("type") or "").endswith(CONNECTOR_READ_OPS)
-    ]
+    connector_reads = connector
     if connector_reads and native:
         fail(
             f"the flow mixes both entity-read shapes — connector "
@@ -266,8 +267,17 @@ def assert_read_filters_input(
     field: str,
     label: str,
     nodes: Iterable[dict[str, Any]] = (),
+    *,
+    column: str,
 ) -> None:
     """Assert the read filters on ``field``, computed, in a form the server accepts.
+
+    ``field`` is the flow input the value must come from; ``column`` is the
+    entity column the filter has to sit on. They coincide in every current
+    scenario and are not the same thing, so ``column`` is passed explicitly:
+    inferring it from ``field`` would false-fail a scenario whose input and
+    column are spelled differently. Without it, a row on the WRONG column
+    carrying the right value passes while querying nothing useful.
 
     The computed half is the anti-hardcode gate: a filter that writes the answer
     in satisfies every behaviour rung while querying nothing. The accepted half
@@ -289,13 +299,13 @@ def assert_read_filters_input(
                 f"the {label} read sets no `entityConfig._filters` rows — an unfiltered "
                 f"`resultMode: {mode or 'multiple'!r}` read {consequence}"
             )
-        if not read_references_input(node, shape, field, nodes):
+        if not read_references_input(node, shape, field, nodes, column=column):
             fail(
-                f"no {label} filter row reaches $vars.…{field}, directly or through a node it "
-                f"reads — the rows are "
+                f"no {label} filter row on column {column!r} reaches $vars.…{field}, directly or "
+                f"through a node it reads — the rows are "
                 f"{[{'field': row.get('field'), 'value': unwrap(row.get('value'))} for row in rows]!r}. "
-                f"Each lookup must filter on its own flow input; a literal there is the answer "
-                f"written in"
+                f"Each lookup must filter its own column on its own flow input; a literal there is "
+                f"the answer written in, and the right value on the wrong column queries nothing"
             )
         for row in rows:
             operator = str(row.get("operator") or "")
@@ -323,7 +333,7 @@ def assert_read_filters_input(
     if "queryExpression" not in query:
         fail(f"the {label} query sets no queryExpression; queryParameters: {sorted(query)}")
     expression = str(query["queryExpression"])
-    if not read_references_input(node, shape, field, nodes):
+    if not read_references_input(node, shape, field, nodes, column=column):
         fail(
             f"the {label} queryExpression is {expression!r} and its filterVariables do not reference "
             f"{field!r} — each lookup must filter on its own flow input. Author the filter via "
@@ -342,6 +352,8 @@ def read_references_input(
     shape: str,
     field: str,
     nodes: Iterable[dict[str, Any]] = (),
+    *,
+    column: str | None = None,
 ) -> bool:
     """True when the read's filter reaches the named flow input.
 
@@ -361,7 +373,13 @@ def read_references_input(
         if other.get("id")
     }
     dependencies = node_dependencies(nodes)
+    wanted = (column or "").strip().lower()
     for row in native_filter_rows(node):
+        # Case-insensitive: a column whose CASE is wrong is a different defect,
+        # caught live, and failing it here is the over-strictness this file keeps
+        # paying for.
+        if wanted and str(row.get("field") or "").strip().lower() != wanted:
+            continue
         value = row.get("value")
         if "$vars." not in str(unwrap(value) or ""):
             continue
@@ -402,6 +420,12 @@ def assert_read_resolves(node: dict[str, Any], shape: str, label: str, flow: dic
                 f"It is the key's PRESENCE that switches the emitted target to the folder-qualified form, "
                 f"so a blank one emits that form with no folder. Omit the key to stay tenant-scoped"
             )
+        if not is_real_uuid(folder):
+            fail(
+                f"the {label} read's `_folderKey` is {folder!r}, which is not a folder id. It is the "
+                f"entity's `folderId` from `uip df entities list`, so the emitted folder-qualified "
+                f"target cannot resolve a value of this shape"
+            )
 
         key = str(unwrap(config.get("_resourceKey")) or unwrap(config.get("_entityKey")) or "").strip()
         if not key:
@@ -411,13 +435,14 @@ def assert_read_resolves(node: dict[str, Any], shape: str, label: str, flow: dic
                 f"worse than none — it packages and breaks on deploy. Keep the entity tenant-scoped, or "
                 f"let the canvas entity picker write all three"
             )
-        attributes = {
-            str(binding.get("propertyAttribute") or "")
+        rows = [
+            binding
             for binding in (flow.get("bindings") or [])
             if isinstance(binding, dict)
             and str(binding.get("resource") or "") == "Entity"
             and str(binding.get("resourceKey") or "") == key
-        }
+        ]
+        attributes = {str(binding.get("propertyAttribute") or "") for binding in rows}
         missing = sorted({"name", "folderKey"} - attributes)
         if missing:
             fail(
@@ -425,6 +450,21 @@ def assert_read_resolves(node: dict[str, Any], shape: str, label: str, flow: dic
                 f"`resource: \"Entity\"` binding row with propertyAttribute {missing} (it declares "
                 f"{sorted(attributes) or 'none'}). Both rows are required, `resource` is the capitalized "
                 f"\"Entity\" — packaging ignores a lowercase row, so the deploy side gets no override"
+            )
+        # The row's whole purpose is to carry the value packaging overrides with
+        # (impl.md — Folder-scoped entities and bindings). Matching the metadata
+        # and skipping `default` reports success on a pair that overrides nothing.
+        valueless = sorted(
+            str(binding.get("propertyAttribute") or "")
+            for binding in rows
+            if str(binding.get("propertyAttribute") or "") in {"name", "folderKey"}
+            and not str(unwrap(binding.get("default")) or "").strip()
+        )
+        if valueless:
+            fail(
+                f"the {label} read's `Entity` binding row(s) for propertyAttribute {valueless} carry no "
+                f"`default`. That field is the value packaging substitutes, so a row without one is "
+                f"matched and then overrides nothing — the deploy side still gets the source-org literal"
             )
         return f"folder-scoped entity, both Entity binding rows on {key[:8]}…"
 

--- a/tests/tasks/uipath-maestro-flow/_shared/check_bindings_no_stubs.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/check_bindings_no_stubs.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Check either native Flow bindings schema for empty or placeholder resources."""
+"""Check either native Flow bindings schema for empty or placeholder resources.
+
+A flow whose only external calls are native `core.datafabric.read` nodes has no
+Integration Service connection to bind, so it legitimately declares no
+`connection` resource. Demanding one there fails the better build (see
+advisory_flow_utils — entity reads). Any connection resource that IS declared is
+still held to a real tenant key.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +14,8 @@ import json
 import re
 from pathlib import Path
 from typing import Any
+
+from advisory_flow_utils import CONNECTOR_READ_PREFIX
 
 EXCLUDED_PARTS = {
     ".cli-stage",
@@ -65,25 +74,54 @@ def invalid_ids(entries: list[dict[str, Any]], schema: str) -> list[str]:
     return failures
 
 
+def _generated(cwd: Path, pattern: str) -> list[Path]:
+    return sorted(
+        path
+        for path in cwd.rglob(pattern)
+        if not EXCLUDED_PARTS.intersection(path.relative_to(cwd).parts)
+    )
+
+
+def needs_a_connection(cwd: Path) -> bool:
+    """True when any generated flow carries a connector node.
+
+    The two callers are Data Fabric scenarios, so "no connector node" means the
+    entity reads are native and there is nothing for a `connection` resource to
+    point at.
+    """
+    for path in _generated(cwd, "*.flow"):
+        try:
+            nodes = json.loads(path.read_text(encoding="utf-8")).get("nodes") or []
+        except (OSError, json.JSONDecodeError):
+            continue
+        if any(str(node.get("type") or "").startswith(CONNECTOR_READ_PREFIX) for node in nodes):
+            return True
+    return False
+
+
 def main() -> None:
     cwd = Path.cwd()
-    candidates = sorted(
+    candidates = [
         path
-        for path in cwd.rglob("bindings*.json")
+        for path in _generated(cwd, "bindings*.json")
         if path.name in {"bindings.json", "bindings_v2.json"}
-        and not EXCLUDED_PARTS.intersection(path.relative_to(cwd).parts)
-    )
+    ]
     assert candidates, "no generated bindings.json or bindings_v2.json found"
+    required = needs_a_connection(cwd)
 
     checked = 0
     for path in candidates:
         entries, schema = load_entries(path)
-        assert entries, f"{path} declares no bindings at all"
+        assert entries or not required, f"{path} declares no bindings at all"
         failures = invalid_ids(entries, schema)
         assert not failures, f"stub or empty bindings in {path}: {failures}"
         checked += len(entries)
 
-    print(f"{checked} bindings across {len(candidates)} file(s), all populated with non-stub values")
+    scope = "connector" if required else "native entity reads, no connection to bind"
+    print(
+        f"{checked} connection binding(s) across {len(candidates)} file(s), all populated with "
+        f"non-stub values ({scope})"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/_shared/check_bindings_no_stubs.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/check_bindings_no_stubs.py
@@ -6,6 +6,12 @@ Integration Service connection to bind, so it legitimately declares no
 `connection` resource. Demanding one there fails the better build (see
 advisory_flow_utils — entity reads). Any connection resource that IS declared is
 still held to a real tenant key.
+
+Measured on the 2026-09-11 eval: such a flow emits NO bindings file at all, not
+an empty one. A pure Data Fabric flow references no packaged resource, so the CLI
+writes nothing, and both native billing tasks died on `assert candidates` one
+line before the connection check could apply. The presence of a `.flow` is what
+separates that from the checker running in the wrong tree and finding nothing.
 """
 
 from __future__ import annotations
@@ -106,8 +112,20 @@ def main() -> None:
         for path in _generated(cwd, "bindings*.json")
         if path.name in {"bindings.json", "bindings_v2.json"}
     ]
-    assert candidates, "no generated bindings.json or bindings_v2.json found"
     required = needs_a_connection(cwd)
+
+    if not candidates:
+        # A `.flow` has to be here for "no bindings file" to mean "none needed"
+        # rather than "this ran in the wrong tree and found nothing".
+        assert _generated(cwd, "*.flow"), (
+            "found neither a generated bindings file nor a .flow to check against"
+        )
+        assert not required, (
+            "no generated bindings.json or bindings_v2.json found, and the flow carries a connector "
+            "node that needs one"
+        )
+        print("no bindings file, and no connector node that needs one (native entity reads)")
+        return
 
     checked = 0
     for path in candidates:

--- a/tests/tasks/uipath-maestro-flow/_shared/check_bindings_no_stubs.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/check_bindings_no_stubs.py
@@ -15,7 +15,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from advisory_flow_utils import CONNECTOR_READ_PREFIX
+from advisory_flow_utils import CONNECTOR_NODE_PREFIX
 
 EXCLUDED_PARTS = {
     ".cli-stage",
@@ -83,18 +83,18 @@ def _generated(cwd: Path, pattern: str) -> list[Path]:
 
 
 def needs_a_connection(cwd: Path) -> bool:
-    """True when any generated flow carries a connector node.
+    """True when any generated flow carries an Integration Service connector node.
 
-    The two callers are Data Fabric scenarios, so "no connector node" means the
-    entity reads are native and there is nothing for a `connection` resource to
-    point at.
+    Matched on the whole `uipath.connector.` family rather than the Data Service
+    one: a checker that only knew Data Service would stop requiring bindings for
+    a flow whose connector is Slack or Jira, which is a silent pass, not a fix.
     """
     for path in _generated(cwd, "*.flow"):
         try:
             nodes = json.loads(path.read_text(encoding="utf-8")).get("nodes") or []
         except (OSError, json.JSONDecodeError):
             continue
-        if any(str(node.get("type") or "").startswith(CONNECTOR_READ_PREFIX) for node in nodes):
+        if any(str(node.get("type") or "").startswith(CONNECTOR_NODE_PREFIX) for node in nodes):
             return True
     return False
 

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
@@ -315,6 +315,119 @@ def test_native_blank_folder_key_fails(tmp_path: Path) -> None:
     assert "leaves it blank" in result.stdout + result.stderr
 
 
+def test_native_filter_on_the_wrong_column_fails(tmp_path: Path) -> None:
+    """The right value on the wrong column queries nothing useful, and checking
+    only the value let it through."""
+
+    def mutate(flow):
+        for rows in _native_rows(flow):
+            for row in rows:
+                row["field"] = "accountNumber"
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode != 0
+    assert "'invoiceNumber'" in result.stdout + result.stderr
+
+
+def test_native_filter_column_case_is_tolerated(tmp_path: Path) -> None:
+    """A column whose CASE is wrong is a different defect, caught live. Failing
+    it here is the over-strictness this file keeps paying for."""
+
+    def mutate(flow):
+        for rows in _native_rows(flow):
+            for row in rows:
+                row["field"] = "InvoiceNumber"
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_native_filter_legacy_in_operator_is_accepted(tmp_path: Path) -> None:
+    """`is any of` is the legacy spelling of `in` and the platform still reads
+    it, so rejecting it fails a filter the serializer accepts."""
+
+    def mutate(flow):
+        for node in flow["nodes"]:
+            config = (node.get("inputs") or {}).get("entityConfig")
+            if config:
+                config["resultMode"] = "multiple"
+                for row in config["_filters"]["rows"]:
+                    row["operator"] = "is any of"
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_native_entity_binding_without_a_default_fails(tmp_path: Path) -> None:
+    """The row's whole purpose is to carry the value packaging overrides with, so
+    matching the metadata and skipping `default` reports success on a pair that
+    overrides nothing."""
+    key = "erp-resource-key"
+
+    def mutate(flow):
+        for node in flow["nodes"]:
+            config = (node.get("inputs") or {}).get("entityConfig")
+            if config:
+                config["_folderKey"] = FOLDER_KEY
+                config["_resourceKey"] = key
+        flow["bindings"] = [
+            _entity_row("Entity", key, attribute, default=None)
+            for attribute in ("name", "folderKey")
+        ]
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode != 0
+    assert "carry no `default`" in result.stdout + result.stderr
+
+
+def test_native_non_uuid_folder_key_fails(tmp_path: Path) -> None:
+    """`_folderKey` is the entity's `folderId`, so the emitted folder-qualified
+    target cannot resolve a value of another shape."""
+
+    def mutate(flow):
+        for node in flow["nodes"]:
+            config = (node.get("inputs") or {}).get("entityConfig")
+            if config:
+                config["_folderKey"] = "Shared/uipath-maestro-flow/BillingDispute"
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode != 0
+    assert "not a folder id" in result.stdout + result.stderr
+
+
+def test_server_side_filter_rejects_a_row_with_no_predicate(tmp_path: Path) -> None:
+    """`rows: [{}]` is a non-empty list the serializer emits nothing from, so
+    list non-emptiness is not the question."""
+    checker = FLOW_TASKS / "multi_node/billing_invoice_lookup/check_server_side_filter.py"
+    flow = _native_flow()
+    for node in flow["nodes"]:
+        config = (node.get("inputs") or {}).get("entityConfig")
+        if config:
+            config["_filters"] = {"logicalOperator": "AND", "rows": [{}], "groups": []}
+    cwd = _project(tmp_path, flow, NON_CONNECTION_BINDINGS, "BillingDisputeResolution")
+
+    result = subprocess.run(
+        [sys.executable, str(checker)], cwd=cwd, capture_output=True, text=True, check=False
+    )
+    assert result.returncode != 0
+    assert "no server-side filter" in result.stdout + result.stderr
+
+
+def test_entity_read_shapes_match_the_structural_gates() -> None:
+    """Two discriminators describe the same two shapes: this module's for the
+    advisories, `flow_check.ENTITY_QUERY_HINTS` for the structural gates. A
+    comment asking to "keep the two in step" is not a guard."""
+    sys.path.insert(0, str(SHARED))
+    import advisory_flow_utils
+    import flow_check
+
+    hints = flow_check.ENTITY_QUERY_HINTS
+    assert len(hints) == 2, hints
+    assert advisory_flow_utils.NATIVE_READ_TYPE in hints
+    connector_type = advisory_flow_utils.CONNECTOR_READ_PREFIX + "query-entity-records"
+    assert any(hint in connector_type for hint in hints), (hints, connector_type)
+
+
 def test_bindings_checker_accepts_a_valid_connection_pair(tmp_path: Path) -> None:
     flow = json.loads((FLOW_TASKS / REFERENCE_CASES["advisory_billing_invoice_lookup.py"]).read_text())
     cwd = _project(tmp_path, flow, CONNECTION_BINDINGS, "BillingInvoiceLookup")
@@ -333,7 +446,7 @@ def test_native_half_authored_folder_scope_fails(tmp_path: Path) -> None:
     for node in flow["nodes"]:
         config = (node.get("inputs") or {}).get("entityConfig")
         if config:
-            config["_folderKey"] = "5da18ec0-7de1-4e57-aaf1-ddc8a369c199"
+            config["_folderKey"] = FOLDER_KEY
     target.write_text(json.dumps(flow))
 
     result = run_script("advisory_billing_invoice_lookup.py", target)
@@ -350,12 +463,9 @@ def test_native_lowercase_entity_binding_row_fails(tmp_path: Path) -> None:
     for node in flow["nodes"]:
         config = (node.get("inputs") or {}).get("entityConfig")
         if config:
-            config["_folderKey"] = "5da18ec0-7de1-4e57-aaf1-ddc8a369c199"
+            config["_folderKey"] = FOLDER_KEY
             config["_resourceKey"] = key
-    flow["bindings"] = [
-        {"resource": "entity", "resourceKey": key, "propertyAttribute": attribute}
-        for attribute in ("name", "folderKey")
-    ]
+    flow["bindings"] = [_entity_row("entity", key, attribute) for attribute in ("name", "folderKey")]
     target.write_text(json.dumps(flow))
 
     result = run_script("advisory_billing_invoice_lookup.py", target)
@@ -370,12 +480,9 @@ def test_native_folder_scope_with_both_binding_rows_passes(tmp_path: Path) -> No
     for node in flow["nodes"]:
         config = (node.get("inputs") or {}).get("entityConfig")
         if config:
-            config["_folderKey"] = "5da18ec0-7de1-4e57-aaf1-ddc8a369c199"
+            config["_folderKey"] = FOLDER_KEY
             config["_resourceKey"] = key
-    flow["bindings"] = [
-        {"resource": "Entity", "resourceKey": key, "propertyAttribute": attribute}
-        for attribute in ("name", "folderKey")
-    ]
+    flow["bindings"] = [_entity_row("Entity", key, attribute) for attribute in ("name", "folderKey")]
     target.write_text(json.dumps(flow))
 
     result = run_script("advisory_billing_invoice_lookup.py", target)
@@ -410,6 +517,18 @@ def _project(tmp_path: Path, flow: dict, bindings: dict, name: str) -> Path:
 
 def _native_flow() -> dict:
     return json.loads((FLOW_TASKS / NATIVE_REFERENCE_CASE[1]).read_text())
+
+
+FOLDER_KEY = "5da18ec0-7de1-4e57-aaf1-ddc8a369c199"
+
+
+def _entity_row(resource: str, key: str, attribute: str, default: str | None = "Orders") -> dict:
+    """A Data Fabric entity binding row. `default` is the value packaging
+    substitutes, so a row without one matches and overrides nothing."""
+    row = {"resource": resource, "resourceKey": key, "propertyAttribute": attribute}
+    if default is not None:
+        row["default"] = FOLDER_KEY if attribute == "folderKey" else default
+    return row
 
 
 CONNECTION_BINDINGS = {

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -28,6 +29,67 @@ REFERENCE_CASES = {
 }
 
 
+# The native `core.datafabric.read` build of each scenario. Tenant availability
+# decides the shape, so a correct build comes in either one and every advisory
+# has to grade both — the 2026-09-11 dispute-resolution run scored 0.727 on a
+# flow that validated, debugged green, and returned the right answer, because
+# the advisory demanded a `connection` binding the native node never has.
+#
+# The dispute-resolution case IS that run's artifact, kept verbatim. The other
+# two are derived from their connector reference below, so the computed filter
+# under test stays the reference's and not the test's.
+NATIVE_REFERENCE_CASE = (
+    "advisory_billing_dispute_resolution.py",
+    "multi_node/billing_dispute_resolution/BillingDisputeResolution.native.reference.flow",
+)
+# Entity -> the column its filter matches on, for `_to_native_reads`.
+NATIVE_FILTER_FIELDS = {
+    "BillingDisputeERP": "invoiceNumber",
+    "BillingDisputeCRM": "accountNumber",
+}
+# The connector reference spells its filter as one CEQL template,
+# `=js:`<column> = '${<expression>}'`` — the interpolation is the value a native
+# filter row carries on its own.
+CEQL_TEMPLATE = re.compile(r"^=js:`(\w+) = '\$\{(.*)\}'`$", re.DOTALL)
+
+
+def _to_native_reads(flow: dict) -> dict:
+    """Rewrite a connector reference's entity reads as native ones, in place."""
+    for node in flow["nodes"]:
+        if "uipath-uipath-dataservice." not in str(node.get("type")):
+            continue
+        detail = node["inputs"]["detail"]
+        entity = detail["pathParameters"]["entityName"]
+        match = CEQL_TEMPLATE.match(str(detail["queryParameters"]["queryExpression"]))
+        assert match, detail["queryParameters"]["queryExpression"]
+        column, expression = match.group(1), match.group(2)
+        assert column == NATIVE_FILTER_FIELDS[entity], (entity, column)
+        node["type"] = "core.datafabric.read"
+        node["typeVersion"] = "1.4"
+        node["inputs"] = {
+            "entityConfig": {
+                "entityName": entity,
+                "resultMode": "multiple",
+                "_recordLimit": 100,
+                "_skip": 0,
+                "_filters": {
+                    "logicalOperator": "AND",
+                    "rows": [{"field": column, "operator": "=", "value": f"=js:{expression}"}],
+                    "groups": [],
+                },
+            }
+        }
+    return flow
+
+
+def native_build(script: str, tmp_path: Path) -> Path:
+    """Write and return a native-shaped build of ``script``'s scenario."""
+    source = FLOW_TASKS / REFERENCE_CASES[script]
+    target = tmp_path / source.name.replace(".reference", "")
+    target.write_text(json.dumps(_to_native_reads(json.loads(source.read_text()))))
+    return target
+
+
 def run_script(script: str, *args: Path | str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(SHARED / script), *(str(arg) for arg in args)],
@@ -42,6 +104,227 @@ def run_script(script: str, *args: Path | str, cwd: Path | None = None) -> subpr
 def test_advisories_accept_repo_reference_flows(script: str, relative_flow: str) -> None:
     result = run_script(script, FLOW_TASKS / relative_flow)
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_advisories_accept_the_native_dispute_resolution_build() -> None:
+    """Regression lock for the 2026-09-11 run: the flow this artifact came from
+    validated, debugged green, and returned the right answer, and the advisory
+    failed it for having no `connection` binding — which the native node never
+    has (data-fabric/planning.md — Native node vs Data Service connector)."""
+    script, relative_flow = NATIVE_REFERENCE_CASE
+    result = run_script(script, FLOW_TASKS / relative_flow)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "native entity read" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "script",
+    ["advisory_billing_invoice_lookup.py", "advisory_billing_discrepancy_detector.py"],
+)
+def test_advisories_accept_native_derived_builds(script: str, tmp_path: Path) -> None:
+    result = run_script(script, native_build(script, tmp_path))
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "native read" in result.stdout
+
+
+def test_native_anti_hardcode_guard_survives(tmp_path: Path) -> None:
+    """The whole point of these gates: a filter that writes the answer in
+    satisfies every behaviour rung while querying nothing. Shape must not be a
+    way around it."""
+    target = native_build("advisory_billing_invoice_lookup.py", tmp_path)
+    flow = json.loads(target.read_text())
+    for node in flow["nodes"]:
+        rows = ((node.get("inputs") or {}).get("entityConfig") or {}).get("_filters", {}).get("rows")
+        for row in rows or []:
+            row["value"] = "MCS-2026-04872"
+    target.write_text(json.dumps(flow))
+
+    result = run_script("advisory_billing_invoice_lookup.py", target)
+    assert result.returncode != 0
+    assert "$vars" in result.stdout + result.stderr
+
+
+def test_native_half_authored_folder_scope_fails(tmp_path: Path) -> None:
+    """`_folderKey` switches the emitted target to the folder-qualified form, so
+    without `_resourceKey` and both Entity binding rows the name and folder
+    serialize as source-org literals: it packages and breaks on deploy."""
+    target = native_build("advisory_billing_invoice_lookup.py", tmp_path)
+    flow = json.loads(target.read_text())
+    for node in flow["nodes"]:
+        config = (node.get("inputs") or {}).get("entityConfig")
+        if config:
+            config["_folderKey"] = "5da18ec0-7de1-4e57-aaf1-ddc8a369c199"
+    target.write_text(json.dumps(flow))
+
+    result = run_script("advisory_billing_invoice_lookup.py", target)
+    assert result.returncode != 0
+    assert "_resourceKey" in result.stdout + result.stderr
+
+
+def test_native_lowercase_entity_binding_row_fails(tmp_path: Path) -> None:
+    """`resource` is the capitalized "Entity"; packaging never turns a lowercase
+    row into a binding resource, so the deploy side gets no override at all."""
+    target = native_build("advisory_billing_invoice_lookup.py", tmp_path)
+    flow = json.loads(target.read_text())
+    key = "orders-resource-key"
+    for node in flow["nodes"]:
+        config = (node.get("inputs") or {}).get("entityConfig")
+        if config:
+            config["_folderKey"] = "5da18ec0-7de1-4e57-aaf1-ddc8a369c199"
+            config["_resourceKey"] = key
+    flow["bindings"] = [
+        {"resource": "entity", "resourceKey": key, "propertyAttribute": attribute}
+        for attribute in ("name", "folderKey")
+    ]
+    target.write_text(json.dumps(flow))
+
+    result = run_script("advisory_billing_invoice_lookup.py", target)
+    assert result.returncode != 0
+    assert "Entity" in result.stdout + result.stderr
+
+
+def test_native_folder_scope_with_both_binding_rows_passes(tmp_path: Path) -> None:
+    target = native_build("advisory_billing_invoice_lookup.py", tmp_path)
+    flow = json.loads(target.read_text())
+    key = "erp-resource-key"
+    for node in flow["nodes"]:
+        config = (node.get("inputs") or {}).get("entityConfig")
+        if config:
+            config["_folderKey"] = "5da18ec0-7de1-4e57-aaf1-ddc8a369c199"
+            config["_resourceKey"] = key
+    flow["bindings"] = [
+        {"resource": "Entity", "resourceKey": key, "propertyAttribute": attribute}
+        for attribute in ("name", "folderKey")
+    ]
+    target.write_text(json.dumps(flow))
+
+    result = run_script("advisory_billing_invoice_lookup.py", target)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "folder-scoped entity" in result.stdout
+
+
+def test_mixed_entity_read_shapes_fail(tmp_path: Path) -> None:
+    """One shape per flow. Two means a set of reads was left behind, and the
+    count assertions downstream would report something else."""
+    source = FLOW_TASKS / REFERENCE_CASES["advisory_billing_discrepancy_detector.py"]
+    flow = json.loads(source.read_text())
+    native = next(node for node in flow["nodes"] if "uipath-uipath-dataservice." in str(node.get("type")))
+    native["type"] = "core.datafabric.read"
+    target = tmp_path / "BillingDiscrepancyDetector.flow"
+    target.write_text(json.dumps(flow))
+
+    result = run_script("advisory_billing_discrepancy_detector.py", target)
+    assert result.returncode != 0
+    assert "mixes both entity-read shapes" in result.stdout + result.stderr
+
+
+def _project(tmp_path: Path, flow: dict, bindings: dict) -> Path:
+    """A generated-solution tree as the two billing checkers walk it: one flow
+    and one bindings file under the cwd they are run from."""
+    project = tmp_path / "proj"
+    project.mkdir(parents=True, exist_ok=True)
+    (project / "BillingInvoiceLookup.flow").write_text(json.dumps(flow))
+    (project / "bindings_v2.json").write_text(json.dumps(bindings))
+    return tmp_path
+
+
+CONNECTION_BINDINGS = {
+    "version": "2.0",
+    "resources": [
+        {
+            "resource": "connection",
+            "key": "data-fabric",
+            "value": {
+                "ConnectionId": {"defaultValue": "d61e5d0e-04af-4f93-95cc-151d81fa08dc"},
+                "FolderKey": {"defaultValue": "c4359cde-55f0-4f0e-9322-c6cdce74ab4c"},
+            },
+        }
+    ],
+}
+# What a native build actually writes: resources for the IxP model, the API
+# workflow and the context index, and no `connection` row at all.
+NATIVE_BINDINGS = {
+    "version": "2.0",
+    "resources": [
+        {"resource": "process", "key": "p", "value": {"name": {"defaultValue": "FinancialPostingFunction"}}}
+    ],
+}
+
+
+def test_bindings_checker_accepts_a_native_build_with_no_connection(tmp_path: Path) -> None:
+    """A flow whose only external calls are native reads has no Integration
+    Service connection to bind, so `declares no bindings at all` is wrong there."""
+    flow = json.loads((FLOW_TASKS / NATIVE_REFERENCE_CASE[1]).read_text())
+    cwd = _project(tmp_path, flow, NATIVE_BINDINGS)
+
+    result = run_script("check_bindings_no_stubs.py", cwd=cwd)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "no connection to bind" in result.stdout
+
+
+def test_bindings_checker_still_requires_one_for_a_connector_build(tmp_path: Path) -> None:
+    """The regression the check exists for: a connector build that dropped its
+    connection row deploys and faults with [102010]."""
+    flow = json.loads((FLOW_TASKS / REFERENCE_CASES["advisory_billing_invoice_lookup.py"]).read_text())
+    cwd = _project(tmp_path, flow, NATIVE_BINDINGS)
+
+    result = run_script("check_bindings_no_stubs.py", cwd=cwd)
+    assert result.returncode != 0
+    assert "declares no bindings at all" in result.stdout + result.stderr
+
+
+def test_bindings_checker_rejects_a_stub_connection_on_a_native_build(tmp_path: Path) -> None:
+    """Zero connection rows is fine; a row that is there and wrong is not."""
+    flow = json.loads((FLOW_TASKS / NATIVE_REFERENCE_CASE[1]).read_text())
+    stub = json.loads(json.dumps(CONNECTION_BINDINGS))
+    stub["resources"][0]["value"]["ConnectionId"]["defaultValue"] = "00000000-0000-0000-0000-000000000001"
+    cwd = _project(tmp_path, flow, stub)
+
+    result = run_script("check_bindings_no_stubs.py", cwd=cwd)
+    assert result.returncode != 0
+    assert "stub or empty bindings" in result.stdout + result.stderr
+
+
+def test_server_side_filter_accepts_native_rows(tmp_path: Path) -> None:
+    checker = FLOW_TASKS / "multi_node/billing_invoice_lookup/check_server_side_filter.py"
+    flow = json.loads((FLOW_TASKS / NATIVE_REFERENCE_CASE[1]).read_text())
+    cwd = _project(tmp_path, flow, NATIVE_BINDINGS)
+
+    result = subprocess.run(
+        [sys.executable, str(checker)], cwd=cwd, capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_server_side_filter_rejects_an_empty_native_filter(tmp_path: Path) -> None:
+    """The `_filters` container is always present, so its emptiness is what
+    separates a server-side filter from fetching the entity whole."""
+    checker = FLOW_TASKS / "multi_node/billing_invoice_lookup/check_server_side_filter.py"
+    flow = json.loads((FLOW_TASKS / NATIVE_REFERENCE_CASE[1]).read_text())
+    for node in flow["nodes"]:
+        config = (node.get("inputs") or {}).get("entityConfig")
+        if config:
+            config["_filters"] = {"logicalOperator": "AND", "rows": [], "groups": []}
+    cwd = _project(tmp_path, flow, NATIVE_BINDINGS)
+
+    result = subprocess.run(
+        [sys.executable, str(checker)], cwd=cwd, capture_output=True, text=True, check=False
+    )
+    assert result.returncode != 0
+    assert "no server-side filter" in result.stdout + result.stderr
+
+
+def test_billing_advisories_use_the_shared_entity_read_discriminator() -> None:
+    """The tests above exercise the helpers, not the call sites. Without this,
+    reverting any advisory to the connector-only prefix keeps the suite green on
+    its connector reference and silently restores the 2026-09-11 failure."""
+    for script in (
+        "advisory_billing_invoice_lookup.py",
+        "advisory_billing_discrepancy_detector.py",
+        "advisory_billing_dispute_resolution.py",
+    ):
+        source = (SHARED / script).read_text(encoding="utf-8")
+        assert "entity_reads(nodes)" in source, script
 
 
 def test_literal_scan_ignores_canvas_descriptions_and_uuid_segments(tmp_path: Path) -> None:

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
@@ -144,6 +144,186 @@ def test_native_anti_hardcode_guard_survives(tmp_path: Path) -> None:
     assert "$vars" in result.stdout + result.stderr
 
 
+def _native_rows(flow: dict) -> list[dict]:
+    """Every native read's root filter rows, for a test to mutate in place."""
+    return [
+        ((node.get("inputs") or {}).get("entityConfig") or {})["_filters"]["rows"]
+        for node in flow["nodes"]
+        if (node.get("inputs") or {}).get("entityConfig")
+    ]
+
+
+def _run_invoice_native(tmp_path: Path, mutate) -> subprocess.CompletedProcess:
+    target = native_build("advisory_billing_invoice_lookup.py", tmp_path)
+    flow = json.loads(target.read_text())
+    mutate(flow)
+    target.write_text(json.dumps(flow))
+    return run_script("advisory_billing_invoice_lookup.py", target)
+
+
+def test_native_filter_with_no_rows_fails(tmp_path: Path) -> None:
+    """An unfiltered read is the client-side-filter build the gate exists to name."""
+
+    def mutate(flow):
+        for rows in _native_rows(flow):
+            rows.clear()
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode != 0
+    assert "no `entityConfig._filters` rows" in result.stdout + result.stderr
+
+
+def test_native_filter_no_rows_message_follows_result_mode(tmp_path: Path) -> None:
+    """A `single` read's failure is an over-match fault, not 100 arbitrary rows."""
+
+    def mutate(flow):
+        for node in flow["nodes"]:
+            config = (node.get("inputs") or {}).get("entityConfig")
+            if config:
+                config["resultMode"] = "single"
+                config["_filters"]["rows"].clear()
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode != 0
+    assert "over-match" in result.stdout + result.stderr
+
+
+def test_native_filter_unsupported_operator_fails(tmp_path: Path) -> None:
+    """The serializer refuses the WHOLE query, so the node emits nothing and
+    every downstream `$vars` reference breaks."""
+
+    def mutate(flow):
+        for rows in _native_rows(flow):
+            for row in rows:
+                row["operator"] = "not in"
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode != 0
+    assert "'not in'" in result.stdout + result.stderr
+
+
+def test_native_filter_blank_value_fails(tmp_path: Path) -> None:
+    """Reachable only past the references check, so the valid row stays: an
+    expression switched on and left blank is refused rather than dropped."""
+
+    def mutate(flow):
+        for rows in _native_rows(flow):
+            rows.append({"field": "status", "operator": "=", "value": "   "})
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode != 0
+    assert "blank value" in result.stdout + result.stderr
+
+
+def test_native_filter_self_reference_fails(tmp_path: Path) -> None:
+    """A query cannot wait on the record it is being run to fetch."""
+
+    def mutate(flow):
+        for rows in _native_rows(flow):
+            rows.append({"field": "status", "operator": "=", "value": "=js:$self.Id"})
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode != 0
+    assert "$self" in result.stdout + result.stderr
+
+
+def test_native_filter_in_a_nested_group_is_found(tmp_path: Path) -> None:
+    """`_filters` is a grouped model, so the computed row may sit in a group."""
+
+    def mutate(flow):
+        for node in flow["nodes"]:
+            config = (node.get("inputs") or {}).get("entityConfig")
+            if not config:
+                continue
+            rows = config["_filters"]["rows"]
+            config["_filters"] = {
+                "logicalOperator": "AND",
+                "rows": [],
+                "groups": [{"logicalOperator": "OR", "rows": list(rows), "groups": []}],
+            }
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_native_filter_reached_through_a_script_hop(tmp_path: Path) -> None:
+    """The prompt asks to normalise the input and THEN look up, and a native row
+    is a single `value`, so the normalisation lands in a Script the row reads.
+    Section 6 of this advisory already tolerates the hop for outputs."""
+
+    def mutate(flow):
+        flow["nodes"].append(
+            {
+                "id": "normalizeInvoice",
+                "type": "core.action.script",
+                "inputs": {"value": "=js:$vars.start.output.invoiceNumber.trim().toUpperCase()"},
+            }
+        )
+        for rows in _native_rows(flow):
+            for row in rows:
+                row["value"] = "=js:$vars.normalizeInvoice.output.value"
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_native_filter_hop_to_nothing_still_fails(tmp_path: Path) -> None:
+    """Following the hop must not degrade into accepting any `$vars` reference."""
+
+    def mutate(flow):
+        flow["nodes"].append(
+            {"id": "constant", "type": "core.action.script", "inputs": {"value": "MCS-9999-00000"}}
+        )
+        for rows in _native_rows(flow):
+            for row in rows:
+                row["value"] = "=js:$vars.constant.output.value"
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode != 0
+    assert "invoiceNumber" in result.stdout + result.stderr
+
+
+def test_native_read_beside_a_connector_write_is_not_a_mix(tmp_path: Path) -> None:
+    """Each native op has its own tenant flag, so `read-entity` on with
+    `create-entity` off is a real configuration, not a half-migrated flow."""
+
+    def mutate(flow):
+        flow["nodes"].append(
+            {
+                "id": "auditWrite",
+                "type": "uipath.connector.uipath-uipath-dataservice.create-entity-record",
+                "inputs": {},
+            }
+        )
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_native_blank_folder_key_fails(tmp_path: Path) -> None:
+    """It is the key's PRESENCE that switches the emitted target to the
+    folder-qualified form, so a blank one emits that form with no folder."""
+
+    def mutate(flow):
+        for node in flow["nodes"]:
+            config = (node.get("inputs") or {}).get("entityConfig")
+            if config:
+                config["_folderKey"] = ""
+
+    result = _run_invoice_native(tmp_path, mutate)
+    assert result.returncode != 0
+    assert "leaves it blank" in result.stdout + result.stderr
+
+
+def test_bindings_checker_accepts_a_valid_connection_pair(tmp_path: Path) -> None:
+    flow = json.loads((FLOW_TASKS / REFERENCE_CASES["advisory_billing_invoice_lookup.py"]).read_text())
+    cwd = _project(tmp_path, flow, CONNECTION_BINDINGS, "BillingInvoiceLookup")
+
+    result = run_script("check_bindings_no_stubs.py", cwd=cwd)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "(connector)" in result.stdout
+
+
 def test_native_half_authored_folder_scope_fails(tmp_path: Path) -> None:
     """`_folderKey` switches the emitted target to the folder-qualified form, so
     without `_resourceKey` and both Entity binding rows the name and folder
@@ -218,14 +398,18 @@ def test_mixed_entity_read_shapes_fail(tmp_path: Path) -> None:
     assert "mixes both entity-read shapes" in result.stdout + result.stderr
 
 
-def _project(tmp_path: Path, flow: dict, bindings: dict) -> Path:
+def _project(tmp_path: Path, flow: dict, bindings: dict, name: str) -> Path:
     """A generated-solution tree as the two billing checkers walk it: one flow
     and one bindings file under the cwd they are run from."""
     project = tmp_path / "proj"
     project.mkdir(parents=True, exist_ok=True)
-    (project / "BillingInvoiceLookup.flow").write_text(json.dumps(flow))
+    (project / f"{name}.flow").write_text(json.dumps(flow))
     (project / "bindings_v2.json").write_text(json.dumps(bindings))
     return tmp_path
+
+
+def _native_flow() -> dict:
+    return json.loads((FLOW_TASKS / NATIVE_REFERENCE_CASE[1]).read_text())
 
 
 CONNECTION_BINDINGS = {
@@ -242,8 +426,9 @@ CONNECTION_BINDINGS = {
     ],
 }
 # What a native build actually writes: resources for the IxP model, the API
-# workflow and the context index, and no `connection` row at all.
-NATIVE_BINDINGS = {
+# workflow and the context index, and no `connection` row at all. Named for what
+# it lacks, because the connector cases below reuse it to mean "the row is gone".
+NON_CONNECTION_BINDINGS = {
     "version": "2.0",
     "resources": [
         {"resource": "process", "key": "p", "value": {"name": {"defaultValue": "FinancialPostingFunction"}}}
@@ -254,8 +439,7 @@ NATIVE_BINDINGS = {
 def test_bindings_checker_accepts_a_native_build_with_no_connection(tmp_path: Path) -> None:
     """A flow whose only external calls are native reads has no Integration
     Service connection to bind, so `declares no bindings at all` is wrong there."""
-    flow = json.loads((FLOW_TASKS / NATIVE_REFERENCE_CASE[1]).read_text())
-    cwd = _project(tmp_path, flow, NATIVE_BINDINGS)
+    cwd = _project(tmp_path, _native_flow(), NON_CONNECTION_BINDINGS, "BillingDisputeResolution")
 
     result = run_script("check_bindings_no_stubs.py", cwd=cwd)
     assert result.returncode == 0, result.stdout + result.stderr
@@ -266,7 +450,7 @@ def test_bindings_checker_still_requires_one_for_a_connector_build(tmp_path: Pat
     """The regression the check exists for: a connector build that dropped its
     connection row deploys and faults with [102010]."""
     flow = json.loads((FLOW_TASKS / REFERENCE_CASES["advisory_billing_invoice_lookup.py"]).read_text())
-    cwd = _project(tmp_path, flow, NATIVE_BINDINGS)
+    cwd = _project(tmp_path, flow, NON_CONNECTION_BINDINGS, "BillingInvoiceLookup")
 
     result = run_script("check_bindings_no_stubs.py", cwd=cwd)
     assert result.returncode != 0
@@ -275,10 +459,9 @@ def test_bindings_checker_still_requires_one_for_a_connector_build(tmp_path: Pat
 
 def test_bindings_checker_rejects_a_stub_connection_on_a_native_build(tmp_path: Path) -> None:
     """Zero connection rows is fine; a row that is there and wrong is not."""
-    flow = json.loads((FLOW_TASKS / NATIVE_REFERENCE_CASE[1]).read_text())
     stub = json.loads(json.dumps(CONNECTION_BINDINGS))
     stub["resources"][0]["value"]["ConnectionId"]["defaultValue"] = "00000000-0000-0000-0000-000000000001"
-    cwd = _project(tmp_path, flow, stub)
+    cwd = _project(tmp_path, _native_flow(), stub, "BillingDisputeResolution")
 
     result = run_script("check_bindings_no_stubs.py", cwd=cwd)
     assert result.returncode != 0
@@ -287,8 +470,7 @@ def test_bindings_checker_rejects_a_stub_connection_on_a_native_build(tmp_path: 
 
 def test_server_side_filter_accepts_native_rows(tmp_path: Path) -> None:
     checker = FLOW_TASKS / "multi_node/billing_invoice_lookup/check_server_side_filter.py"
-    flow = json.loads((FLOW_TASKS / NATIVE_REFERENCE_CASE[1]).read_text())
-    cwd = _project(tmp_path, flow, NATIVE_BINDINGS)
+    cwd = _project(tmp_path, _native_flow(), NON_CONNECTION_BINDINGS, "BillingDisputeResolution")
 
     result = subprocess.run(
         [sys.executable, str(checker)], cwd=cwd, capture_output=True, text=True, check=False
@@ -300,12 +482,12 @@ def test_server_side_filter_rejects_an_empty_native_filter(tmp_path: Path) -> No
     """The `_filters` container is always present, so its emptiness is what
     separates a server-side filter from fetching the entity whole."""
     checker = FLOW_TASKS / "multi_node/billing_invoice_lookup/check_server_side_filter.py"
-    flow = json.loads((FLOW_TASKS / NATIVE_REFERENCE_CASE[1]).read_text())
+    flow = _native_flow()
     for node in flow["nodes"]:
         config = (node.get("inputs") or {}).get("entityConfig")
         if config:
             config["_filters"] = {"logicalOperator": "AND", "rows": [], "groups": []}
-    cwd = _project(tmp_path, flow, NATIVE_BINDINGS)
+    cwd = _project(tmp_path, flow, NON_CONNECTION_BINDINGS, "BillingDisputeResolution")
 
     result = subprocess.run(
         [sys.executable, str(checker)], cwd=cwd, capture_output=True, text=True, check=False

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
@@ -565,6 +565,42 @@ def test_bindings_checker_accepts_a_native_build_with_no_connection(tmp_path: Pa
     assert "no connection to bind" in result.stdout
 
 
+def test_bindings_checker_accepts_a_native_build_with_no_bindings_file(tmp_path: Path) -> None:
+    """What the 2026-09-11 eval actually produced. A pure Data Fabric flow
+    references no packaged resource, so the CLI writes no bindings file at all,
+    and both native billing tasks died on `assert candidates` one line before the
+    connection check could apply. The fixture that supplied an empty-of-
+    connections file did not reproduce this: that shape never occurs."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "BillingInvoiceLookup.flow").write_text(json.dumps(_native_flow()))
+
+    result = run_script("check_bindings_no_stubs.py", cwd=tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "no bindings file, and no connector node that needs one" in result.stdout
+
+
+def test_bindings_checker_requires_a_file_for_a_connector_build(tmp_path: Path) -> None:
+    """The other half: a connector flow with no bindings file at all is the
+    missing-connection regression, not a native build."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    flow = json.loads((FLOW_TASKS / REFERENCE_CASES["advisory_billing_invoice_lookup.py"]).read_text())
+    (project / "BillingInvoiceLookup.flow").write_text(json.dumps(flow))
+
+    result = run_script("check_bindings_no_stubs.py", cwd=tmp_path)
+    assert result.returncode != 0
+    assert "carries a connector node that needs one" in result.stdout + result.stderr
+
+
+def test_bindings_checker_fails_when_it_finds_no_flow(tmp_path: Path) -> None:
+    """Relaxing the bindings-file requirement must not let a checker that ran in
+    the wrong tree report success on an empty directory."""
+    result = run_script("check_bindings_no_stubs.py", cwd=tmp_path)
+    assert result.returncode != 0
+    assert "neither a generated bindings file nor a .flow" in result.stdout + result.stderr
+
+
 def test_bindings_checker_still_requires_one_for_a_connector_build(tmp_path: Path) -> None:
     """The regression the check exists for: a connector build that dropped its
     connection row deploys and faults with [102010]."""

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/BillingDisputeResolution.native.reference.flow
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/BillingDisputeResolution.native.reference.flow
@@ -1,0 +1,4994 @@
+{
+  "id": "9482affe-f351-4b90-9cc9-447b5a7b14a0",
+  "version": "1.9",
+  "name": "BillingDisputeResolution",
+  "nodes": [
+    {
+      "id": "start",
+      "type": "core.trigger.manual",
+      "typeVersion": "1.0",
+      "display": {
+        "label": "Manual trigger"
+      },
+      "inputs": {
+        "entryPointId": "d06b449b-abf0-426b-b9e1-da16579eb58f",
+        "isDefaultEntryPoint": true
+      }
+    },
+    {
+      "id": "invoiceExtraction1",
+      "type": "uipath.ixp.invoices-billing-f0c606f9-ixp.99f5bbfa-5f29-8033-8662-25001b6bb18e-79a7d12e-da84-4bf4-ab60-7f34b44dd178",
+      "typeVersion": "1.0.0",
+      "display": {
+        "label": "Invoice Extraction"
+      },
+      "inputs": {
+        "model": {
+          "id": "99f5bbfa-5f29-8033-8662-25001b6bb18e",
+          "modelName": "invoices-billing-f0c606f9-ixp",
+          "modelDisplayName": "invoices-billing",
+          "folderKey": "79a7d12e-da84-4bf4-ab60-7f34b44dd178",
+          "folderName": "Shared/uipath-maestro-flow/BillingDispute",
+          "folderPath": "c4359cde-55f0-4f0e-9322-c6cdce74ab4c.5da18ec0-7de1-4e57-aaf1-ddc8a369c199.79a7d12e-da84-4bf4-ab60-7f34b44dd178",
+          "description": ""
+        },
+        "modelName": "invoices-billing-f0c606f9-ixp",
+        "description": "",
+        "projectName": "invoices-billing-f0c606f9-ixp",
+        "versionTag": "",
+        "folderKey": "79a7d12e-da84-4bf4-ab60-7f34b44dd178",
+        "folderName": "Shared/uipath-maestro-flow/BillingDispute",
+        "fileRef": "=js:$vars.start.output.disputedInvoice",
+        "pageRange": ""
+      },
+      "outputs": {
+        "output": {
+          "name": "output",
+          "type": "object",
+          "source": "=this",
+          "var": "output"
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the node fails",
+          "source": "=Error",
+          "var": "error"
+        }
+      }
+    },
+    {
+      "id": "normalizeData1",
+      "type": "core.action.script",
+      "typeVersion": "1.1",
+      "display": {
+        "label": "Normalize Data"
+      },
+      "inputs": {
+        "script": "const fields = (((($vars.invoiceExtraction1 || {}).output || {}).ExtractionResult || {}).ResultsDocument || {}).Fields || []; const flat = Array.isArray(fields) ? fields.map(f => ({ Id: f.Id ?? f.id ?? \"\", Name: f.Name ?? f.name ?? \"\", Value: f.Value ?? f.value ?? null, Type: f.Type ?? f.type ?? \"\", ...f })) : []; const raw = String($vars.start.output.webhookPayload.invoice.invoiceNumber || \"\").trim().toUpperCase(); return { normalizedInvoice: flat, fields: flat, normalizedInvoiceNumber: raw.startsWith(\"MCS-\") ? raw : \"MCS-\" + raw };"
+      }
+    },
+    {
+      "id": "crmLookup1",
+      "type": "core.datafabric.read",
+      "typeVersion": "1.4",
+      "display": {
+        "label": "CRM Lookup"
+      },
+      "inputs": {
+        "entityConfig": {
+          "entityName": "BillingDisputeCRM",
+          "resultMode": "multiple",
+          "_recordLimit": 100,
+          "_skip": 0,
+          "_selectedFieldNames": [
+            "Id",
+            "accountNumber",
+            "accountName",
+            "accountTier",
+            "onTimePaymentRate",
+            "priorValidDisputes",
+            "priorInvalidDisputes",
+            "priorDisputeSummary",
+            "accountManagerName",
+            "accountManagerEmail"
+          ],
+          "_filters": {
+            "logicalOperator": "AND",
+            "rows": [
+              {
+                "field": "accountNumber",
+                "operator": "=",
+                "value": "=js:$vars.start.output.webhookPayload.customer.accountNumber"
+              }
+            ],
+            "groups": []
+          }
+        }
+      }
+    },
+    {
+      "id": "erpLookup1",
+      "type": "core.datafabric.read",
+      "typeVersion": "1.4",
+      "display": {
+        "label": "ERP Lookup"
+      },
+      "inputs": {
+        "entityConfig": {
+          "entityName": "BillingDisputeERP",
+          "resultMode": "multiple",
+          "_recordLimit": 100,
+          "_skip": 0,
+          "_selectedFieldNames": [
+            "Id",
+            "invoiceNumber",
+            "lineNumber",
+            "accountNumber",
+            "description",
+            "quantity",
+            "unitPrice",
+            "amount",
+            "contractedRate"
+          ],
+          "_filters": {
+            "logicalOperator": "AND",
+            "rows": [
+              {
+                "field": "invoiceNumber",
+                "operator": "=",
+                "value": "=js:$vars.normalizeData1.output.normalizedInvoiceNumber"
+              }
+            ],
+            "groups": []
+          }
+        }
+      }
+    },
+    {
+      "id": "mergeLookups1",
+      "type": "core.logic.merge",
+      "typeVersion": "1.0",
+      "display": {
+        "label": "Merge Lookups"
+      },
+      "inputs": {}
+    },
+    {
+      "id": "discrepancyDetection1",
+      "type": "core.action.script",
+      "typeVersion": "1.1",
+      "display": {
+        "label": "Discrepancy Detection"
+      },
+      "inputs": {
+        "script": "const disputed = (((($vars.start || {}).output || {}).webhookPayload || {}).dispute || {}).disputedLineItems || []; const erp = (($vars.erpLookup1 || {}).output || {}).results || []; const rows = disputed.map(d => { const match = erp.find(r => String(r.lineNumber) === String(d.lineNumber)); const disputedAmount = Number(d.amount != null ? d.amount : (Number(d.quantity || 0) * Number(d.unitPrice || 0))); const contractedAmount = match ? Number(match.amount != null ? match.amount : (Number(match.quantity || 0) * Number(match.unitPrice != null ? match.unitPrice : (match.contractedRate || 0)))) : 0; const delta = disputedAmount - contractedAmount; return { lineNumber:d.lineNumber, description:d.description, disputedAmount, contractedAmount, delta, pricingMismatch: Boolean(match) && delta !== 0, erpMatch: match || null }; }); const totalOvercharge=rows.reduce((s,r)=>s+(r.delta>0?r.delta:0),0); const totalUndercharge=rows.reduce((s,r)=>s+(r.delta<0?Math.abs(r.delta):0),0); return { lines:rows, totalOvercharge, totalUndercharge, mismatchCount:rows.filter(r=>r.pricingMismatch).length };"
+      }
+    },
+    {
+      "id": "disputeAnalystAgent1",
+      "type": "uipath.agent.autonomous",
+      "typeVersion": "1.4",
+      "display": {
+        "label": "Dispute Analyst Agent"
+      },
+      "inputs": {
+        "agentInputVariables": [
+          {
+            "id": "normalizeData1__output__normalizedInvoice",
+            "type": "array",
+            "binding": "=$vars.normalizeData1.output.normalizedInvoice"
+          },
+          {
+            "id": "crmLookup1__output__results",
+            "type": "array",
+            "binding": "=$vars.crmLookup1.output.results"
+          },
+          {
+            "id": "erpLookup1__output__results",
+            "type": "array",
+            "binding": "=$vars.erpLookup1.output.results"
+          },
+          {
+            "id": "discrepancyDetection1__output__summary",
+            "type": "object",
+            "binding": "=$vars.discrepancyDetection1.output"
+          },
+          {
+            "id": "start__output__invoiceNumber",
+            "type": "string",
+            "binding": "=$vars.start.output.webhookPayload.invoice.invoiceNumber"
+          }
+        ],
+        "agentOutputVariables": [
+          {
+            "id": "determination",
+            "type": "string"
+          },
+          {
+            "id": "recommendedAction",
+            "type": "string"
+          },
+          {
+            "id": "autoResolutionEligible",
+            "type": "boolean"
+          },
+          {
+            "id": "creditAmount",
+            "type": "number"
+          },
+          {
+            "id": "confidence",
+            "type": "number"
+          },
+          {
+            "id": "rationale",
+            "type": "string"
+          }
+        ],
+        "source": "33f5478a-f749-41f5-976c-cfa16cf5d6d3"
+      }
+    },
+    {
+      "id": "billingDisputeSopIndex1",
+      "type": "uipath.agent.resource.context.index.billing-dispute-sop-index.cc45b9b4-dbf6-47b3-40ac-08debc0cec5b",
+      "typeVersion": "1.0.0",
+      "display": {
+        "label": "Billing Dispute SOP Index"
+      },
+      "inputs": {
+        "source": "e8e487eb-8113-4c84-8466-eec1bb3e9722"
+      }
+    },
+    {
+      "id": "routeRecommendedAction1",
+      "type": "core.logic.switch",
+      "typeVersion": "1.1",
+      "display": {
+        "label": "Route Recommended Action"
+      },
+      "inputs": {
+        "cases": [
+          {
+            "id": "escalate",
+            "label": "Escalate to manager",
+            "expression": "$vars.disputeAnalystAgent1.output.recommendedAction === \"escalate_to_manager\""
+          },
+          {
+            "id": "auto",
+            "label": "Auto resolve",
+            "expression": "$vars.disputeAnalystAgent1.output.recommendedAction === \"auto_resolve\""
+          },
+          {
+            "id": "reject",
+            "label": "Reject",
+            "expression": "$vars.disputeAnalystAgent1.output.recommendedAction === \"reject\""
+          }
+        ]
+      }
+    },
+    {
+      "id": "logCreditAmount1",
+      "type": "core.action.script",
+      "typeVersion": "1.1",
+      "display": {
+        "label": "Log Credit Amount"
+      },
+      "inputs": {
+        "script": "return { creditAmount: $vars.disputeAnalystAgent1.output.creditAmount };"
+      }
+    },
+    {
+      "id": "managerApprovalDecision1",
+      "type": "core.logic.decision",
+      "typeVersion": "1.3",
+      "display": {
+        "label": "Manager Approval Decision"
+      },
+      "inputs": {
+        "trueLabel": "Rejected",
+        "falseLabel": "Approved",
+        "expression": "false"
+      }
+    },
+    {
+      "id": "financialpostingfunction1",
+      "type": "uipath.core.api-workflow.07d45a91-9413-4dad-82ff-28306c2d85ea",
+      "typeVersion": "1.0.0",
+      "display": {
+        "label": "FinancialPostingFunction"
+      },
+      "inputs": {
+        "invoiceNumber": "=js:$vars.start.output.webhookPayload.invoice.invoiceNumber"
+      }
+    },
+    {
+      "id": "resolutionWriterAgent1",
+      "type": "uipath.agent.autonomous",
+      "typeVersion": "1.4",
+      "display": {
+        "label": "Resolution Writer Agent"
+      },
+      "inputs": {
+        "agentInputVariables": [
+          {
+            "id": "start__output__invoiceNumber",
+            "type": "string",
+            "binding": "=$vars.start.output.webhookPayload.invoice.invoiceNumber"
+          },
+          {
+            "id": "disputeAnalystAgent1__output__creditAmount",
+            "type": "number",
+            "binding": "=$vars.disputeAnalystAgent1.output.creditAmount"
+          },
+          {
+            "id": "disputeAnalystAgent1__output__determination",
+            "type": "string",
+            "binding": "=$vars.disputeAnalystAgent1.output.determination"
+          },
+          {
+            "id": "disputeAnalystAgent1__output__rationale",
+            "type": "string",
+            "binding": "=$vars.disputeAnalystAgent1.output.rationale"
+          }
+        ],
+        "agentOutputVariables": [
+          {
+            "id": "subject",
+            "type": "string"
+          },
+          {
+            "id": "body",
+            "type": "string"
+          }
+        ],
+        "source": "3b9d3fc5-1dd9-4172-9b47-167c39def4ac"
+      }
+    },
+    {
+      "id": "returnResolution1",
+      "type": "core.control.end",
+      "typeVersion": "1.0",
+      "display": {
+        "label": "Return Resolution"
+      },
+      "inputs": {},
+      "outputs": {
+        "output": {
+          "name": "output",
+          "type": "object",
+          "source": "=this",
+          "var": "output"
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the node fails",
+          "source": "=Error",
+          "var": "error"
+        },
+        "determination": {
+          "source": "=js:$vars.disputeAnalystAgent1.output.determination"
+        },
+        "recommendedAction": {
+          "source": "=js:$vars.disputeAnalystAgent1.output.recommendedAction"
+        },
+        "creditAmount": {
+          "source": "=js:$vars.disputeAnalystAgent1.output.creditAmount"
+        },
+        "rationale": {
+          "source": "=js:$vars.disputeAnalystAgent1.output.rationale"
+        },
+        "resolutionEmailBody": {
+          "source": "=js:$vars.resolutionWriterAgent1.output.body"
+        }
+      }
+    },
+    {
+      "id": "returnRejection1",
+      "type": "core.control.end",
+      "typeVersion": "1.0",
+      "display": {
+        "label": "Return Rejection"
+      },
+      "inputs": {},
+      "outputs": {
+        "determination": {
+          "source": "=js:$vars.disputeAnalystAgent1.output.determination"
+        },
+        "recommendedAction": {
+          "source": "=js:$vars.disputeAnalystAgent1.output.recommendedAction"
+        },
+        "creditAmount": {
+          "source": "=js:$vars.disputeAnalystAgent1.output.creditAmount"
+        },
+        "rationale": {
+          "source": "=js:$vars.disputeAnalystAgent1.output.rationale"
+        },
+        "resolutionEmailBody": {
+          "source": "No resolution email was drafted because the dispute was rejected."
+        }
+      }
+    },
+    {
+      "id": "returnManagerRejection1",
+      "type": "core.control.end",
+      "typeVersion": "1.0",
+      "display": {
+        "label": "Return Manager Rejection"
+      },
+      "inputs": {},
+      "outputs": {
+        "determination": {
+          "source": "=js:$vars.disputeAnalystAgent1.output.determination"
+        },
+        "recommendedAction": {
+          "source": "=js:$vars.disputeAnalystAgent1.output.recommendedAction"
+        },
+        "creditAmount": {
+          "source": "=js:$vars.disputeAnalystAgent1.output.creditAmount"
+        },
+        "rationale": {
+          "source": "=js:$vars.disputeAnalystAgent1.output.rationale"
+        },
+        "resolutionEmailBody": {
+          "source": "No resolution email was drafted because the manager rejected the dispute."
+        }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "start-output-invoiceExtraction1-input",
+      "sourceNodeId": "start",
+      "sourcePort": "output",
+      "targetNodeId": "invoiceExtraction1",
+      "targetPort": "input"
+    },
+    {
+      "id": "invoiceExtraction1-success-normalizeData1-input",
+      "sourceNodeId": "invoiceExtraction1",
+      "sourcePort": "success",
+      "targetNodeId": "normalizeData1",
+      "targetPort": "input"
+    },
+    {
+      "id": "normalizeData1-success-crmLookup1-input",
+      "sourceNodeId": "normalizeData1",
+      "sourcePort": "success",
+      "targetNodeId": "crmLookup1",
+      "targetPort": "input"
+    },
+    {
+      "id": "normalizeData1-success-erpLookup1-input",
+      "sourceNodeId": "normalizeData1",
+      "sourcePort": "success",
+      "targetNodeId": "erpLookup1",
+      "targetPort": "input"
+    },
+    {
+      "id": "crmLookup1-output-mergeLookups1-input",
+      "sourceNodeId": "crmLookup1",
+      "sourcePort": "output",
+      "targetNodeId": "mergeLookups1",
+      "targetPort": "input"
+    },
+    {
+      "id": "erpLookup1-output-mergeLookups1-input",
+      "sourceNodeId": "erpLookup1",
+      "sourcePort": "output",
+      "targetNodeId": "mergeLookups1",
+      "targetPort": "input"
+    },
+    {
+      "id": "mergeLookups1-output-discrepancyDetection1-input",
+      "sourceNodeId": "mergeLookups1",
+      "sourcePort": "output",
+      "targetNodeId": "discrepancyDetection1",
+      "targetPort": "input"
+    },
+    {
+      "id": "discrepancyDetection1-success-disputeAnalystAgent1-input",
+      "sourceNodeId": "discrepancyDetection1",
+      "sourcePort": "success",
+      "targetNodeId": "disputeAnalystAgent1",
+      "targetPort": "input"
+    },
+    {
+      "id": "disputeAnalystAgent1-success-routeRecommendedAction1-input",
+      "sourceNodeId": "disputeAnalystAgent1",
+      "sourcePort": "success",
+      "targetNodeId": "routeRecommendedAction1",
+      "targetPort": "input"
+    },
+    {
+      "id": "disputeAnalystAgent1-context-billingDisputeSopIndex1-input",
+      "sourceNodeId": "disputeAnalystAgent1",
+      "sourcePort": "context",
+      "targetNodeId": "billingDisputeSopIndex1",
+      "targetPort": "input"
+    },
+    {
+      "id": "routeRecommendedAction1-case-escalate-managerApprovalDecision1-input",
+      "sourceNodeId": "routeRecommendedAction1",
+      "sourcePort": "case-escalate",
+      "targetNodeId": "managerApprovalDecision1",
+      "targetPort": "input"
+    },
+    {
+      "id": "routeRecommendedAction1-case-auto-logCreditAmount1-input",
+      "sourceNodeId": "routeRecommendedAction1",
+      "sourcePort": "case-auto",
+      "targetNodeId": "logCreditAmount1",
+      "targetPort": "input"
+    },
+    {
+      "id": "routeRecommendedAction1-case-reject-returnRejection1-input",
+      "sourceNodeId": "routeRecommendedAction1",
+      "sourcePort": "case-reject",
+      "targetNodeId": "returnRejection1",
+      "targetPort": "input"
+    },
+    {
+      "id": "logCreditAmount1-success-financialpostingfunction1-input",
+      "sourceNodeId": "logCreditAmount1",
+      "sourcePort": "success",
+      "targetNodeId": "financialpostingfunction1",
+      "targetPort": "input"
+    },
+    {
+      "id": "managerApprovalDecision1-false-financialpostingfunction1-input",
+      "sourceNodeId": "managerApprovalDecision1",
+      "sourcePort": "false",
+      "targetNodeId": "financialpostingfunction1",
+      "targetPort": "input"
+    },
+    {
+      "id": "managerApprovalDecision1-true-returnManagerRejection1-input",
+      "sourceNodeId": "managerApprovalDecision1",
+      "sourcePort": "true",
+      "targetNodeId": "returnManagerRejection1",
+      "targetPort": "input"
+    },
+    {
+      "id": "financialpostingfunction1-output-resolutionWriterAgent1-input",
+      "sourceNodeId": "financialpostingfunction1",
+      "sourcePort": "output",
+      "targetNodeId": "resolutionWriterAgent1",
+      "targetPort": "input"
+    },
+    {
+      "id": "resolutionWriterAgent1-success-returnResolution1-input",
+      "sourceNodeId": "resolutionWriterAgent1",
+      "sourcePort": "success",
+      "targetNodeId": "returnResolution1",
+      "targetPort": "input"
+    }
+  ],
+  "definitions": [
+    {
+      "nodeType": "core.trigger.manual",
+      "version": "1.0",
+      "category": "trigger",
+      "description": "Start the process manually",
+      "tags": [
+        "trigger",
+        "start",
+        "manual"
+      ],
+      "sortOrder": 80,
+      "display": {
+        "label": "Manual trigger",
+        "icon": "play",
+        "shape": "circle"
+      },
+      "handleConfiguration": [
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "output",
+              "type": "source",
+              "handleType": "output",
+              "showButton": true,
+              "constraints": {
+                "forbiddenTargetCategories": [
+                  "trigger"
+                ]
+              }
+            }
+          ],
+          "visible": true
+        }
+      ],
+      "model": {
+        "type": "bpmn:StartEvent",
+        "entryPointId": true
+      },
+      "outputDefinition": {
+        "output": {
+          "type": "object",
+          "description": "Data passed when manually triggering the process.",
+          "source": "null",
+          "var": "output"
+        }
+      },
+      "toolbarExtensions": {
+        "design": {
+          "actions": [
+            {
+              "id": "change-trigger-type",
+              "icon": "square-mouse-pointer",
+              "label": "Change trigger type"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "uipath.ixp.invoices-billing-f0c606f9-ixp.99f5bbfa-5f29-8033-8662-25001b6bb18e-79a7d12e-da84-4bf4-ab60-7f34b44dd178",
+      "version": "1.0.0",
+      "category": "document-extraction.published",
+      "tags": [
+        "ixp",
+        "document-understanding",
+        "extraction"
+      ],
+      "description": "(Shared/uipath-maestro-flow/BillingDispute)",
+      "sortOrder": 545,
+      "display": {
+        "canvasLabel": "Extract",
+        "isPreview": true,
+        "label": "invoices-billing",
+        "description": "(Shared/uipath-maestro-flow/BillingDispute)",
+        "icon": "file-text"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ]
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "success",
+              "type": "source",
+              "handleType": "output"
+            },
+            {
+              "id": "error",
+              "label": "Error",
+              "type": "source",
+              "handleType": "output",
+              "visible": "{inputs.errorHandlingEnabled}",
+              "constraints": {
+                "maxConnections": 1
+              }
+            }
+          ]
+        }
+      ],
+      "supportsErrorHandling": true,
+      "model": {
+        "type": "bpmn:ServiceTask",
+        "serviceType": "IXP.Extraction",
+        "bindings": {
+          "resource": "ixpDeployment",
+          "entityType": "ixpDeployment",
+          "resourceSubType": null,
+          "resourceKey": "99f5bbfa-5f29-8033-8662-25001b6bb18e",
+          "name": "invoices-billing",
+          "values": [
+            {
+              "name": "name",
+              "propertyAttribute": "name",
+              "default": "invoices-billing"
+            },
+            {
+              "name": "folderPath",
+              "propertyAttribute": "folderPath",
+              "default": "Shared/uipath-maestro-flow/BillingDispute"
+            }
+          ]
+        }
+      },
+      "form": {
+        "id": "ixp-standalone-form",
+        "title": "IXP",
+        "sections": [
+          {
+            "id": "ixp-model",
+            "title": "Configuration",
+            "fields": [
+              {
+                "name": "inputs.model",
+                "type": "custom",
+                "component": "ixp-model-folder-selector",
+                "label": ""
+              }
+            ]
+          },
+          {
+            "id": "ixp-file-upload",
+            "title": "File input",
+            "collapsible": true,
+            "defaultExpanded": true,
+            "fields": [
+              {
+                "name": "inputs.fileRef",
+                "type": "file",
+                "label": "File",
+                "description": "File to extract data from",
+                "validation": {
+                  "required": true,
+                  "messages": {
+                    "required": "A file is required for extraction"
+                  }
+                }
+              },
+              {
+                "name": "inputs.pageRange",
+                "type": "text",
+                "label": "Page range",
+                "placeholder": "e.g. 1-5",
+                "description": "Optional page range to process."
+              }
+            ]
+          },
+          {
+            "id": "schema-definition",
+            "title": "Taxonomy",
+            "collapsible": true,
+            "defaultExpanded": true,
+            "fields": [
+              {
+                "name": "inputs.model",
+                "type": "custom",
+                "component": "ixp-model-taxonomy",
+                "label": ""
+              }
+            ]
+          }
+        ]
+      },
+      "debug": {
+        "runtime": "bpmnEngine"
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "projectName": {
+            "type": "string"
+          },
+          "projectId": {
+            "type": "string"
+          },
+          "versionTag": {
+            "type": "string"
+          },
+          "folderKey": {
+            "type": "string",
+            "minLength": 1
+          },
+          "folderName": {
+            "type": "string"
+          },
+          "model": {
+            "type": "object"
+          },
+          "modelName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "fileRef": {
+            "type": "string",
+            "minLength": 1
+          },
+          "pageRange": {
+            "type": "string"
+          },
+          "attachmentConfig": {
+            "type": "object"
+          },
+          "attachment": {
+            "type": "object",
+            "description": "File to extract data from.",
+            "properties": {
+              "ID": {
+                "type": "string",
+                "description": "Orchestrator attachment key"
+              },
+              "FullName": {
+                "type": "string",
+                "description": "File name"
+              },
+              "MimeType": {
+                "type": "string",
+                "description": "The MIME type of the content"
+              },
+              "Metadata": {
+                "type": "object",
+                "description": "Dictionary of metadata",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "ID"
+            ]
+          }
+        },
+        "required": [
+          "fileRef",
+          "modelName",
+          "folderKey"
+        ]
+      },
+      "inputDefaults": {
+        "model": {
+          "id": "99f5bbfa-5f29-8033-8662-25001b6bb18e",
+          "modelName": "invoices-billing-f0c606f9-ixp",
+          "modelDisplayName": "invoices-billing",
+          "folderKey": "79a7d12e-da84-4bf4-ab60-7f34b44dd178",
+          "folderName": "Shared/uipath-maestro-flow/BillingDispute",
+          "folderPath": "c4359cde-55f0-4f0e-9322-c6cdce74ab4c.5da18ec0-7de1-4e57-aaf1-ddc8a369c199.79a7d12e-da84-4bf4-ab60-7f34b44dd178",
+          "description": ""
+        },
+        "modelName": "invoices-billing-f0c606f9-ixp",
+        "description": "",
+        "projectName": "invoices-billing-f0c606f9-ixp",
+        "versionTag": "",
+        "folderKey": "79a7d12e-da84-4bf4-ab60-7f34b44dd178",
+        "folderName": "Shared/uipath-maestro-flow/BillingDispute",
+        "fileRef": "",
+        "pageRange": ""
+      },
+      "outputDefinition": {
+        "output": {
+          "name": "output",
+          "type": "object",
+          "source": "=this",
+          "var": "output",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+              "ExtractionResult": {
+                "type": "object",
+                "properties": {
+                  "DocumentId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ResultsVersion": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                  },
+                  "ResultsDocument": {
+                    "type": "object",
+                    "properties": {
+                      "Bounds": {
+                        "type": "object",
+                        "properties": {
+                          "PageCount": {
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": -2147483648,
+                            "maximum": 2147483647
+                          },
+                          "PageRange": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "Language": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "DocumentGroup": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "DocumentCategory": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "DocumentTypeId": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "DocumentTypeName": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "DocumentTypeDataVersion": {
+                        "type": "integer",
+                        "format": "int32",
+                        "minimum": -2147483648,
+                        "maximum": 2147483647
+                      },
+                      "DataVersion": {
+                        "type": "integer",
+                        "format": "int32",
+                        "minimum": -2147483648,
+                        "maximum": 2147483647
+                      },
+                      "DocumentTypeSource": {
+                        "enum": [
+                          "Automatic",
+                          "Manual",
+                          "ManuallyChanged",
+                          "Defaulted",
+                          "External"
+                        ],
+                        "type": "string"
+                      },
+                      "DocumentTypeField": {
+                        "type": "object",
+                        "properties": {
+                          "Components": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "FieldId": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "FieldName": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "FieldType": {
+                                  "enum": [
+                                    "Text",
+                                    "Number",
+                                    "Date",
+                                    "Name",
+                                    "Address",
+                                    "Keyword",
+                                    "Set",
+                                    "Boolean",
+                                    "Table",
+                                    "Internal",
+                                    "FieldGroup",
+                                    "MonetaryQuantity"
+                                  ],
+                                  "type": "string"
+                                },
+                                "IsMissing": {
+                                  "type": "boolean"
+                                },
+                                "DataSource": {
+                                  "enum": [
+                                    "Automatic",
+                                    "Manual",
+                                    "ManuallyChanged",
+                                    "Defaulted",
+                                    "External"
+                                  ],
+                                  "type": "string"
+                                },
+                                "Values": {
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
+                                  "items": {
+                                    "type": "any"
+                                  }
+                                },
+                                "DataVersion": {
+                                  "type": "integer",
+                                  "format": "int32",
+                                  "minimum": -2147483648,
+                                  "maximum": 2147483647
+                                },
+                                "OperatorConfirmed": {
+                                  "type": "boolean"
+                                },
+                                "ValidatorNotes": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "ValidatorNotesInfo": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "Value": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "UnformattedValue": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "Reference": {
+                            "type": "object",
+                            "properties": {
+                              "TextStartIndex": {
+                                "type": "integer",
+                                "format": "int32",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                              },
+                              "TextLength": {
+                                "type": "integer",
+                                "format": "int32",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                              },
+                              "Tokens": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "TextStartIndex": {
+                                      "type": "integer",
+                                      "format": "int32",
+                                      "minimum": -2147483648,
+                                      "maximum": 2147483647
+                                    },
+                                    "TextLength": {
+                                      "type": "integer",
+                                      "format": "int32",
+                                      "minimum": -2147483648,
+                                      "maximum": 2147483647
+                                    },
+                                    "Page": {
+                                      "type": "integer",
+                                      "format": "int32",
+                                      "minimum": -2147483648,
+                                      "maximum": 2147483647
+                                    },
+                                    "PageWidth": {
+                                      "type": "number",
+                                      "format": "float",
+                                      "minimum": -3.402823669209385e+38,
+                                      "maximum": 3.402823669209385e+38
+                                    },
+                                    "PageHeight": {
+                                      "type": "number",
+                                      "format": "float",
+                                      "minimum": -3.402823669209385e+38,
+                                      "maximum": 3.402823669209385e+38
+                                    },
+                                    "Boxes": {
+                                      "type": [
+                                        "array",
+                                        "null"
+                                      ],
+                                      "items": {
+                                        "maxItems": 4,
+                                        "minItems": 4,
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "DerivedFields": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "FieldId": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "Value": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "Confidence": {
+                            "type": "number",
+                            "format": "float",
+                            "minimum": -3.402823669209385e+38,
+                            "maximum": 3.402823669209385e+38
+                          },
+                          "OperatorConfirmed": {
+                            "type": "boolean"
+                          },
+                          "OcrConfidence": {
+                            "type": "number",
+                            "format": "float",
+                            "minimum": -3.402823669209385e+38,
+                            "maximum": 3.402823669209385e+38
+                          },
+                          "TextType": {
+                            "enum": [
+                              "Unknown",
+                              "Text",
+                              "Checkbox",
+                              "Handwriting",
+                              "Barcode",
+                              "QRcode",
+                              "Stamp",
+                              "Logo",
+                              "Circle",
+                              "Underline",
+                              "Cut"
+                            ],
+                            "type": "string"
+                          },
+                          "ValidatorNotes": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "ValidatorNotesInfo": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "Fields": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "FieldId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "FieldName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "FieldType": {
+                              "enum": [
+                                "Text",
+                                "Number",
+                                "Date",
+                                "Name",
+                                "Address",
+                                "Keyword",
+                                "Set",
+                                "Boolean",
+                                "Table",
+                                "Internal",
+                                "FieldGroup",
+                                "MonetaryQuantity"
+                              ],
+                              "type": "string"
+                            },
+                            "IsMissing": {
+                              "type": "boolean"
+                            },
+                            "DataSource": {
+                              "enum": [
+                                "Automatic",
+                                "Manual",
+                                "ManuallyChanged",
+                                "Defaulted",
+                                "External"
+                              ],
+                              "type": "string"
+                            },
+                            "Values": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "Components": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": "any"
+                                    }
+                                  },
+                                  "Value": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "UnformattedValue": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "Reference": {
+                                    "type": "object",
+                                    "properties": {
+                                      "TextStartIndex": {
+                                        "type": "integer",
+                                        "format": "int32",
+                                        "minimum": -2147483648,
+                                        "maximum": 2147483647
+                                      },
+                                      "TextLength": {
+                                        "type": "integer",
+                                        "format": "int32",
+                                        "minimum": -2147483648,
+                                        "maximum": 2147483647
+                                      },
+                                      "Tokens": {
+                                        "type": [
+                                          "array",
+                                          "null"
+                                        ],
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "TextStartIndex": {
+                                              "type": "integer",
+                                              "format": "int32",
+                                              "minimum": -2147483648,
+                                              "maximum": 2147483647
+                                            },
+                                            "TextLength": {
+                                              "type": "integer",
+                                              "format": "int32",
+                                              "minimum": -2147483648,
+                                              "maximum": 2147483647
+                                            },
+                                            "Page": {
+                                              "type": "integer",
+                                              "format": "int32",
+                                              "minimum": -2147483648,
+                                              "maximum": 2147483647
+                                            },
+                                            "PageWidth": {
+                                              "type": "number",
+                                              "format": "float",
+                                              "minimum": -3.402823669209385e+38,
+                                              "maximum": 3.402823669209385e+38
+                                            },
+                                            "PageHeight": {
+                                              "type": "number",
+                                              "format": "float",
+                                              "minimum": -3.402823669209385e+38,
+                                              "maximum": 3.402823669209385e+38
+                                            },
+                                            "Boxes": {
+                                              "type": [
+                                                "array",
+                                                "null"
+                                              ],
+                                              "items": {
+                                                "maxItems": 4,
+                                                "minItems": 4,
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "number"
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "additionalProperties": false
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "DerivedFields": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "FieldId": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "Value": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "Confidence": {
+                                    "type": "number",
+                                    "format": "float",
+                                    "minimum": -3.402823669209385e+38,
+                                    "maximum": 3.402823669209385e+38
+                                  },
+                                  "OperatorConfirmed": {
+                                    "type": "boolean"
+                                  },
+                                  "OcrConfidence": {
+                                    "type": "number",
+                                    "format": "float",
+                                    "minimum": -3.402823669209385e+38,
+                                    "maximum": 3.402823669209385e+38
+                                  },
+                                  "TextType": {
+                                    "enum": [
+                                      "Unknown",
+                                      "Text",
+                                      "Checkbox",
+                                      "Handwriting",
+                                      "Barcode",
+                                      "QRcode",
+                                      "Stamp",
+                                      "Logo",
+                                      "Circle",
+                                      "Underline",
+                                      "Cut"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "ValidatorNotes": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "ValidatorNotesInfo": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "DataVersion": {
+                              "type": "integer",
+                              "format": "int32",
+                              "minimum": -2147483648,
+                              "maximum": 2147483647
+                            },
+                            "OperatorConfirmed": {
+                              "type": "boolean"
+                            },
+                            "ValidatorNotes": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "ValidatorNotesInfo": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "Tables": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "FieldId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "FieldName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "IsMissing": {
+                              "type": "boolean"
+                            },
+                            "DataSource": {
+                              "enum": [
+                                "Automatic",
+                                "Manual",
+                                "ManuallyChanged",
+                                "Defaulted",
+                                "External"
+                              ],
+                              "type": "string"
+                            },
+                            "DataVersion": {
+                              "type": "integer",
+                              "format": "int32",
+                              "minimum": -2147483648,
+                              "maximum": 2147483647
+                            },
+                            "OperatorConfirmed": {
+                              "type": "boolean"
+                            },
+                            "Values": {
+                              "type": [
+                                "array",
+                                "null"
+                              ],
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "OperatorConfirmed": {
+                                    "type": "boolean"
+                                  },
+                                  "Confidence": {
+                                    "type": "number",
+                                    "format": "float",
+                                    "minimum": -3.402823669209385e+38,
+                                    "maximum": 3.402823669209385e+38
+                                  },
+                                  "OcrConfidence": {
+                                    "type": "number",
+                                    "format": "float",
+                                    "minimum": -3.402823669209385e+38,
+                                    "maximum": 3.402823669209385e+38
+                                  },
+                                  "Cells": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "RowIndex": {
+                                          "type": "integer",
+                                          "format": "int32",
+                                          "minimum": -2147483648,
+                                          "maximum": 2147483647
+                                        },
+                                        "ColumnIndex": {
+                                          "type": "integer",
+                                          "format": "int32",
+                                          "minimum": -2147483648,
+                                          "maximum": 2147483647
+                                        },
+                                        "IsHeader": {
+                                          "type": "boolean"
+                                        },
+                                        "IsMissing": {
+                                          "type": "boolean"
+                                        },
+                                        "OperatorConfirmed": {
+                                          "type": "boolean"
+                                        },
+                                        "DataSource": {
+                                          "enum": [
+                                            "Automatic",
+                                            "Manual",
+                                            "ManuallyChanged",
+                                            "Defaulted",
+                                            "External"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "DataVersion": {
+                                          "type": "integer",
+                                          "format": "int32",
+                                          "minimum": -2147483648,
+                                          "maximum": 2147483647
+                                        },
+                                        "Values": {
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "Components": {
+                                                "type": [
+                                                  "array",
+                                                  "null"
+                                                ],
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "FieldId": {
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
+                                                    },
+                                                    "FieldName": {
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
+                                                    },
+                                                    "FieldType": {
+                                                      "enum": [
+                                                        "Text",
+                                                        "Number",
+                                                        "Date",
+                                                        "Name",
+                                                        "Address",
+                                                        "Keyword",
+                                                        "Set",
+                                                        "Boolean",
+                                                        "Table",
+                                                        "Internal",
+                                                        "FieldGroup",
+                                                        "MonetaryQuantity"
+                                                      ],
+                                                      "type": "string"
+                                                    },
+                                                    "IsMissing": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "DataSource": {
+                                                      "enum": [
+                                                        "Automatic",
+                                                        "Manual",
+                                                        "ManuallyChanged",
+                                                        "Defaulted",
+                                                        "External"
+                                                      ],
+                                                      "type": "string"
+                                                    },
+                                                    "Values": {
+                                                      "type": [
+                                                        "array",
+                                                        "null"
+                                                      ],
+                                                      "items": {
+                                                        "type": "any"
+                                                      }
+                                                    },
+                                                    "DataVersion": {
+                                                      "type": "integer",
+                                                      "format": "int32",
+                                                      "minimum": -2147483648,
+                                                      "maximum": 2147483647
+                                                    },
+                                                    "OperatorConfirmed": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "ValidatorNotes": {
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
+                                                    },
+                                                    "ValidatorNotesInfo": {
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "Value": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "UnformattedValue": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "Reference": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "TextStartIndex": {
+                                                    "type": "integer",
+                                                    "format": "int32",
+                                                    "minimum": -2147483648,
+                                                    "maximum": 2147483647
+                                                  },
+                                                  "TextLength": {
+                                                    "type": "integer",
+                                                    "format": "int32",
+                                                    "minimum": -2147483648,
+                                                    "maximum": 2147483647
+                                                  },
+                                                  "Tokens": {
+                                                    "type": [
+                                                      "array",
+                                                      "null"
+                                                    ],
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "TextStartIndex": {
+                                                          "type": "integer",
+                                                          "format": "int32",
+                                                          "minimum": -2147483648,
+                                                          "maximum": 2147483647
+                                                        },
+                                                        "TextLength": {
+                                                          "type": "integer",
+                                                          "format": "int32",
+                                                          "minimum": -2147483648,
+                                                          "maximum": 2147483647
+                                                        },
+                                                        "Page": {
+                                                          "type": "integer",
+                                                          "format": "int32",
+                                                          "minimum": -2147483648,
+                                                          "maximum": 2147483647
+                                                        },
+                                                        "PageWidth": {
+                                                          "type": "number",
+                                                          "format": "float",
+                                                          "minimum": -3.402823669209385e+38,
+                                                          "maximum": 3.402823669209385e+38
+                                                        },
+                                                        "PageHeight": {
+                                                          "type": "number",
+                                                          "format": "float",
+                                                          "minimum": -3.402823669209385e+38,
+                                                          "maximum": 3.402823669209385e+38
+                                                        },
+                                                        "Boxes": {
+                                                          "type": [
+                                                            "array",
+                                                            "null"
+                                                          ],
+                                                          "items": {
+                                                            "maxItems": 4,
+                                                            "minItems": 4,
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "number"
+                                                            }
+                                                          }
+                                                        }
+                                                      },
+                                                      "additionalProperties": false
+                                                    }
+                                                  }
+                                                },
+                                                "additionalProperties": false
+                                              },
+                                              "DerivedFields": {
+                                                "type": [
+                                                  "array",
+                                                  "null"
+                                                ],
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "FieldId": {
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
+                                                    },
+                                                    "Value": {
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "additionalProperties": false
+                                                }
+                                              },
+                                              "Confidence": {
+                                                "type": "number",
+                                                "format": "float",
+                                                "minimum": -3.402823669209385e+38,
+                                                "maximum": 3.402823669209385e+38
+                                              },
+                                              "OperatorConfirmed": {
+                                                "type": "boolean"
+                                              },
+                                              "OcrConfidence": {
+                                                "type": "number",
+                                                "format": "float",
+                                                "minimum": -3.402823669209385e+38,
+                                                "maximum": 3.402823669209385e+38
+                                              },
+                                              "TextType": {
+                                                "enum": [
+                                                  "Unknown",
+                                                  "Text",
+                                                  "Checkbox",
+                                                  "Handwriting",
+                                                  "Barcode",
+                                                  "QRcode",
+                                                  "Stamp",
+                                                  "Logo",
+                                                  "Circle",
+                                                  "Underline",
+                                                  "Cut"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "ValidatorNotes": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "ValidatorNotesInfo": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              }
+                                            },
+                                            "additionalProperties": false
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "ColumnInfo": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "FieldId": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "FieldName": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "FieldType": {
+                                          "enum": [
+                                            "Text",
+                                            "Number",
+                                            "Date",
+                                            "Name",
+                                            "Address",
+                                            "Keyword",
+                                            "Set",
+                                            "Boolean",
+                                            "Table",
+                                            "Internal",
+                                            "FieldGroup",
+                                            "MonetaryQuantity"
+                                          ],
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "NumberOfRows": {
+                                    "type": "integer",
+                                    "format": "int32",
+                                    "minimum": -2147483648,
+                                    "maximum": 2147483647
+                                  },
+                                  "ValidatorNotes": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "ValidatorNotesInfo": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "ValidatorNotes": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "ValidatorNotesInfo": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "ExtractorPayloads": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "Id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "Payload": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "SavedPayloadId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "TaxonomySchemaMapping": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "BusinessRulesResults": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "FieldId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "FieldType": {
+                          "enum": [
+                            "Text",
+                            "Number",
+                            "Date",
+                            "Name",
+                            "Address",
+                            "Keyword",
+                            "Set",
+                            "Boolean",
+                            "Table",
+                            "Internal",
+                            "FieldGroup",
+                            "MonetaryQuantity"
+                          ],
+                          "type": "string"
+                        },
+                        "Criticality": {
+                          "enum": [
+                            "Must",
+                            "Should"
+                          ],
+                          "type": "string"
+                        },
+                        "IsValid": {
+                          "type": "boolean"
+                        },
+                        "Results": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "Value": {
+                                "type": "object",
+                                "properties": {
+                                  "Value": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "DerivedValue": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "IsValid": {
+                                "type": "boolean"
+                              },
+                              "Rules": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "Rule": {
+                                      "type": "object",
+                                      "properties": {
+                                        "Name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "Type": {
+                                          "enum": [
+                                            "Mandatory",
+                                            "PossibleValues",
+                                            "Regex",
+                                            "StartsWith",
+                                            "EndsWith",
+                                            "FixedLength",
+                                            "IsNumeric",
+                                            "IsDate",
+                                            "IsEmail",
+                                            "Contains",
+                                            "Expression",
+                                            "TableExpression",
+                                            "IsEmpty"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "LogicalOperator": {
+                                          "enum": [
+                                            "AND",
+                                            "OR"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "ComparisonOperator": {
+                                          "enum": [
+                                            "Equals",
+                                            "NotEquals",
+                                            "Greater",
+                                            "Less",
+                                            "GreaterOrEqual",
+                                            "LessOrEqual"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "Expression": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "SetValues": {
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "IsValid": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "BrokenRules": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "Name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "Type": {
+                                "enum": [
+                                  "Mandatory",
+                                  "PossibleValues",
+                                  "Regex",
+                                  "StartsWith",
+                                  "EndsWith",
+                                  "FixedLength",
+                                  "IsNumeric",
+                                  "IsDate",
+                                  "IsEmail",
+                                  "Contains",
+                                  "Expression",
+                                  "TableExpression",
+                                  "IsEmpty"
+                                ],
+                                "type": "string"
+                              },
+                              "LogicalOperator": {
+                                "enum": [
+                                  "AND",
+                                  "OR"
+                                ],
+                                "type": "string"
+                              },
+                              "ComparisonOperator": {
+                                "enum": [
+                                  "Equals",
+                                  "NotEquals",
+                                  "Greater",
+                                  "Less",
+                                  "GreaterOrEqual",
+                                  "LessOrEqual"
+                                ],
+                                "type": "string"
+                              },
+                              "Expression": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "SetValues": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "RowIndex": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "format": "int32",
+                          "minimum": -2147483648,
+                          "maximum": 2147483647
+                        },
+                        "TableFieldId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "Taxonomy": {
+                "type": "object",
+                "properties": {
+                  "DataContractVersion": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "default": "1.2"
+                  },
+                  "DocumentTypes": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "DocumentTypeId": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "Group": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "Category": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "Name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "OptionalUniqueIdentifier": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "TypeField": {
+                          "type": "object",
+                          "properties": {
+                            "FieldId": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "FieldName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "Fields": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "FieldId": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "FieldName": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "IsMultiValue": {
+                                "type": "boolean"
+                              },
+                              "Type": {
+                                "enum": [
+                                  "Text",
+                                  "Number",
+                                  "Date",
+                                  "Name",
+                                  "Address",
+                                  "Keyword",
+                                  "Set",
+                                  "Boolean",
+                                  "Table",
+                                  "Internal",
+                                  "FieldGroup",
+                                  "MonetaryQuantity"
+                                ],
+                                "type": "string"
+                              },
+                              "DeriveFieldsFormat": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "Components": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": "any"
+                                }
+                              },
+                              "SetValues": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "Metadata": {
+                                "type": [
+                                  "array",
+                                  "null"
+                                ],
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "Key": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    },
+                                    "Value": {
+                                      "type": [
+                                        "string",
+                                        "null"
+                                      ]
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "RuleSet": {
+                                "type": "object",
+                                "properties": {
+                                  "Criticality": {
+                                    "enum": [
+                                      "Must",
+                                      "Should"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "Rules": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "Name": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "Type": {
+                                          "enum": [
+                                            "Mandatory",
+                                            "PossibleValues",
+                                            "Regex",
+                                            "StartsWith",
+                                            "EndsWith",
+                                            "FixedLength",
+                                            "IsNumeric",
+                                            "IsDate",
+                                            "IsEmail",
+                                            "Contains",
+                                            "Expression",
+                                            "TableExpression",
+                                            "IsEmpty"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "LogicalOperator": {
+                                          "enum": [
+                                            "AND",
+                                            "OR"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "ComparisonOperator": {
+                                          "enum": [
+                                            "Equals",
+                                            "NotEquals",
+                                            "Greater",
+                                            "Less",
+                                            "GreaterOrEqual",
+                                            "LessOrEqual"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "Expression": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "SetValues": {
+                                          "type": [
+                                            "array",
+                                            "null"
+                                          ],
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "DefaultValue": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "DataSource": {
+                                "type": "object",
+                                "properties": {
+                                  "ResourceId": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "ElementFieldId": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "Metadata": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "Key": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "Value": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "Groups": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "Name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "Categories": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "SupportedLanguages": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "Name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "Code": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "ReportAsExceptionSettings": {
+                    "type": "object",
+                    "properties": {
+                      "ExceptionReasonOptions": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "ExceptionReason": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the node fails",
+          "source": "=Error",
+          "var": "error",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": [
+              "code",
+              "message",
+              "detail",
+              "category",
+              "status"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code as a string"
+              },
+              "message": {
+                "type": "string",
+                "description": "High-level error message"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Detailed error description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Error category"
+              },
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      }
+    },
+    {
+      "nodeType": "core.action.script",
+      "version": "1.1",
+      "category": "data-operations",
+      "description": "Run custom JavaScript code",
+      "tags": [
+        "code",
+        "javascript",
+        "python"
+      ],
+      "sortOrder": 70,
+      "supportsErrorHandling": true,
+      "display": {
+        "label": "Script",
+        "icon": "code"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ]
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "success",
+              "type": "source",
+              "handleType": "output"
+            },
+            {
+              "id": "error",
+              "label": "Error",
+              "type": "source",
+              "handleType": "output",
+              "visible": "{inputs.errorHandlingEnabled}",
+              "constraints": {
+                "maxConnections": 1
+              }
+            }
+          ]
+        }
+      ],
+      "debug": {
+        "runtime": "clientScript"
+      },
+      "model": {
+        "type": "bpmn:ScriptTask"
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "script": {
+            "type": "string",
+            "minLength": 1,
+            "errorMessage": "Add a script function",
+            "validationSeverity": "warning"
+          }
+        },
+        "required": [
+          "script"
+        ]
+      },
+      "inputDefaults": {
+        "script": ""
+      },
+      "outputDefinition": {
+        "output": {
+          "type": "any",
+          "description": "The return value of the script",
+          "source": "=result.response",
+          "var": "output"
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the node fails",
+          "source": "=Error",
+          "var": "error",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": [
+              "code",
+              "message",
+              "detail",
+              "category",
+              "status"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code as a string"
+              },
+              "message": {
+                "type": "string",
+                "description": "High-level error message"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Detailed error description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Error category"
+              },
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "form": {
+        "id": "script-properties",
+        "title": "Script configuration",
+        "sections": [
+          {
+            "id": "script",
+            "title": "Script",
+            "collapsible": true,
+            "defaultExpanded": true,
+            "fields": [
+              {
+                "name": "inputs.script",
+                "type": "custom",
+                "component": "script-editor",
+                "componentProps": {
+                  "language": "javascript",
+                  "returnType": "any",
+                  "validationMode": "script",
+                  "minHeight": 200,
+                  "placeholder": " // Return any value\nreturn {\n  message: \"Web request response\",\n  data: $vars.httpRequest1.output\n};"
+                },
+                "label": "Code",
+                "description": "JavaScript expression that returns a result"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "nodeType": "core.datafabric.read",
+      "version": "1.4",
+      "category": "data",
+      "description": "Query one or more entity records from Data Fabric",
+      "tags": [
+        "datafabric",
+        "entity",
+        "data",
+        "read",
+        "query"
+      ],
+      "sortOrder": 35,
+      "display": {
+        "label": "Query entity records",
+        "icon": "layers-arrow-up-right"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ]
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "output",
+              "type": "source",
+              "handleType": "output"
+            }
+          ]
+        }
+      ],
+      "model": {
+        "type": "bpmn:Task",
+        "debug": {
+          "runtime": "bpmnEngine"
+        }
+      },
+      "runtimeConstraints": {
+        "exclude": [
+          "api-function"
+        ]
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "entityConfig": {
+            "type": "object",
+            "properties": {
+              "entityName": {
+                "type": "string",
+                "minLength": 1,
+                "errorMessage": "An entity must be selected"
+              },
+              "resultMode": {
+                "type": "string",
+                "enum": [
+                  "single",
+                  "multiple"
+                ],
+                "description": "Whether the node queries one record or a list of records",
+                "errorMessage": "Choose whether to query one record or multiple records"
+              }
+            },
+            "required": [
+              "entityName"
+            ],
+            "errorMessage": {
+              "required": "An entity must be selected"
+            }
+          }
+        },
+        "required": [
+          "entityConfig"
+        ]
+      },
+      "inputDefaults": {
+        "entityConfig": {
+          "resultMode": "single"
+        }
+      },
+      "outputDefinition": {
+        "output": {
+          "type": "jsonSchema",
+          "description": "Entity record queried by this node, or the matching records under \"results\"",
+          "source": "=response",
+          "var": "output"
+        }
+      },
+      "form": {
+        "id": "read-entity-properties",
+        "title": "Query entity records configuration",
+        "sections": [
+          {
+            "id": "entity-config",
+            "title": "Entity configuration",
+            "collapsible": true,
+            "defaultExpanded": true,
+            "fields": [
+              {
+                "name": "inputs.entityConfig",
+                "type": "custom",
+                "component": "entity-config",
+                "label": ""
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "nodeType": "core.logic.merge",
+      "version": "1.0",
+      "category": "control-flow",
+      "description": "Join parallel branches into one path",
+      "tags": [
+        "control-flow",
+        "merge"
+      ],
+      "sortOrder": 65,
+      "display": {
+        "label": "Merge",
+        "icon": "merge"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ],
+          "visible": true
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "output",
+              "type": "source",
+              "handleType": "output"
+            }
+          ],
+          "visible": true
+        }
+      ],
+      "model": {
+        "type": "bpmn:ParallelGateway"
+      },
+      "runtimeConstraints": {
+        "exclude": [
+          "api-function"
+        ]
+      }
+    },
+    {
+      "nodeType": "uipath.agent.autonomous",
+      "version": "1.4",
+      "category": "agent",
+      "description": "AI agent that completes tasks autonomously",
+      "tags": [
+        "agentic",
+        "ai",
+        "autonomous",
+        "agent"
+      ],
+      "sortOrder": 10,
+      "supportsErrorHandling": true,
+      "display": {
+        "label": "Autonomous agent",
+        "icon": "autonomous-agent",
+        "shape": "rectangle"
+      },
+      "handleConfiguration": [
+        {
+          "position": "top",
+          "handles": [
+            {
+              "id": "escalation",
+              "type": "source",
+              "handleType": "artifact",
+              "label": "Escalations",
+              "showButton": true,
+              "constraints": {
+                "allowedTargets": [
+                  {
+                    "nodeType": "uipath.agent.resource.escalation"
+                  },
+                  {
+                    "nodeType": "uipath.agent.resource.escalation.*"
+                  }
+                ],
+                "validationMessage": "Only Agent Escalation nodes can connect here",
+                "addNodePanel": {
+                  "searchScope": "deep",
+                  "searchProviders": []
+                }
+              }
+            }
+          ]
+        },
+        {
+          "position": "bottom",
+          "handles": [
+            {
+              "id": "context",
+              "type": "source",
+              "handleType": "artifact",
+              "label": "Context",
+              "showButton": true,
+              "constraints": {
+                "allowedTargets": [
+                  {
+                    "nodeType": "uipath.agent.resource.context.*"
+                  }
+                ],
+                "validationMessage": "Only Context resource nodes can connect here",
+                "addNodePanel": {
+                  "searchScope": "deep",
+                  "searchProviders": [],
+                  "refreshOnFocus": "context",
+                  "createNewActions": [
+                    {
+                      "label": "Create new Context",
+                      "icon": "plus",
+                      "description": "Opens in a new tab",
+                      "urlTemplate": "/{org}/agents_/indexes/add",
+                      "categoryId": "agent"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "id": "tool",
+              "type": "source",
+              "handleType": "artifact",
+              "label": "Tools",
+              "showButton": true,
+              "constraints": {
+                "allowedTargets": [
+                  {
+                    "nodeType": "uipath.agent.resource.tool.*"
+                  }
+                ],
+                "validationMessage": "Only Tool resource nodes can connect here",
+                "addNodePanel": {
+                  "searchScope": "deep",
+                  "searchProviders": [],
+                  "refreshOnFocus": "mcp",
+                  "createNewActions": [
+                    {
+                      "label": "Create new MCP server",
+                      "icon": "plus",
+                      "urlTemplate": "/{org}/{tenant}/orchestrator_/mcp",
+                      "categoryId": "agent.tool.mcp"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ]
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "success",
+              "type": "source",
+              "handleType": "output",
+              "isDefaultForType": true
+            },
+            {
+              "id": "error",
+              "label": "Error",
+              "type": "source",
+              "handleType": "output",
+              "visible": "{inputs.errorHandlingEnabled}",
+              "constraints": {
+                "maxConnections": 1
+              }
+            }
+          ]
+        }
+      ],
+      "form": {
+        "id": "settings-form",
+        "title": "Agent settings",
+        "metadata": {
+          "propertyPanel": {
+            "sectionTabs": {
+              "section-advanced": "advanced"
+            }
+          }
+        },
+        "mode": "onChange",
+        "reValidateMode": "onChange",
+        "sections": [
+          {
+            "id": "section-1",
+            "title": "Agent settings",
+            "collapsible": true,
+            "defaultExpanded": true,
+            "fields": [
+              {
+                "name": "inputs.mode",
+                "type": "custom",
+                "component": "agent-harness-picker",
+                "label": ""
+              },
+              {
+                "name": "inputs.model",
+                "type": "custom",
+                "component": "agent-model-picker",
+                "label": "Model",
+                "componentProps": {
+                  "placeholder": "gpt-4o-2024-11-20"
+                }
+              },
+              {
+                "name": "inputs.systemPrompt",
+                "type": "custom",
+                "component": "prompt-editor",
+                "label": "System prompt",
+                "componentProps": {
+                  "multiline": true,
+                  "minRows": 4,
+                  "maxRows": 20,
+                  "placeholder": "Enter the system prompt"
+                }
+              },
+              {
+                "name": "inputs.userPrompt",
+                "type": "custom",
+                "component": "prompt-editor",
+                "label": "User prompt",
+                "componentProps": {
+                  "multiline": true,
+                  "minRows": 3,
+                  "maxRows": 15,
+                  "placeholder": "Enter the user prompt"
+                }
+              }
+            ]
+          },
+          {
+            "id": "section-advanced",
+            "title": "Advanced settings",
+            "collapsible": true,
+            "defaultExpanded": false,
+            "fields": [
+              {
+                "name": "inputs.temperature",
+                "type": "slider",
+                "label": "Temperature",
+                "defaultValue": 0,
+                "min": 0,
+                "max": 1,
+                "step": 0.01
+              },
+              {
+                "name": "inputs.maxTokenPerResponse",
+                "type": "slider",
+                "label": "Maximum tokens per response",
+                "defaultValue": 16384,
+                "min": 0,
+                "step": 1,
+                "maxRef": {
+                  "fromField": "inputs.modelMaxTokens",
+                  "fallback": 16384
+                }
+              },
+              {
+                "name": "inputs.maxIterations",
+                "type": "slider",
+                "label": "Maximum iterations",
+                "defaultValue": 25,
+                "min": 1,
+                "max": 100,
+                "step": 1
+              }
+            ]
+          },
+          {
+            "id": "guardrails",
+            "collapsible": false,
+            "fields": [
+              {
+                "name": "inputs.guardrails",
+                "type": "custom",
+                "component": "guardrails-editor",
+                "label": "",
+                "componentProps": {
+                  "toolName": "Agent",
+                  "scope": "Agent"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "systemPrompt": {
+            "type": "string",
+            "minLength": 1,
+            "errorMessage": {
+              "minLength": "System prompt is required"
+            }
+          },
+          "userPrompt": {
+            "type": "string",
+            "minLength": 1,
+            "errorMessage": {
+              "minLength": "User prompt is required"
+            }
+          },
+          "model": {
+            "type": "string",
+            "minLength": 1,
+            "errorMessage": {
+              "minLength": "Model is required"
+            }
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "standard",
+              "advanced"
+            ]
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "maxTokenPerResponse": {
+            "type": "number",
+            "minimum": 0
+          },
+          "modelMaxTokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "maxIterations": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "guardrails": {
+            "type": "array"
+          },
+          "agentInputVariables": {
+            "type": "array"
+          },
+          "agentOutputVariables": {
+            "type": "array"
+          }
+        },
+        "required": [
+          "systemPrompt",
+          "userPrompt",
+          "model"
+        ]
+      },
+      "inputDefaults": {
+        "systemPrompt": "You are an agentic assistant.",
+        "userPrompt": "What is the current date?",
+        "model": "gpt-4o-2024-11-20",
+        "mode": "standard",
+        "agentInputVariables": [],
+        "agentOutputVariables": [
+          {
+            "id": "content",
+            "type": "string"
+          }
+        ]
+      },
+      "outputDefinition": {
+        "output": {
+          "type": "object",
+          "description": "Agent response",
+          "var": "output",
+          "properties": {
+            "content": {
+              "type": "string",
+              "description": "The agent response text"
+            }
+          }
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the node fails",
+          "source": "=Error",
+          "var": "error",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": [
+              "code",
+              "message",
+              "detail",
+              "category",
+              "status"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code as a string"
+              },
+              "message": {
+                "type": "string",
+                "description": "High-level error message"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Detailed error description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Error category"
+              },
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "model": {
+        "source": true,
+        "type": "bpmn:ServiceTask",
+        "serviceType": "Orchestrator.StartInlineAgentJob",
+        "version": "v2",
+        "context": [
+          {
+            "name": "_label",
+            "type": "string",
+            "value": ""
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "value": ""
+          },
+          {
+            "name": "entryPoint",
+            "type": "string",
+            "value": ""
+          }
+        ]
+      },
+      "debug": {
+        "runtime": "bpmnEngine"
+      }
+    },
+    {
+      "nodeType": "uipath.agent.resource.context.index.billing-dispute-sop-index.cc45b9b4-dbf6-47b3-40ac-08debc0cec5b",
+      "version": "1.0.0",
+      "category": "agent",
+      "tags": [
+        "agent-context",
+        "index"
+      ],
+      "description": "SOP grounding for the Billing Dispute Analyst agent.",
+      "sortOrder": 510,
+      "display": {
+        "label": "Billing Dispute SOP Index",
+        "description": "SOP grounding for the Billing Dispute Analyst agent.",
+        "icon": "context",
+        "shape": "circle"
+      },
+      "handleConfiguration": [
+        {
+          "position": "top",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "artifact",
+              "constraints": {
+                "maxConnections": 1,
+                "allowedSources": [
+                  {
+                    "nodeType": "uipath.agent.autonomous",
+                    "handleId": "context"
+                  },
+                  {
+                    "nodeType": "uipath.agent.conversational",
+                    "handleId": "context"
+                  },
+                  {
+                    "nodeType": "uipath.agent.voice",
+                    "handleId": "context"
+                  }
+                ],
+                "validationMessage": "Only Agent's context handle can connect here"
+              }
+            }
+          ]
+        }
+      ],
+      "model": {
+        "source": true,
+        "bindings": {
+          "resource": "index",
+          "resourceKey": "cc45b9b4-dbf6-47b3-40ac-08debc0cec5b",
+          "resourceSubType": null,
+          "entityKey": "cc45b9b4-dbf6-47b3-40ac-08debc0cec5b",
+          "folderKey": "79a7d12e-da84-4bf4-ab60-7f34b44dd178",
+          "folderPath": "Shared/uipath-maestro-flow/BillingDispute",
+          "values": [
+            {
+              "name": "name",
+              "propertyAttribute": "name",
+              "default": "Billing Dispute SOP Index"
+            },
+            {
+              "name": "folderPath",
+              "propertyAttribute": "folderPath",
+              "default": "Shared/uipath-maestro-flow/BillingDispute"
+            }
+          ]
+        }
+      },
+      "form": {
+        "id": "context-index-form",
+        "title": "Context index",
+        "sections": [
+          {
+            "id": "index-settings",
+            "title": "Index settings",
+            "collapsible": true,
+            "defaultExpanded": true,
+            "fields": [
+              {
+                "name": "inputs",
+                "type": "custom",
+                "component": "index-settings-editor",
+                "label": ""
+              }
+            ]
+          }
+        ]
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "indexId": {
+            "type": "string"
+          },
+          "indexName": {
+            "type": "string"
+          },
+          "folderKey": {
+            "type": "string"
+          },
+          "folderPath": {
+            "type": "string"
+          },
+          "retrievalMode": {
+            "type": "string"
+          },
+          "query": {
+            "type": "object"
+          },
+          "threshold": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "resultCount": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 40
+          },
+          "fileExtension": {
+            "type": "string"
+          },
+          "folderPathPrefix": {
+            "type": "object"
+          },
+          "citations": {
+            "type": "string"
+          },
+          "outputColumns": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "webSearchGrounding": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "retrievalMode": {
+                  "not": {
+                    "enum": [
+                      "deeprag",
+                      "batchtransform"
+                    ]
+                  }
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "query": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "mode": {
+                          "const": "prompt"
+                        },
+                        "promptValue": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "promptValue"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "mode": {
+                          "const": "text-builder"
+                        },
+                        "textValue": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "textValue"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "mode": {
+                          "const": "variable"
+                        },
+                        "argumentPath": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "argumentPath"
+                      ]
+                    }
+                  ],
+                  "errorMessage": "Query is required"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "retrievalMode": {
+                  "const": "deeprag"
+                }
+              },
+              "required": [
+                "retrievalMode"
+              ]
+            },
+            "then": {
+              "properties": {
+                "query": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "mode": {
+                          "const": "prompt"
+                        },
+                        "promptValue": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "promptValue"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "mode": {
+                          "const": "text-builder"
+                        },
+                        "textValue": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "textValue"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "mode": {
+                          "const": "variable"
+                        },
+                        "argumentPath": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "argumentPath"
+                      ]
+                    }
+                  ],
+                  "errorMessage": "DeepRAG task is required"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "retrievalMode": {
+                  "const": "batchtransform"
+                }
+              },
+              "required": [
+                "retrievalMode"
+              ]
+            },
+            "then": {
+              "properties": {
+                "query": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "mode": {
+                          "const": "prompt"
+                        },
+                        "promptValue": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "promptValue"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "mode": {
+                          "const": "text-builder"
+                        },
+                        "textValue": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "textValue"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "mode": {
+                          "const": "variable"
+                        },
+                        "argumentPath": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "mode",
+                        "argumentPath"
+                      ]
+                    }
+                  ],
+                  "errorMessage": "Batch transform task is required"
+                },
+                "outputColumns": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "description": {
+                        "type": "string",
+                        "minLength": 1,
+                        "errorMessage": "Description is required for every output column"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "description"
+                    ]
+                  },
+                  "errorMessage": {
+                    "minItems": "At least one output column is required"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "inputDefaults": {
+        "indexId": "cc45b9b4-dbf6-47b3-40ac-08debc0cec5b",
+        "indexName": "Billing Dispute SOP Index",
+        "folderKey": "79a7d12e-da84-4bf4-ab60-7f34b44dd178",
+        "folderPath": "Shared/uipath-maestro-flow/BillingDispute",
+        "retrievalMode": "semantic",
+        "query": {
+          "mode": "prompt",
+          "textValue": "",
+          "promptValue": "The query for the Semantic strategy",
+          "argumentPath": ""
+        },
+        "threshold": 0,
+        "resultCount": 3,
+        "fileExtension": "All",
+        "folderPathPrefix": {
+          "mode": "text-builder",
+          "textValue": "",
+          "promptValue": "",
+          "argumentPath": ""
+        },
+        "citations": "enabled",
+        "outputColumns": [],
+        "webSearchGrounding": {
+          "value": "enabled"
+        }
+      }
+    },
+    {
+      "nodeType": "core.logic.switch",
+      "version": "1.1",
+      "category": "control-flow",
+      "description": "Route to one of many branches by condition",
+      "tags": [
+        "control-flow",
+        "switch",
+        "case",
+        "when"
+      ],
+      "sortOrder": 62,
+      "display": {
+        "label": "Switch",
+        "icon": "between-horizontal-start"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ],
+          "visible": true
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "case-{item.id}",
+              "type": "source",
+              "handleType": "output",
+              "label": "{item.label || 'Case ' + (index + 1)}",
+              "repeat": "inputs.cases"
+            },
+            {
+              "id": "default",
+              "type": "source",
+              "handleType": "output",
+              "label": "Default"
+            }
+          ],
+          "visible": true
+        }
+      ],
+      "debug": {
+        "runtime": "clientScript"
+      },
+      "model": {
+        "type": "bpmn:ExclusiveGateway"
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "cases": {
+            "type": "array",
+            "minItems": 1,
+            "errorMessage": "At least one case is required",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "expression": {
+                  "type": "string",
+                  "minLength": 1,
+                  "errorMessage": "Add a condition"
+                }
+              },
+              "required": [
+                "expression"
+              ]
+            }
+          }
+        },
+        "required": [
+          "cases"
+        ]
+      },
+      "outputDefinition": {
+        "matchedCase": {
+          "type": "string",
+          "description": "The label of the matched case",
+          "var": "matchedCase"
+        },
+        "matchedCaseId": {
+          "type": "string",
+          "description": "The ID of the matched case (\"default\" for the default branch)",
+          "var": "matchedCaseId"
+        }
+      },
+      "inputDefaults": {
+        "cases": [
+          {
+            "id": "default-1",
+            "label": "Case 1",
+            "expression": ""
+          },
+          {
+            "id": "default-2",
+            "label": "Case 2",
+            "expression": ""
+          }
+        ]
+      },
+      "form": {
+        "id": "switch-properties",
+        "title": "Switch configuration",
+        "sections": [
+          {
+            "id": "cases",
+            "title": "Cases",
+            "description": "Each case is evaluated in order. The first condition that returns true is taken.",
+            "collapsible": true,
+            "defaultExpanded": true,
+            "fields": [
+              {
+                "name": "inputs.cases",
+                "type": "custom",
+                "label": "Switch cases",
+                "component": "case-list-editor",
+                "componentProps": {
+                  "minCases": 1,
+                  "maxCases": 10,
+                  "expressionPlaceholder": "$vars.httpRequest1.output.statusCode >= 200 && $vars.httpRequest1.output.statusCode < 300",
+                  "expressionValidationFields": [
+                    {
+                      "subPath": "expression",
+                      "validationMode": "expression",
+                      "expectedType": "boolean"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "runtimeConstraints": {
+        "exclude": [
+          "api-function"
+        ]
+      }
+    },
+    {
+      "nodeType": "core.logic.decision",
+      "version": "1.3",
+      "category": "control-flow",
+      "description": "Branch on a true or false condition",
+      "tags": [
+        "control-flow",
+        "if",
+        "loop",
+        "switch"
+      ],
+      "sortOrder": 61,
+      "display": {
+        "label": "Decision",
+        "icon": "trending-up-down"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ],
+          "visible": true
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "true",
+              "type": "source",
+              "handleType": "output",
+              "label": "{inputs.trueLabel}"
+            },
+            {
+              "id": "false",
+              "type": "source",
+              "handleType": "output",
+              "label": "{inputs.falseLabel}"
+            }
+          ],
+          "visible": true
+        }
+      ],
+      "debug": {
+        "runtime": "clientScript"
+      },
+      "model": {
+        "type": "bpmn:InclusiveGateway"
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "expression": {
+            "type": "string",
+            "minLength": 1,
+            "errorMessage": "Add a condition"
+          },
+          "trueLabel": {
+            "type": "string"
+          },
+          "falseLabel": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "expression"
+        ]
+      },
+      "outputDefinition": {
+        "matchedCase": {
+          "type": "string",
+          "description": "The label of the matched branch (true/false label)",
+          "var": "matchedCase"
+        },
+        "matchedCaseId": {
+          "type": "string",
+          "description": "The branch that was taken (true or false)",
+          "var": "matchedCaseId"
+        }
+      },
+      "inputDefaults": {
+        "trueLabel": "True",
+        "falseLabel": "False"
+      },
+      "form": {
+        "id": "decision-properties",
+        "title": "Decision configuration",
+        "sections": [
+          {
+            "id": "condition",
+            "title": "Condition",
+            "fields": [
+              {
+                "name": "inputs.expression",
+                "type": "custom",
+                "component": "code-editor",
+                "componentProps": {
+                  "singleLine": true,
+                  "mode": "expression",
+                  "toggleable": false,
+                  "language": "javascript",
+                  "returnType": "boolean",
+                  "validationMode": "expression",
+                  "showVariableButton": true,
+                  "placeholder": "$vars.httpRequest1.output.statusCode >= 200 && $vars.httpRequest1.output.statusCode < 300"
+                },
+                "label": "Condition",
+                "description": "The condition must be a JavaScript expression that evaluates to true or false."
+              },
+              {
+                "name": "inputs.trueLabel",
+                "type": "text",
+                "label": "True branch label",
+                "description": "This label appears on the true branch."
+              },
+              {
+                "name": "inputs.falseLabel",
+                "type": "text",
+                "label": "False branch label",
+                "description": "This label appears on the false branch."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "nodeType": "uipath.core.api-workflow.07d45a91-9413-4dad-82ff-28306c2d85ea",
+      "version": "1.0.0",
+      "category": "api-workflow.published",
+      "runtimeConstraints": {
+        "exclude": [
+          "api-function"
+        ]
+      },
+      "description": "",
+      "tags": [],
+      "sortOrder": 640,
+      "supportsErrorHandling": true,
+      "display": {
+        "label": "FinancialPostingFunction",
+        "icon": "api"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ]
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "output",
+              "type": "source",
+              "handleType": "output"
+            },
+            {
+              "id": "error",
+              "label": "Error",
+              "type": "source",
+              "handleType": "output",
+              "visible": "{inputs.errorHandlingEnabled}",
+              "constraints": {
+                "maxConnections": 1
+              }
+            }
+          ]
+        }
+      ],
+      "model": {
+        "type": "bpmn:ServiceTask",
+        "serviceType": "Orchestrator.ExecuteApiWorkflowAsync",
+        "version": "v2",
+        "listingVersion": "1.0.0",
+        "bindings": {
+          "resource": "process",
+          "resourceSubType": "Api",
+          "resourceKey": "Shared/uipath-maestro-flow/BillingDispute.FinancialPostingFunction",
+          "orchestratorType": "api",
+          "values": [
+            {
+              "name": "name",
+              "propertyAttribute": "name",
+              "default": "FinancialPostingFunction"
+            },
+            {
+              "name": "folderPath",
+              "propertyAttribute": "folderPath",
+              "default": "Shared/uipath-maestro-flow/BillingDispute"
+            }
+          ]
+        },
+        "context": [
+          {
+            "name": "name",
+            "type": "string",
+            "value": "<bindings.name>"
+          },
+          {
+            "name": "folderPath",
+            "type": "string",
+            "value": "<bindings.folderPath>"
+          },
+          {
+            "name": "_label",
+            "type": "string",
+            "value": "FinancialPostingFunction"
+          }
+        ]
+      },
+      "form": {
+        "id": "activity-properties",
+        "title": "API Workflow",
+        "sections": [
+          {
+            "id": "inputs",
+            "title": "Inputs",
+            "collapsible": true,
+            "defaultExpanded": true,
+            "fields": [
+              {
+                "name": "inputs.invoiceNumber",
+                "type": "text",
+                "label": "invoiceNumber"
+              }
+            ]
+          }
+        ]
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "invoiceNumber": {
+            "type": "string"
+          }
+        }
+      },
+      "inputDefaults": {
+        "invoiceNumber": ""
+      },
+      "outputDefinition": {
+        "error": {
+          "type": "object",
+          "description": "Error information if the node fails",
+          "source": "=Error",
+          "var": "error",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": [
+              "code",
+              "message",
+              "detail",
+              "category",
+              "status"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code as a string"
+              },
+              "message": {
+                "type": "string",
+                "description": "High-level error message"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Detailed error description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Error category"
+              },
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "debug": {
+        "runtime": "bpmnEngine"
+      }
+    },
+    {
+      "nodeType": "core.control.end",
+      "version": "1.0",
+      "category": "control-flow",
+      "description": "Mark the end of a process path",
+      "tags": [
+        "control-flow",
+        "end",
+        "finish",
+        "complete"
+      ],
+      "sortOrder": 66,
+      "display": {
+        "label": "End",
+        "icon": "circle-check",
+        "shape": "circle"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ]
+        }
+      ],
+      "model": {
+        "type": "bpmn:EndEvent"
+      }
+    }
+  ],
+  "runtime": "maestro",
+  "bindings": [
+    {
+      "id": "byf4qw11L",
+      "name": "name",
+      "type": "string",
+      "resource": "ixpDeployment",
+      "resourceKey": "99f5bbfa-5f29-8033-8662-25001b6bb18e",
+      "default": "invoices-billing",
+      "propertyAttribute": "name"
+    },
+    {
+      "id": "bxD4pkO8J",
+      "name": "folderPath",
+      "type": "string",
+      "resource": "ixpDeployment",
+      "resourceKey": "99f5bbfa-5f29-8033-8662-25001b6bb18e",
+      "default": "Shared/uipath-maestro-flow/BillingDispute",
+      "propertyAttribute": "folderPath"
+    },
+    {
+      "id": "bW4AajuIr",
+      "name": "name",
+      "type": "string",
+      "resource": "index",
+      "resourceKey": "cc45b9b4-dbf6-47b3-40ac-08debc0cec5b",
+      "default": "Billing Dispute SOP Index",
+      "propertyAttribute": "name"
+    },
+    {
+      "id": "bL20r8vi6",
+      "name": "folderPath",
+      "type": "string",
+      "resource": "index",
+      "resourceKey": "cc45b9b4-dbf6-47b3-40ac-08debc0cec5b",
+      "default": "Shared/uipath-maestro-flow/BillingDispute",
+      "propertyAttribute": "folderPath"
+    },
+    {
+      "id": "bEMTSaWqC",
+      "name": "name",
+      "type": "string",
+      "resource": "process",
+      "resourceKey": "Shared/uipath-maestro-flow/BillingDispute.FinancialPostingFunction",
+      "default": "FinancialPostingFunction",
+      "propertyAttribute": "name",
+      "resourceSubType": "Api"
+    },
+    {
+      "id": "bs3HbwT6R",
+      "name": "folderPath",
+      "type": "string",
+      "resource": "process",
+      "resourceKey": "Shared/uipath-maestro-flow/BillingDispute.FinancialPostingFunction",
+      "default": "Shared/uipath-maestro-flow/BillingDispute",
+      "propertyAttribute": "folderPath",
+      "resourceSubType": "Api"
+    }
+  ],
+  "variables": {
+    "nodes": [
+      {
+        "id": "start.output",
+        "type": "object",
+        "description": "Data passed when manually triggering the process.",
+        "binding": {
+          "nodeId": "start",
+          "outputId": "output"
+        }
+      },
+      {
+        "id": "invoiceExtraction1.output",
+        "type": "object",
+        "binding": {
+          "nodeId": "invoiceExtraction1",
+          "outputId": "output"
+        }
+      },
+      {
+        "id": "invoiceExtraction1.error",
+        "type": "object",
+        "description": "Error information if the node fails",
+        "binding": {
+          "nodeId": "invoiceExtraction1",
+          "outputId": "error"
+        }
+      },
+      {
+        "id": "normalizeData1.output",
+        "type": "any",
+        "description": "The return value of the script",
+        "binding": {
+          "nodeId": "normalizeData1",
+          "outputId": "output"
+        }
+      },
+      {
+        "id": "normalizeData1.error",
+        "type": "object",
+        "description": "Error information if the node fails",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "required": [
+            "code",
+            "message",
+            "detail",
+            "category",
+            "status"
+          ],
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Error code as a string"
+            },
+            "message": {
+              "type": "string",
+              "description": "High-level error message"
+            },
+            "detail": {
+              "type": "string",
+              "description": "Detailed error description"
+            },
+            "category": {
+              "type": "string",
+              "description": "Error category"
+            },
+            "status": {
+              "type": "integer",
+              "description": "HTTP status code"
+            }
+          },
+          "additionalProperties": false
+        },
+        "binding": {
+          "nodeId": "normalizeData1",
+          "outputId": "error"
+        }
+      },
+      {
+        "id": "crmLookup1.output",
+        "type": "jsonSchema",
+        "description": "Entity record queried by this node, or the matching records under \"results\"",
+        "binding": {
+          "nodeId": "crmLookup1",
+          "outputId": "output"
+        }
+      },
+      {
+        "id": "erpLookup1.output",
+        "type": "jsonSchema",
+        "description": "Entity record queried by this node, or the matching records under \"results\"",
+        "binding": {
+          "nodeId": "erpLookup1",
+          "outputId": "output"
+        }
+      },
+      {
+        "id": "discrepancyDetection1.output",
+        "type": "any",
+        "description": "The return value of the script",
+        "binding": {
+          "nodeId": "discrepancyDetection1",
+          "outputId": "output"
+        }
+      },
+      {
+        "id": "discrepancyDetection1.error",
+        "type": "object",
+        "description": "Error information if the node fails",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "required": [
+            "code",
+            "message",
+            "detail",
+            "category",
+            "status"
+          ],
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Error code as a string"
+            },
+            "message": {
+              "type": "string",
+              "description": "High-level error message"
+            },
+            "detail": {
+              "type": "string",
+              "description": "Detailed error description"
+            },
+            "category": {
+              "type": "string",
+              "description": "Error category"
+            },
+            "status": {
+              "type": "integer",
+              "description": "HTTP status code"
+            }
+          },
+          "additionalProperties": false
+        },
+        "binding": {
+          "nodeId": "discrepancyDetection1",
+          "outputId": "error"
+        }
+      },
+      {
+        "id": "disputeAnalystAgent1.output",
+        "type": "object",
+        "description": "Agent response",
+        "binding": {
+          "nodeId": "disputeAnalystAgent1",
+          "outputId": "output"
+        }
+      },
+      {
+        "id": "disputeAnalystAgent1.error",
+        "type": "object",
+        "description": "Error information if the node fails",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "required": [
+            "code",
+            "message",
+            "detail",
+            "category",
+            "status"
+          ],
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Error code as a string"
+            },
+            "message": {
+              "type": "string",
+              "description": "High-level error message"
+            },
+            "detail": {
+              "type": "string",
+              "description": "Detailed error description"
+            },
+            "category": {
+              "type": "string",
+              "description": "Error category"
+            },
+            "status": {
+              "type": "integer",
+              "description": "HTTP status code"
+            }
+          },
+          "additionalProperties": false
+        },
+        "binding": {
+          "nodeId": "disputeAnalystAgent1",
+          "outputId": "error"
+        }
+      },
+      {
+        "id": "routeRecommendedAction1.matchedCase",
+        "type": "string",
+        "description": "The label of the matched case",
+        "binding": {
+          "nodeId": "routeRecommendedAction1",
+          "outputId": "matchedCase"
+        }
+      },
+      {
+        "id": "routeRecommendedAction1.matchedCaseId",
+        "type": "string",
+        "description": "The ID of the matched case (\"default\" for the default branch)",
+        "binding": {
+          "nodeId": "routeRecommendedAction1",
+          "outputId": "matchedCaseId"
+        }
+      },
+      {
+        "id": "logCreditAmount1.output",
+        "type": "any",
+        "description": "The return value of the script",
+        "binding": {
+          "nodeId": "logCreditAmount1",
+          "outputId": "output"
+        }
+      },
+      {
+        "id": "logCreditAmount1.error",
+        "type": "object",
+        "description": "Error information if the node fails",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "required": [
+            "code",
+            "message",
+            "detail",
+            "category",
+            "status"
+          ],
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Error code as a string"
+            },
+            "message": {
+              "type": "string",
+              "description": "High-level error message"
+            },
+            "detail": {
+              "type": "string",
+              "description": "Detailed error description"
+            },
+            "category": {
+              "type": "string",
+              "description": "Error category"
+            },
+            "status": {
+              "type": "integer",
+              "description": "HTTP status code"
+            }
+          },
+          "additionalProperties": false
+        },
+        "binding": {
+          "nodeId": "logCreditAmount1",
+          "outputId": "error"
+        }
+      },
+      {
+        "id": "managerApprovalDecision1.matchedCase",
+        "type": "string",
+        "description": "The label of the matched branch (true/false label)",
+        "binding": {
+          "nodeId": "managerApprovalDecision1",
+          "outputId": "matchedCase"
+        }
+      },
+      {
+        "id": "managerApprovalDecision1.matchedCaseId",
+        "type": "string",
+        "description": "The branch that was taken (true or false)",
+        "binding": {
+          "nodeId": "managerApprovalDecision1",
+          "outputId": "matchedCaseId"
+        }
+      },
+      {
+        "id": "financialpostingfunction1.error",
+        "type": "object",
+        "description": "Error information if the node fails",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "required": [
+            "code",
+            "message",
+            "detail",
+            "category",
+            "status"
+          ],
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Error code as a string"
+            },
+            "message": {
+              "type": "string",
+              "description": "High-level error message"
+            },
+            "detail": {
+              "type": "string",
+              "description": "Detailed error description"
+            },
+            "category": {
+              "type": "string",
+              "description": "Error category"
+            },
+            "status": {
+              "type": "integer",
+              "description": "HTTP status code"
+            }
+          },
+          "additionalProperties": false
+        },
+        "binding": {
+          "nodeId": "financialpostingfunction1",
+          "outputId": "error"
+        }
+      },
+      {
+        "id": "resolutionWriterAgent1.output",
+        "type": "object",
+        "description": "Agent response",
+        "binding": {
+          "nodeId": "resolutionWriterAgent1",
+          "outputId": "output"
+        }
+      },
+      {
+        "id": "resolutionWriterAgent1.error",
+        "type": "object",
+        "description": "Error information if the node fails",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "required": [
+            "code",
+            "message",
+            "detail",
+            "category",
+            "status"
+          ],
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Error code as a string"
+            },
+            "message": {
+              "type": "string",
+              "description": "High-level error message"
+            },
+            "detail": {
+              "type": "string",
+              "description": "Detailed error description"
+            },
+            "category": {
+              "type": "string",
+              "description": "Error category"
+            },
+            "status": {
+              "type": "integer",
+              "description": "HTTP status code"
+            }
+          },
+          "additionalProperties": false
+        },
+        "binding": {
+          "nodeId": "resolutionWriterAgent1",
+          "outputId": "error"
+        }
+      },
+      {
+        "id": "returnResolution1.output",
+        "type": "object",
+        "binding": {
+          "nodeId": "returnResolution1",
+          "outputId": "output"
+        }
+      },
+      {
+        "id": "returnResolution1.error",
+        "type": "object",
+        "description": "Error information if the node fails",
+        "binding": {
+          "nodeId": "returnResolution1",
+          "outputId": "error"
+        }
+      },
+      {
+        "id": "returnResolution1.determination",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnResolution1",
+          "outputId": "determination"
+        }
+      },
+      {
+        "id": "returnResolution1.recommendedAction",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnResolution1",
+          "outputId": "recommendedAction"
+        }
+      },
+      {
+        "id": "returnResolution1.creditAmount",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnResolution1",
+          "outputId": "creditAmount"
+        }
+      },
+      {
+        "id": "returnResolution1.rationale",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnResolution1",
+          "outputId": "rationale"
+        }
+      },
+      {
+        "id": "returnResolution1.resolutionEmailBody",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnResolution1",
+          "outputId": "resolutionEmailBody"
+        }
+      },
+      {
+        "id": "returnRejection1.determination",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnRejection1",
+          "outputId": "determination"
+        }
+      },
+      {
+        "id": "returnRejection1.recommendedAction",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnRejection1",
+          "outputId": "recommendedAction"
+        }
+      },
+      {
+        "id": "returnRejection1.creditAmount",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnRejection1",
+          "outputId": "creditAmount"
+        }
+      },
+      {
+        "id": "returnRejection1.rationale",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnRejection1",
+          "outputId": "rationale"
+        }
+      },
+      {
+        "id": "returnRejection1.resolutionEmailBody",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnRejection1",
+          "outputId": "resolutionEmailBody"
+        }
+      },
+      {
+        "id": "returnManagerRejection1.determination",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnManagerRejection1",
+          "outputId": "determination"
+        }
+      },
+      {
+        "id": "returnManagerRejection1.recommendedAction",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnManagerRejection1",
+          "outputId": "recommendedAction"
+        }
+      },
+      {
+        "id": "returnManagerRejection1.creditAmount",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnManagerRejection1",
+          "outputId": "creditAmount"
+        }
+      },
+      {
+        "id": "returnManagerRejection1.rationale",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnManagerRejection1",
+          "outputId": "rationale"
+        }
+      },
+      {
+        "id": "returnManagerRejection1.resolutionEmailBody",
+        "type": "string",
+        "binding": {
+          "nodeId": "returnManagerRejection1",
+          "outputId": "resolutionEmailBody"
+        }
+      }
+    ],
+    "globals": [
+      {
+        "id": "disputedInvoice",
+        "direction": "in",
+        "type": "file",
+        "description": "Disputed invoice PDF",
+        "triggerNodeId": "start"
+      },
+      {
+        "id": "webhookPayload",
+        "direction": "in",
+        "type": "object",
+        "description": "Billing dispute submission event",
+        "triggerNodeId": "start"
+      },
+      {
+        "id": "determination",
+        "direction": "out",
+        "type": "string"
+      },
+      {
+        "id": "recommendedAction",
+        "direction": "out",
+        "type": "string"
+      },
+      {
+        "id": "creditAmount",
+        "direction": "out",
+        "type": "number"
+      },
+      {
+        "id": "rationale",
+        "direction": "out",
+        "type": "string"
+      },
+      {
+        "id": "resolutionEmailBody",
+        "direction": "out",
+        "type": "string"
+      }
+    ]
+  },
+  "layout": {
+    "nodes": {
+      "start": {
+        "position": {
+          "x": -192,
+          "y": 0
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "invoiceExtraction1": {
+        "position": {
+          "x": 0,
+          "y": 0
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "normalizeData1": {
+        "position": {
+          "x": 192,
+          "y": -16
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "crmLookup1": {
+        "position": {
+          "x": 384,
+          "y": 160
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "erpLookup1": {
+        "position": {
+          "x": 384,
+          "y": -32
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "mergeLookups1": {
+        "position": {
+          "x": 576,
+          "y": -32
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "discrepancyDetection1": {
+        "position": {
+          "x": 768,
+          "y": -32
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "disputeAnalystAgent1": {
+        "position": {
+          "x": 960,
+          "y": -144
+        },
+        "size": {
+          "width": 288,
+          "height": 96
+        }
+      },
+      "billingDisputeSopIndex1": {
+        "position": {
+          "x": 1008,
+          "y": 48
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "routeRecommendedAction1": {
+        "position": {
+          "x": 1344,
+          "y": 0
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "logCreditAmount1": {
+        "position": {
+          "x": 1536,
+          "y": -16
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "managerApprovalDecision1": {
+        "position": {
+          "x": 1536,
+          "y": -208
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "financialpostingfunction1": {
+        "position": {
+          "x": 1728,
+          "y": -32
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "resolutionWriterAgent1": {
+        "position": {
+          "x": 1920,
+          "y": -48
+        },
+        "size": {
+          "width": 288,
+          "height": 96
+        }
+      },
+      "returnResolution1": {
+        "position": {
+          "x": 2304,
+          "y": -64
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "returnRejection1": {
+        "position": {
+          "x": 1536,
+          "y": 176
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "returnManagerRejection1": {
+        "position": {
+          "x": 1728,
+          "y": -224
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      }
+    }
+  }
+}

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/check_server_side_filter.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/check_server_side_filter.py
@@ -6,14 +6,26 @@ script passes the 8-row oracle on seeded data but silently breaks once the
 entity outgrows the page limit. This check records which route the build took;
 it is advisory (pass_threshold 0) and never gates the score.
 
-Passes when the query-entity-records node carries a non-empty filter — a
-`queryExpression` (inline or `=js:` bound) or a structured filter/filterGroup,
-including the `{var_…}` + `filterVariables` form `node configure` emits for
-dynamic operands.
+Passes when the read carries a non-empty filter. On the Data Service connector
+that is a `queryExpression` (inline or `=js:` bound) or a structured
+filter/filterGroup, including the `{var_…}` + `filterVariables` form `node
+configure` emits for dynamic operands. On the native `core.datafabric.read` node
+it is at least one `entityConfig._filters` row — the container is always present,
+so its emptiness is what matters.
 """
 import glob
 import json
+import os
 import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+from _shared.advisory_flow_utils import (  # noqa: E402
+    NATIVE_READ_TYPE,
+    native_filter_rows,
+)
 
 
 def find_flow() -> dict:
@@ -38,13 +50,23 @@ def has_filter(obj) -> bool:
     return False
 
 
+def filters_server_side(node) -> bool:
+    if node.get("type") == NATIVE_READ_TYPE:
+        return bool(native_filter_rows(node))
+    return has_filter(node.get("inputs", {}))
+
+
 flow = find_flow()
-queries = [n for n in flow.get("nodes", []) if "query-entity-records" in n.get("type", "")]
+queries = [
+    n
+    for n in flow.get("nodes", [])
+    if "query-entity-records" in n.get("type", "") or n.get("type") == NATIVE_READ_TYPE
+]
 if not queries:
-    print("ADVISORY FAIL: no query-entity-records node")
+    print("ADVISORY FAIL: no entity-read node (query-entity-records or core.datafabric.read)")
     sys.exit(1)
 
-unfiltered = [n["id"] for n in queries if not has_filter(n.get("inputs", {}))]
+unfiltered = [n["id"] for n in queries if not filters_server_side(n)]
 if unfiltered:
     print(f"ADVISORY FAIL: no server-side filter on {', '.join(unfiltered)} — "
           "entity fetched whole and filtered client-side; breaks silently past the page limit")

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/check_server_side_filter.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/check_server_side_filter.py
@@ -52,7 +52,13 @@ def has_filter(obj) -> bool:
 
 def filters_server_side(node) -> bool:
     if node.get("type") == NATIVE_READ_TYPE:
-        return bool(native_filter_rows(node))
+        # A row is a predicate only once it names a column and carries a value.
+        # `rows: [{}]` is a list the serializer emits nothing from, so list
+        # non-emptiness is not the question.
+        return any(
+            str(row.get("field") or "").strip() and str(row.get("value") or "").strip()
+            for row in native_filter_rows(node)
+        )
     return has_filter(node.get("inputs", {}))
 
 


### PR DESCRIPTION
Follow-up to #3231, which named this PR as the way to close its own known gap.

## What

Every advisory on the three DevCon billing tasks reads the entity lookups as Integration Service connector activities. A flow built with the native `core.datafabric.read` node fails them on contracts that node does not have:

| Advisory | Task(s) | Weight | Demands | Native build |
|---|---|---|---|---|
| `advisory_billing_dispute_resolution` | dispute resolution | 1.0 | a `connection` binding | has none |
| `advisory_billing_invoice_lookup` | invoice lookup | 1.0 | `detail.connectionId` + `connectionFolderKey` | has neither |
| `advisory_billing_discrepancy_detector` | discrepancy detector | 1.0 | the same pair, on both reads | the same |
| `check_bindings_no_stubs` | both siblings | 1.0 ea. | `declares no bindings at all` | no `connection` row |
| `check_server_side_filter` | invoice lookup | 1.0 | a `query-entity-records` node | is not one |

This adds one shared definition of "the nodes that read entity records" plus the native equivalent of each shape-specific assertion, and points every call site at it:

```python
CONNECTOR_READ_PREFIX = "uipath.connector.uipath-uipath-dataservice."
NATIVE_READ_TYPE = "core.datafabric.read"

def entity_reads(nodes) -> tuple[str, list[dict]]: ...
```

Each equivalent replaces a connector assertion one-for-one:

| Connector assertion | Native equivalent |
|---|---|
| `entityName` in the `{entityName}` path slot | `entityConfig.entityName` |
| `queryExpression` computed from `$vars` | a `_filters` row whose value is a `=js:` expression on the flow's own input |
| CEQL string literal single-quoted | operator in the supported set, value non-blank, no `$self`, each refuses the **whole** query |
| a non-empty `queryExpression`/`filter`/`filterGroup` | at least one `_filters` row |
| `connectionId`/`connectionFolderKey` uuid pair | entity scope; a connection required only of a flow that has a connector node |

## Why

The native node needs **no** Integration Service connection and **no** `bindings[]` connection row (`data-fabric/planning.md:62`), so demanding one fails the better build for being the better build.

From the 2026-09-11 run of `skill-flow-devcon-billing-dispute-resolution`:

- `uip maestro flow validate` → `Valid`
- the agent built two `core.datafabric.read` nodes, tenant-scoped, filters pushed server-side
- `check_e2e_billing_dispute_resolution.py` → `OK: flow returned a real SOP-grounded resolution citing MCS-2026-04872 (no email sent)`
- all five contract outputs declared with the contract's types
- **score 0.727**, and the advisory's line was:

```
FAIL: the flow declares NO `connection` binding.
```

`pass_threshold: 0` keeps an advisory from gating run *status*, but not from contributing its zero to the weighted score, 8/11 is exactly the arithmetic of two zeros at weights 2 and 1.

## The anti-hardcode guard survives

It is the whole reason the offline behaviour rungs mean anything, so shape must not be a way around it. The native branch requires a `_filters` row whose value is a `=js:` expression on the flow's own input; a literal there fails. `test_native_anti_hardcode_guard_survives` locks it by replacing the derived row's value with the canonical answer and asserting the advisory still fails.

## Deliberately not required

An `Entity` binding row on a **tenant-scoped** read. A tenant-scoped entity needs nothing beyond `entityName` (`impl.md:303`), and the skill tells the agent to stay tenant-scoped when it cannot resolve a `_resourceKey`, calling a half-authored folder scope "worse than none" (`impl.md:333`). The run's flow carried no entity binding and debugged green.

The pair **is** required once `_folderKey` appears, where the name and folder otherwise serialize as source-org literals and break on deploy. Both that and the lowercase `resource: "entity"` form packaging silently ignores are asserted.

## Nothing is loosened for a connector build

- `check_bindings_no_stubs` still fails a connector flow with no connection row (`test_bindings_checker_still_requires_one_for_a_connector_build`), and still fails a stub row wherever one is declared, native build included (`test_bindings_checker_rejects_a_stub_connection_on_a_native_build`).
- `check_server_side_filter` still fails an empty `_filters` container, which is always present and so cannot be read as "filtered" (`test_server_side_filter_rejects_an_empty_native_filter`).
- `check_server_side_filter` has one caller and `check_bindings_no_stubs` two, all three Data Fabric scenarios, so no other task's behaviour can move.

## Fixtures

`BillingDisputeResolution.native.reference.flow` is the 2026-09-11 artifact kept verbatim, the only real native build of any of these scenarios, and the exact flow that scored 0. The other two native cases are derived from their connector reference inside the test, so the computed filter under test stays the reference's rather than something hand-written here.

## Verification

```
pytest tests/tasks/uipath-maestro-flow/ -q
1205 passed in 27.52s
```

14 new tests. Reverting the discriminator is caught **twice, independently**, by the artifact fixture and by the call-site guard, verified by temporarily reverting `advisory_billing_dispute_resolution.py`'s call site and watching both fail. Five negative cases were each run by hand to confirm they fail for the intended reason, not incidentally.

Includes the corpus guards: `test_same_ground_corpus.py`, `test_criterion_budgets.py`, `test_same_ground_advisories.py`, `test_headless_preamble.py`.

## One tightening, not strictly required

`advisory_billing_invoice_lookup` and `advisory_billing_discrepancy_detector` each hand-rolled a **prefix-only** uuid regex (`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-`). Both now use this module's existing `is_real_uuid`, which full-matches all 36 characters. A truncated uuid used to pass the connector branch and now fails. Both connector references still pass. Easy to back out if you would rather keep the diff pure.

## Measured effect

Run [34626987724](https://github.com/UiPath/skills/actions/runs/34626987724), `run-coder-eval.yml` on this branch, codex / `gpt-5.6-terra` to match the 2026-09-11 run. Pinned explicitly: `CODEX_MODEL` now defaults to `gpt-5.6-luna`, so leaving it blank would have measured a different model against the old numbers.

| Task | Shape built | 2026-09-11 | This run | After `f4872dd` |
|---|---|---|---|---|
| `billing_invoice_lookup` | native, 1 read | 0.727 | **0.909** | 11/11 |
| `billing_discrepancy_detector` | native, 2 reads | 0.800 | **0.900** | 10/10 |
| `billing_dispute_resolution` | connector, 2 reads | 0.727 | **1.000** | 1.000 |

All three FAILURE to SUCCESS. Two built native and exercised the new path; the third built connector-shaped and confirms that path is unbroken end to end, live.

**The run found a defect three reviews missed.** Both native tasks still lost one weight-1 advisory to `AssertionError: no generated bindings.json or bindings_v2.json found`. A pure Data Fabric flow references no packaged resource, so the CLI writes no bindings file at all, and `check_bindings_no_stubs` died one line before the connection check could apply. The earlier commit had fixed the wrong assertion, and the fixture hid it by supplying a file holding a `process` resource, a shape these flows never produce. Fixed in `f4872dd`, with the checker replayed against all three real artifact trees from the run.

The last column is criterion-weight arithmetic on top of that replay, not a second measured run.

**Still unexercised:** `billing_dispute_resolution` built connector-shaped this time, so the native branch of its advisory has live coverage only from the 2026-09-11 artifact, which is the fixture in this PR. Shape choice varies per run, which is the reason both shapes have to be gradeable.

**`billing_dispute_resolution` scored 1.000 without PR 1.** Its structural gate accepts the connector shape, so the gate only passes while the agent happens to build that way. PR 1 is still needed for the native case.

## Self-review, and what it changed

Reviewed in [#3249 (review)](https://github.com/UiPath/skills/pull/3249#pullrequestreview-5181266307): eight findings, two majors. Both majors are fixed in `d9ffb4c`, and both were verified to fail the suite when reverted.

1. **major** the native filter check could not follow a Script hop, which `billing_invoice_lookup`'s own prompt ("normalize the input ... then look up") invites. A false failure on the task this PR unblocks. `read_references_input` now follows it, via a `transitive_refs` factored out of `source_depends_on`.
2. **major** four of five native `fail()` paths had no automated coverage. Added, plus a `groups[]`-nested filter row, a `native_filter_rows` branch nothing reached.
3. **minor** the mixed-shape check was asymmetric and could false-fail a native read beside a connector write, which is a real tenant configuration since each native op has its own flag.
4. **minor** `needs_a_connection` matched only the Data Service prefix, so a future caller using Slack or Jira would silently stop requiring bindings.
5. **minor** `_folderKey` is folder scope by presence, so a blank one was being read as tenant-scoped.
6. **minor** the no-rows message asserted a `resultMode` nothing had checked.
7. **minor** two test-fixture naming problems.
8. **minor** house style: em-dashes, now out of this body. Commit `e56349c` still carries seven in its message; a squash merge composes the landed message from this body, so they do not reach `main`. Say the word if you want that commit rewritten instead.

Suite after the fixes: **1226 passed**, from 1191 on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
