### PR TITLE
fix(uipath-maestro-case): state SLA unit semantics — `m` is months

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
@@ -58,6 +58,8 @@ After grouping elements by target, compose the `slaRules` array and write it int
 ]
 ```
 
+> **`unit` is the sdd.md token verbatim**: `min` (minutes), `h` (hours), `d` (days), `w` (weeks), `m` (**months**). Never map `m` onto `min`, and never rewrite a unit or clamp a count to clear the 15–1000 floor — that floor applies to `min` only.
+
 ### Root-target shape
 
 ```json

--- a/skills/uipath-maestro-case/references/plugins/sla/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/planning.md
@@ -39,7 +39,7 @@ Set root SLA first, then stage SLAs. This mirrors the schema precedence: stage >
 | Field | Source | Notes |
 |-------|--------|-------|
 | `count` | sdd.md duration number | Positive integer |
-| `unit` | sdd.md duration unit | `min` \| `h` \| `d` \| `w` \| `m` |
+| `unit` | sdd.md duration unit | `min` (minutes) \| `h` (hours) \| `d` (days) \| `w` (weeks) \| `m` (months). Carry the sdd.md token verbatim — `m` is **months**, never minutes. |
 | `target` | sdd.md target (root vs stage) | `"root"` or `"<stage-name>"` |
 | `display-name` | sdd.md `SLA Title` (§1 Case Metadata for root; `**SLA Title:**` under `#### Stage SLA`) or generated fallback | Required non-empty SLA title, unique within the target, and MUST NOT contain `:`. Carry the SDD title verbatim. If the SDD has no title, ask for one or use the deterministic fallback `SLA Rule {N}` and record it. |
 | `rationale` | sdd.md case/stage SLA Design Rationale | Required reviewer context for the target, duration, threshold, and escalation behavior. |
@@ -196,7 +196,7 @@ Before emitting SLA elements, reject or repair the same cases the Case App rejec
 
 - every SLA rule has a non-empty, target-unique `display-name`;
 - every escalation has a non-empty, target-unique `display-name`;
-- every SLA `count` is positive, and minute-based values are between 15 and 1000 inclusive;
+- every SLA `count` is positive, and `unit: "min"` counts are between 15 and 1000 inclusive. This floor applies ONLY to `min`; `h` / `d` / `w` / `m` counts carry no floor, so never rewrite a unit or clamp a count to satisfy it;
 - every non-default rule has a condition/expression;
 - every escalation has at least one recipient, and every `at-risk` escalation carries `at-risk-percentage`.
 
@@ -204,6 +204,7 @@ Before emitting SLA elements, reject or repair the same cases the Case App rejec
 
 - **Do not fabricate expression syntax.** Describe conditional SLA rules in natural language during planning; the execution phase handles the exact syntax.
 - **Do not lose the conditional rule's target.** Root and stage rules have the same entry shape but different destinations (`metadata.slaRules[]` vs `node.data.slaRules[]`). Preserve the SDD row's target through to the caseplan write.
