### PR TITLE
fix(test): raise e2e_01 timeout to 3600, 2400 confirmed insufficient

### DIFF
--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -19,10 +19,20 @@ run_limits:
   # nightly.yaml). This test declared turn_timeout 2400 without also raising
   # task_timeout (previously fixed in 34aa3c773, since lost) so it kept
   # inheriting the 1200s default and dying mid-first-turn at exactly that
-  # mark, as re-confirmed on 2026-09-10 run 2026-09-10_04-18-49
-  # ("Task timed out after 1200s", iteration_count 1).
-  task_timeout: 2400
-  turn_timeout: 2400
+  # mark, confirmed on 2026-09-10 run 2026-09-10_04-18-49 ("Task timed out
+  # after 1200s", iteration_count 1) and fixed to 2400/2400 in #3196.
+  # 2400 still wasn't enough: 2026-09-11 run 2026-09-11_04-17-20 ran the full
+  # 2400s and timed out again ("Agent turn timed out after 2400s", iteration
+  # 1, 119 assistant turns, max_turns_exhausted False). The iteration log
+  # shows real forward progress the whole time, not a loop: live SharePoint/
+  # SAP connection discovery, IXP taxonomy lookup for invoice extraction, and
+  # registry lookups for every node type, each a real network round trip,
+  # before the agent even started writing the flow JSON around the 25-minute
+  # mark. Raised to 3600, matching the established heavy-single-turn budget
+  # used elsewhere in the repo (e.g. uipath-maestro-bpmn's external_wait and
+  # high_volume_batch tasks).
+  task_timeout: 3600
+  turn_timeout: 3600
 
 initial_prompt: |
   Build a UiPath Flow named "InvoiceApproval" that extracts invoice data


### PR DESCRIPTION
## Summary
skill-hitl-e2e-invoice-approval-greenfield failed again in the 2026-09-11 nightly (run 2026-09-11_04-17-20), on the Claude line: ERROR, "Agent turn timed out after 2400s".

#3196 raised this task from 1200s (an inherited default) to 2400/2400. That fix resolved the previous failure mode and is still correct. Today's run shows a different failure: the agent used the full 2400s making real forward progress the entire time. 119 assistant turns, max_turns_exhausted false.

## Evidence
The iteration log shows continuous, necessary work: live SharePoint and SAP connection discovery via uip is connections list, an IXP taxonomy lookup for invoice extraction, and registry lookups for every node type the flow needs. Each of those is a real network call. The agent was still on setup work, generating a UUID for the HITL schema, around the 25-minute mark of the 40-minute budget, before it had written the bulk of the flow JSON.

## Fix
Raised task_timeout and turn_timeout to 3600, matching the established heavy-single-turn budget already used elsewhere in the repo for similarly connector-discovery-heavy tasks (uipath-maestro-bpmn's external_wait and high_volume_batch tasks, at 3600 for the same reason).

## Test plan
- [x] 2026-09-11_04-17-20 run.json: ERROR, "Agent turn timed out after 2400s", iteration 1
- [x] Traced the full iteration log: continuous connector, registry, and taxonomy discovery work throughout
- [ ] Full coder-eval run to confirm 3600s covers the current task

🤖 Generated with [Claude Code](https://claude.com/claude-code)