### PR TITLE
chore: refresh uip CLI catalog (1.203.0-dev.8651)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-09-11T04:06:55Z",
-  "cli_version": "1.203.0-dev.8632",
+  "generated_at": "2026-09-12T04:06:14Z",
+  "cli_version": "1.203.0-dev.8651",
   "verbs": [
     "admin",
     "admin audit",
@@ -1330,6 +1330,7 @@
     "rpa remote",
     "rpa remote configure",
     "rpa remote download-file",
+    "rpa remote echo",
     "rpa remote exec",
     "rpa remote start",
     "rpa remote status",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.203.0-dev.8651`. The catalog has 1575 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.