+- **Do not normalize the sdd.md duration unit.** `m` in an sdd.md SLA row is **months**, not minutes — emit `unit: "m"` and keep the count as written. A count below 15 is legal for `m` / `h` / `d` / `w`; the 15–1000 floor is `min`-only. Rewriting the unit or clamping the count to clear a floor that does not apply silently moves every escalation deadline in the case.
 - **Do not invert rule order.** Conditional rules are evaluated in insertion order — insert them in the priority order the sdd.md specifies.
 - **Do not skip the resolver to save a CLI call.** Email / group-name recipients MUST go through [§ Identity Resolution](#identity-resolution). Writing `<UNRESOLVED: ...>` directly without attempting `uip admin users/groups list` is a planning bug.
 - **Do not fabricate UUIDs.** When the resolver returns 0 / multi / partial matches, AskUserQuestion or keep `<UNRESOLVED>` — never guess a UUID, never auto-pick the first candidate without the exact-email / exact-name gate.

--- a/tests/tasks/uipath-maestro-case/aged_invoice_structural/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/aged_invoice_structural/fixtures/sdd.md
@@ -33,7 +33,7 @@
 | Case Name | AgedInvoiceResolution |
 | Case Description | Registers an aged invoice case, triages it, captures AP ownership, and closes it, with interrupting SLA-escalation and automation-incident lanes. Compact connector-free proof-of-value variant. |
 | Case Identifier | Type: constant. Prefix: AIR |
-| Case-Level SLA | 90 m |
+| Case-Level SLA | 90 min |
 | SLA Type | time-based |
 | SLA Title | Case Resolution SLA |
 | Case App | Disabled |
@@ -103,7 +103,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 15 | m | 70% | Notify: UserGroup: AP Intake | Notify: UserGroup: AP Intake |
+| 15 | min | 70% | Notify: UserGroup: AP Intake | Notify: UserGroup: AP Intake |
 
 #### Tasks
 
@@ -217,7 +217,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 15 | m | 70% | Notify: UserGroup: AP Clerk | Notify: UserGroup: AP Team Lead |
+| 15 | min | 70% | Notify: UserGroup: AP Clerk | Notify: UserGroup: AP Team Lead |
 
 #### Tasks
 
@@ -302,7 +302,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 15 | m | 70% | Notify: UserGroup: AP Clerk | Notify: UserGroup: AP Team Lead |
+| 15 | min | 70% | Notify: UserGroup: AP Clerk | Notify: UserGroup: AP Team Lead |
 
 #### Tasks
 
@@ -457,7 +457,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 15 | m | 70% | Notify: UserGroup: AP Team Lead | Notify: UserGroup: Finance Operations |
+| 15 | min | 70% | Notify: UserGroup: AP Team Lead | Notify: UserGroup: Finance Operations |
 
 #### Tasks
 
@@ -518,7 +518,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 15 | m | 70% | Notify: UserGroup: Automation Support | Notify: UserGroup: Automation CoE |
+| 15 | min | 70% | Notify: UserGroup: Automation Support | Notify: UserGroup: Automation CoE |
 
 #### Tasks
 

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/fixtures/sdd.md
@@ -39,7 +39,7 @@
 | Case Name | ExpenseReimbursementRunnable |
 | Case Description | Handles an employee-submitted expense from submission through manager and finance approval to payment and close-out, ending in Approved, Rejected, or Withdrawn. Fully-automated runnable variant bound to generic tenant resources. |
 | Case Identifier | Type: constant. Prefix: EXP |
-| Case-Level SLA | 15 m |
+| Case-Level SLA | 350 min |
 | SLA Type | time-based |
 | Case App | Disabled |
 | Task-output passing | Direct |
@@ -70,7 +70,7 @@
 
 | Name | Category | Type | sourceTriggers | sourceFields | Default | Description |
 |------|----------|------|----------------|--------------|---------|-------------|
-| caseRef | In | string | | | `""` (empty string) | External reference supplied by the caller at case start. |
+| caseRef | In | string | | | `""` | External reference supplied by the caller at case start. |
 | employeeName | Variable | string | | | "Jane Smith" | Submitting employee's name. |
 | employeeEmail | Variable | string | | | "jane.smith@acme.com" | Submitting employee's email. |
 | amount | Variable | float | | | 1250.00 | Expense amount. |
@@ -111,7 +111,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 3 | m | 70% | Notify: Finance Ops | Notify: Finance Ops |
+| 45 | min | 70% | Notify: Finance Ops | Notify: Finance Ops |
 
 #### Tasks
 
@@ -214,7 +214,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 5 | m | 70% | Notify: Manager | Notify: Manager |
+| 75 | min | 70% | Notify: Manager | Notify: Manager |
 
 #### Tasks
 
@@ -302,7 +302,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 5 | m | 70% | Notify: Finance Ops | Notify: Finance Ops |
+| 75 | min | 70% | Notify: Finance Ops | Notify: Finance Ops |
 
 #### Tasks
 
@@ -438,7 +438,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 4 | m | 70% | Notify: Finance Ops | Notify: Finance Ops |
+| 60 | min | 70% | Notify: Finance Ops | Notify: Finance Ops |
 
 #### Tasks
 
@@ -576,7 +576,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 2 | m | 70% | Notify: Finance Ops | Notify: Finance Ops |
+| 30 | min | 70% | Notify: Finance Ops | Notify: Finance Ops |
 
 #### Tasks
 
@@ -678,7 +678,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 2 | m | 70% | Notify: Finance Ops | Notify: Finance Ops |
+| 30 | min | 70% | Notify: Finance Ops | Notify: Finance Ops |
 
 #### Tasks
 
@@ -780,7 +780,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 2 | m | 70% | Notify: Finance Ops | Notify: Finance Ops |
+| 30 | min | 70% | Notify: Finance Ops | Notify: Finance Ops |
 
 #### Tasks
 


### PR DESCRIPTION
fix(uipath-maestro-case): state SLA unit semantics — `m` is months

The expense-runnable e2e failed in `validate --strict --sdd`, gained STRICT_SDD_SLA_DURATION_MISMATCH and
STRICT_SDD_VARIABLE_DEFAULT_MISMATCH 

The SLA plugin listed the unit vocabulary `min|h|d|w|m` with no semantics; only case-schema.md said `m` means months. An agent reading just plugins/sla/ takes `m` for minutes, collides with the documented 15-minute floor, and "repairs" the conflict: the failing run clamped all eight SLA rules to 15 min. The new check compares only the case-level rule, so the seven equally-wrong stage SLAs went unreported.

Changes:
- plugins/sla/planning.md: spell out min/h/d/w/m, scope the 15–1000 floor to  `unit: "min"`, add an anti-pattern against normalizing the SDD unit
- plugins/sla/impl-json.md: same semantics beside the `"<min|h|d|w|m>"` placeholder
- both fixtures meant minutes but wrote `m` — normalize to `min` (expense scaled x15  to clear the floor, aged-invoice token-only) and drop the `(empty string)` gloss  that the new default check parsed as the value instead of the code-span

Verified: sdd_check.py OK on aged-invoice, unchanged on expense (52 pre-existing
template findings before and after); 99 pytest pass; npm run skills:validate OK; a
corrected caseplan/SDD pair validates clean. 

Rerun tests:
https://github.com/UiPath/skills/actions/runs/34640710432(claude)
https://github.com/UiPath/skills/actions/runs/34640684698(codex)
both succeeded