### PR TITLE
fix(tests): retry case debug once for a tenant-side fault, never for a plan fault

### DIFF
--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -22,6 +22,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from typing import Any, Iterable, NoReturn, Sequence
 
 
@@ -450,6 +451,40 @@ def _fail(msg: str) -> NoReturn:
     sys.exit(f"FAIL: {msg}")
 
 
+# `uip maestro case debug` drives a live tenant, and three of its faults are the
+# service's, not the plan's: the poll returning 403/5xx mid-run, and the debug
+# instance being cancelled out from under the poll. All three exit non-zero with
+# the plan intact, and none survived a re-run — measured 2026-09-11 on
+# skill-case-single-api-workflow (403 Forbidden on poll-instance-status),
+# skill-case-multi-linear-three-stages (finalStatus Cancelled, and a 504 on the
+# same poll in CI run 34510099349), each of which then passed 4/4 on re-run
+# across both harnesses. One retry is therefore the difference between grading
+# the build and grading the tenant's afternoon. A fault that is NOT in this set
+# still fails on the first attempt: a plan defect must never be retried into a
+# pass, and a real platform regression must still turn the suite red — which is
+# why the retry announces itself on stdout instead of absorbing the fault.
+_TRANSIENT_DEBUG_HTTP = frozenset({"403", "408", "409", "425", "429", "500", "502", "503", "504"})
+_DEBUG_PHASE_FAULT = re.compile(r"Failed during [\w-]+:\s*(\d{3})\b")
+_DEBUG_CANCELLED = re.compile(r'"finalStatus"\s*:\s*"Cancelled"', re.IGNORECASE)
+_DEBUG_RETRY_SLEEP_S = 15
+
+
+def debug_fault_is_transient(output: str) -> str | None:
+    """Name the tenant-side fault in a failed ``case debug`` output, else None.
+
+    Matches only the two observed shapes: an HTTP status from the debug
+    service's own phase report, and a cancelled instance. Anything else —
+    validation errors, unresolved resources, a plan that cannot start — returns
+    None and fails on the first attempt.
+    """
+    match = _DEBUG_PHASE_FAULT.search(output)
+    if match and match.group(1) in _TRANSIENT_DEBUG_HTTP:
+        return f"HTTP {match.group(1)} from the debug service"
+    if _DEBUG_CANCELLED.search(output):
+        return "the debug instance was cancelled mid-run"
+    return None
+
+
 def _run(cmd: Sequence[str], *, timeout: int, what: str) -> subprocess.CompletedProcess[str]:
     """``subprocess.run`` that reports a timeout as a FAIL, not a traceback.
 
@@ -630,6 +665,22 @@ def run_debug(
         refresh_timeout=refresh_timeout,
     )
     status = _get_ci(payload or {}, "finalStatus", "FinalStatus", "status", "Status")
+    if status == "Cancelled":
+        # Same tenant-side fault as the non-zero-exit path, reported through a
+        # clean exit. One retry, announced, then it counts.
+        print(
+            "NOTE: retrying `uip maestro case debug` once — the debug instance "
+            "was cancelled mid-run, which is the tenant's fault and not the plan's.",
+            flush=True,
+        )
+        time.sleep(_DEBUG_RETRY_SLEEP_S)
+        payload = start_debug(
+            timeout=timeout,
+            project_glob=project_glob,
+            solution_glob=solution_glob,
+            refresh_timeout=refresh_timeout,
+        )
+        status = _get_ci(payload or {}, "finalStatus", "FinalStatus", "status", "Status")
     if status != "Completed" and status != "Successful":
         _fail(f"Case did not complete (finalStatus={status})\nPayload: {json.dumps(payload, default=str)[:2000]}")
     return payload
@@ -678,11 +729,23 @@ def start_debug(
         "uip", "maestro", "case", "debug", project_dir,
         "--log-level", "debug", "--output", "json",
     ]
-    r = _run(debug_cmd, timeout=timeout, what="uip maestro case debug")
-    if r.returncode != 0:
-        _fail(
-            f"case debug exit {r.returncode}\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    for attempt in (1, 2):
+        r = _run(debug_cmd, timeout=timeout, what="uip maestro case debug")
+        if r.returncode == 0:
+            break
+        fault = debug_fault_is_transient(f"{r.stdout}\n{r.stderr}")
+        if fault is None or attempt == 2:
+            retried = " (after one retry)" if attempt == 2 else ""
+            _fail(
+                f"case debug exit {r.returncode}{retried}\n"
+                f"stdout: {r.stdout}\nstderr: {r.stderr}"
+            )
+        print(
+            f"NOTE: retrying `uip maestro case debug` once — {fault}, "
+            f"which is the tenant's fault and not the plan's.",
+            flush=True,
         )
+        time.sleep(_DEBUG_RETRY_SLEEP_S)
     data = _parse_json(r.stdout)
     if data is None:
         _fail(f"Could not parse JSON from case debug\n{r.stdout}")

--- a/tests/tasks/uipath-maestro-case/_shared/test_case_check_debug_retry.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_case_check_debug_retry.py
@@ -1,0 +1,134 @@
+"""Guard: `uip maestro case debug` is retried once for tenant faults, never for plan faults.
+
+The debug graders drive a live tenant. Three faults observed on 2026-09-11 were
+the service's and not the plan's — a 403 and a 504 on `poll-instance-status`,
+and a debug instance cancelled mid-run — and all three passed on re-run (4/4
+across both harnesses). Everything else must still fail on the first attempt:
+retrying a plan defect into a pass is the failure mode this test exists to
+prevent.
+
+    python3 -m pytest tests/tasks/uipath-maestro-case/_shared/test_case_check_debug_retry.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import case_check  # noqa: E402
+
+TRANSIENT = [
+    # verbatim shapes from the 2026-09-11 nightlies and CI run 34510099349
+    'Failed during poll-instance-status: 403 Forbidden on GET /api/v1/debug-instances/fc07737f/element-executions',
+    'Failed during poll-instance-status: 504 Gateway Timeout on GET /api/v1/debug-instances/918e7df2/element-executions',
+    '{"Result": "Success", "Code": "CaseDebug", "Data": {"finalStatus": "Cancelled"}}',
+    'Failed during start-instance: 429 Too Many Requests',
+    'Failed during poll-instance-status: 503 Service Unavailable',
+]
+
+PLAN_FAULTS = [
+    'Failed during start-instance: 400 Bad Request',
+    'ValidationError: unknown option "-instance-id"',
+    '{"Result": "Failure", "ErrorCode": "invalid_argument", "Message": "Resource is not configured"}',
+    '{"Result": "Success", "Data": {"finalStatus": "Faulted"}}',
+    'Failed during poll-instance-status: 404 Not Found',
+]
+
+
+@pytest.mark.parametrize("output", TRANSIENT)
+def test_tenant_faults_are_named(output: str) -> None:
+    assert case_check.debug_fault_is_transient(output) is not None, output
+
+
+@pytest.mark.parametrize("output", PLAN_FAULTS)
+def test_plan_faults_are_not_retried(output: str) -> None:
+    assert case_check.debug_fault_is_transient(output) is None, output
+
+
+class _Recorder:
+    """Stands in for subprocess.run: scripted returncodes, counted calls."""
+
+    def __init__(self, *results: tuple[int, str]) -> None:
+        self.results = list(results)
+        self.debug_calls = 0
+
+    def __call__(self, cmd, **kwargs):  # noqa: ANN001, ANN003
+        joined = " ".join(cmd)
+        if "debug" in joined:
+            self.debug_calls += 1
+            code, out = self.results.pop(0)
+            return subprocess.CompletedProcess(cmd, code, out, "")
+        # `solution resources refresh`
+        return subprocess.CompletedProcess(cmd, 0, "{}", "")
+
+
+OK_PAYLOAD = json.dumps({"Result": "Success", "Data": {"finalStatus": "Completed"}})
+
+
+@pytest.fixture
+def _stub_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(case_check, "find_project_dir", lambda *a, **k: str(tmp_path))
+    monkeypatch.setattr(case_check, "find_solution_dir", lambda *a, **k: str(tmp_path))
+    monkeypatch.setattr(case_check.time, "sleep", lambda _s: None)
+
+
+def test_transient_fault_retries_once_and_succeeds(
+    monkeypatch: pytest.MonkeyPatch, _stub_paths: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rec = _Recorder((1, 'Failed during poll-instance-status: 403 Forbidden on GET /x'), (0, OK_PAYLOAD))
+    monkeypatch.setattr(subprocess, "run", rec)
+    payload = case_check.start_debug()
+    assert payload["finalStatus"] == "Completed"
+    assert rec.debug_calls == 2
+    assert "retrying" in capsys.readouterr().out
+
+
+def test_transient_fault_twice_still_fails_and_says_it_retried(
+    monkeypatch: pytest.MonkeyPatch, _stub_paths: None
+) -> None:
+    fault = (1, 'Failed during poll-instance-status: 504 Gateway Timeout on GET /x')
+    rec = _Recorder(fault, fault)
+    monkeypatch.setattr(subprocess, "run", rec)
+    with pytest.raises(SystemExit) as exc:
+        case_check.start_debug()
+    assert rec.debug_calls == 2
+    assert "after one retry" in str(exc.value)
+
+
+def test_plan_fault_fails_on_the_first_attempt(
+    monkeypatch: pytest.MonkeyPatch, _stub_paths: None
+) -> None:
+    rec = _Recorder((1, '{"Result": "Failure", "Message": "Resource is not configured"}'), (0, OK_PAYLOAD))
+    monkeypatch.setattr(subprocess, "run", rec)
+    with pytest.raises(SystemExit) as exc:
+        case_check.start_debug()
+    assert rec.debug_calls == 1, "a plan fault must never be retried"
+    assert "after one retry" not in str(exc.value)
+
+
+def test_clean_exit_reporting_cancelled_is_retried_by_run_debug(
+    monkeypatch: pytest.MonkeyPatch, _stub_paths: None
+) -> None:
+    cancelled = (0, json.dumps({"Result": "Success", "Data": {"finalStatus": "Cancelled"}}))
+    rec = _Recorder(cancelled, (0, OK_PAYLOAD))
+    monkeypatch.setattr(subprocess, "run", rec)
+    payload = case_check.run_debug()
+    assert payload["finalStatus"] == "Completed"
+    assert rec.debug_calls == 2
+
+
+def test_faulted_is_not_retried_by_run_debug(
+    monkeypatch: pytest.MonkeyPatch, _stub_paths: None
+) -> None:
+    faulted = (0, json.dumps({"Result": "Success", "Data": {"finalStatus": "Faulted"}}))
+    rec = _Recorder(faulted, (0, OK_PAYLOAD))
+    monkeypatch.setattr(subprocess, "run", rec)
+    with pytest.raises(SystemExit):
+        case_check.run_debug()
+    assert rec.debug_calls == 1, "a Faulted case is the plan's fault"


### PR DESCRIPTION
## Why

Two case graders died in the 2026-09-11 nightlies on faults that belong to the debug service, not to the plan:

| task | harness | fault |
|---|---|---|
| `single-api-workflow` | terra | `Failed during poll-instance-status: 403 Forbidden on GET /api/v1/debug-instances/…/element-executions` |
| `multi-linear-three-stages` | Sonnet | `finalStatus: Cancelled` with the stage still `InProgress` — and a `504 Gateway Timeout` on the same poll in CI run 34510099349 |

Re-ran both tasks on both harnesses this afternoon: **4 of 4 passed at 1.0**, no 403, no 504, no cancellation. Neither fault survives a retry and neither was measuring the build. `start_debug` fails on the first non-zero exit, so one afternoon of tenant weather costs two tasks a night on a suite we report on.

## What

`debug_fault_is_transient()` names exactly two shapes and nothing else:

- an HTTP status from the debug service's own phase report — 403, 408, 409, 425, 429, 5xx
- a cancelled instance (`"finalStatus": "Cancelled"`)

`start_debug` retries once on those, after a 15 s pause. `run_debug` gets the same single retry for a `Cancelled` status that arrives through a clean exit.

**Everything else fails on the first attempt** — a 400, a 404, a validation error, an unresolved resource, a `Faulted` case. Retrying a plan defect into a pass is worse than the flake it would hide.

**A retry is never silent.** It prints what it is retrying and why, and a second failure carries `after one retry` in the message, so a genuine platform regression still turns the suite red with a legible reason instead of being absorbed.

## Test

15 unit tests in `_shared/test_case_check_debug_retry.py`, parameterised against the verbatim nightly output, covering both directions — the transient set retried, the plan-fault set not — plus call-count assertions that a plan fault invokes `debug` exactly once.

```
pytest tests/tasks/uipath-maestro-case/_shared/test_case_check_debug_retry.py   15 passed
pytest tests/tasks/uipath-maestro-case/                                        153 passed   # the CI job's own command
```

Mutation-checked: disabling the transient classifier turns 6 of the 15 red; making the retry unconditional turns 2 red.

## Scope

`tests/tasks/uipath-maestro-case/_shared/` only — this team's path in `CODEOWNERS`. It changes grading semantics for every case task that calls `run_debug` / `start_debug`, which is the reason the transient set is a closed list of two observed shapes rather than a blanket retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)