### PR TITLE
docs(uipath-functions): document the local-debug flags on function run

### DIFF
--- a/skills/uipath-functions/SKILL.md
+++ b/skills/uipath-functions/SKILL.md
@@ -131,6 +131,7 @@ uip function new <NAME> -l py|ts|js [--empty]   # scaffold (TypeScript default; 
 uip function init                    # Python only — entry-points.json, bindings.json, project.uiproj
 uip function serve [--port 7070] [--runtime node|deno]   # JS/TS only — local HTTP server, hot reload
 uip function run                     # both languages — one-shot local execution
+uip function run --function <NAME> --inspect-wait 127.0.0.1:9229   # JS/TS — hold for a debugger to attach
 uip function pack [--nolock]         # build the .nupkg
 uip function publish [--feed-id <FEED_ID>]      # upload package to a process feed
 uip function push --project-id <PROJECT_ID>     # sync sources to a Studio Web project

--- a/skills/uipath-functions/references/js/local-dev-guide.md
+++ b/skills/uipath-functions/references/js/local-dev-guide.md
@@ -76,8 +76,33 @@ uip function run --entrypoint functions/<FILE>.ts --input-file <INPUT_JSON_PATH>
 | `--input '<JSON>'` \| `--input-file <PATH>` | Input payload (default `{}`; file takes priority) |
 | `--context '<JSON>'` \| `--context-file <PATH>` | Runtime-context JSON — simulate job identity/platform values (file takes priority) |
 | `--runtime node\|deno` | Runtime (default `node`) |
+| `--production` | Run under production context; skip the `.uipath/server-runner` install when it already exists |
+| `--inspect [ENDPOINT]` | Open the V8 inspector while the function runs (default `127.0.0.1:9229`) |
+| `--inspect-wait [ENDPOINT]` | Open the V8 inspector and wait for a debugger to attach **before** executing (default `127.0.0.1:9229`) |
+| `--trace-store` | Post the run's trace spans to the platform trace store (scope from `UIPATH_*` env vars + `UIPATH_ACCESS_TOKEN`) |
 
 Exit code mirrors the job outcome: non-zero when the run would Fault. Fault mapping and the runtime-context shape → [job-mode-guide.md](job-mode-guide.md).
+
+### Attach a debugger
+
+`--inspect-wait` holds the run before the handler executes and keeps the process
+alive until the debugger disconnects, so breakpoints bind instead of being missed
+while the runtime starts. This is what the VS Code extension runs on F5.
+
+```bash
+uip function run --function <NAME> --input '{}' --inspect-wait 127.0.0.1:9229
+```
+
+Attach with a VS Code `attach` configuration on the same port, or any CDP client.
+`--inspect` opens the inspector without holding the run — use it when you only
+want the process inspectable, not paused. Both take the endpoint as an optional
+value, so the bare flag means `127.0.0.1:9229`.
+
+Breakpoints map back to the original `.ts` through the inline source map, so set
+them in your source file, not in generated output.
+
+Requires a `uip` whose bundled `@uipath/coded-functions-js-cli` is >= 0.1.83.
+Older builds forward the flags and the runner rejects them.
 
 Sharp edge: the CLI help for `run` may describe an HTTP invoke against the serve endpoint — that text is stale. `run` is the job runner; the flags above are the real surface and are forwarded correctly.
 


### PR DESCRIPTION
## What

`uip function run` grew three local-debug flags for VS Code F5 debugging of TS coded functions — `--inspect`, `--inspect-wait` and `--trace-store` — and none of them appear anywhere in this repo. An agent asked to debug a coded function has nothing to reach for today.

- Adds the three flags to the `run` flag table in `references/js/local-dev-guide.md`, plus a short **Attach a debugger** section covering the attach flow and why `--inspect-wait` (not `--inspect`) is the one that makes breakpoints bind.
- Adds one example line to the SKILL.md CLI reference.
- Also adds `--production` to the same table — it was already shipping and already missing, and leaving one known gap in a table I was completing seemed worse than the extra row.

Flag wording is taken from `uipath-functions run --help`, not guessed.

## Ordering

The flags need a `uip` whose bundled `@uipath/coded-functions-js-cli` is >= 0.1.83. That lands via UiPath/cli#3915, which is open. On an older `uip` the flags are forwarded and the runner rejects them, so the floor is stated where they are documented — but you may still prefer to hold this until that CLI release ships.

## Left alone deliberately

- The "Sharp edge" note saying the CLI help for `run` may describe an HTTP invoke against the serve endpoint. UiPath/cli#3915 fixes that help text, but the note is hedged with "may" and stays true for older CLIs. Worth deleting once the fix is in a release you can name.
- SKILL.md says the plural spelling `uip functions` "is not available". It still works as an alias on current builds (`uip functions run --function <n>` runs fine). The guidance to always write the singular is good; the factual claim is wrong. Not my change to make here.

## Verification

`check-skill-status.py`, `check-skills-sh.py`, `npm run skills:validate` (27 skills, both flavors) and `npm run skills:check-links` (6783 links) all pass. No skill added, renamed or removed, so the two registries need no edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
